### PR TITLE
Bug with SmartDate ctor and nullable DateTimes fixed

### DIFF
--- a/Source/Csla.test/SmartDate/SmartDateTests.cs
+++ b/Source/Csla.test/SmartDate/SmartDateTests.cs
@@ -133,6 +133,15 @@ namespace Csla.Test.SmartDate
       d = new Csla.SmartDate(now, false);
       Assert.AreEqual(now, d.Date);
       Assert.IsFalse(d.EmptyIsMin);
+
+      d = new Csla.SmartDate((DateTime?)null, true);
+      Assert.AreEqual(DateTime.MinValue, d.Date);
+      d = new Csla.SmartDate((DateTime?)null, false);
+      Assert.AreEqual(DateTime.MaxValue, d.Date);
+      d = new Csla.SmartDate((DateTime?)null, Csla.SmartDate.EmptyValue.MinDate);
+      Assert.AreEqual(DateTime.MinValue, d.Date);
+      d = new Csla.SmartDate((DateTime?)null, Csla.SmartDate.EmptyValue.MaxDate);
+      Assert.AreEqual(DateTime.MaxValue, d.Date);
     }
     #endregion
 

--- a/Source/Csla/SmartDate.cs
+++ b/Source/Csla/SmartDate.cs
@@ -407,7 +407,7 @@ namespace Csla
       {
         if (!_initialized)
         {
-          _date = DateTime.MinValue;
+          _date = _emptyValue == SmartDate.EmptyValue.MinDate ? DateTime.MinValue : DateTime.MaxValue;
           _initialized = true;
         }
         return _date;


### PR DESCRIPTION
The bug was with ctor of SmartDates passing in a null DateTime? with
EmptyValue set to MaxValue. It was always setting the Date to MinValue.
