### PR TITLE
LoadProperty/LoadPropertyConvert now sets null strings to empty

### DIFF
--- a/Source/Csla.test/PropertyGetSet/NullStringEditableRoot.cs
+++ b/Source/Csla.test/PropertyGetSet/NullStringEditableRoot.cs
@@ -1,0 +1,161 @@
+using System;
+using Csla;
+
+namespace Csla.Test.PropertyGetSet
+{
+  [Serializable]
+  public class NullStringEditableRoot : BusinessBase<NullStringEditableRoot>
+  {
+    #region Business Methods
+
+    #region SetProperty and SetPropertyConvert
+
+    public static readonly PropertyInfo<string> UsesSetManagedProperty = RegisterProperty<string>(c => c.UsesSetManaged);
+    public string UsesSetManaged
+    {
+      get { return GetProperty(UsesSetManagedProperty); }
+      set { SetProperty(UsesSetManagedProperty, value, Csla.Security.NoAccessBehavior.ThrowException); }
+    }
+
+    public static readonly PropertyInfo<string> UsesSetBackingProperty = RegisterProperty<string>(c => c.UsesSetBacking, RelationshipTypes.PrivateField);
+    // [NotUndoable, NonSerialized]
+    private string _usesSetBacking = UsesSetBackingProperty.DefaultValue;
+    public string UsesSetBacking
+    {
+      get { return GetProperty(UsesSetBackingProperty, _usesSetBacking); }
+      set { SetProperty("UsesSetBacking", ref _usesSetBacking, value, Csla.Security.NoAccessBehavior.ThrowException); }
+    }
+
+    public static readonly PropertyInfo<Csla.SmartDate> UsesSetConvertManagedSmartDateProperty = RegisterProperty<Csla.SmartDate>(c => c.UsesSetConvertManagedSmartDate);
+    public string UsesSetConvertManagedSmartDate
+    {
+      get { return GetPropertyConvert<Csla.SmartDate, string>(UsesSetConvertManagedSmartDateProperty); }
+      set { SetPropertyConvert<Csla.SmartDate, string>(UsesSetConvertManagedSmartDateProperty, value); }
+    }
+
+    //    protected void SetPropertyConvert<P, V>(string propertyName, ref P field, V newValue, Security.NoAccessBehavior noAccess)
+    public static readonly PropertyInfo<Csla.SmartDate> UsesSetConvertBackingSmartDateProperty = RegisterProperty<Csla.SmartDate>(c => c.UsesSetConvertBackingSmartDate, RelationshipTypes.PrivateField);
+    private Csla.SmartDate _usesSetConvertBackingSmartDate = UsesSetConvertBackingSmartDateProperty.DefaultValue;
+    public string UsesSetConvertBackingSmartDate
+    {
+      get { return GetProperty(UsesSetConvertBackingSmartDateProperty, _usesSetConvertBackingSmartDate); }
+      set { SetPropertyConvert<Csla.SmartDate, string>("UsesSetConvertBackingSmartDate", ref _usesSetConvertBackingSmartDate, value, Csla.Security.NoAccessBehavior.ThrowException); }
+    }
+
+    public static readonly PropertyInfo<object> UsesSetConvertManagedObjectProperty = RegisterProperty<object>(c => c.UsesSetConvertManagedObject);
+    public string UsesSetConvertManagedObject
+    {
+      get { return GetPropertyConvert<object, string>(UsesSetConvertManagedObjectProperty); }
+      set { SetPropertyConvert<object, string>(UsesSetConvertManagedObjectProperty, value); }
+    }
+
+    //    protected void SetPropertyConvert<P, V>(string propertyName, ref P field, V newValue, Security.NoAccessBehavior noAccess)
+    public static readonly PropertyInfo<object> UsesSetConvertBackingObjectProperty = RegisterProperty<object>(c => c.UsesSetConvertBackingObject, RelationshipTypes.PrivateField);
+    private object _usesSetConvertBackingObject = UsesSetConvertBackingObjectProperty.DefaultValue;
+    public string UsesSetConvertBackingObject
+    {
+      get { return GetPropertyConvert<object, string>(UsesSetConvertBackingObjectProperty, _usesSetConvertBackingObject); }
+      set { SetPropertyConvert<object, string>("UsesSetConvertBackingObject", ref _usesSetConvertBackingObject, value, Csla.Security.NoAccessBehavior.ThrowException); }
+    }
+
+    #endregion
+
+    #region LoadProperty and LoadPropertyConvert
+
+    public static readonly PropertyInfo<string> UsesLoadProperty = RegisterProperty<string>(c => c.UsesLoad);
+    public string UsesLoad
+    {
+      get { return GetProperty(UsesLoadProperty); }
+      set { LoadProperty(UsesLoadProperty, value); }
+    }
+
+    public static readonly PropertyInfo<string> UsesLoadMarkDirtyProperty = RegisterProperty<string>(c => c.UsesLoadMarkDirty);
+    public string UsesLoadMarkDirty
+    {
+      get { return GetProperty(UsesLoadMarkDirtyProperty); }
+      set { LoadPropertyMarkDirty(UsesLoadMarkDirtyProperty, value); }
+    }
+
+    public static readonly PropertyInfo<object> UsesLoadConvertSmartDateProperty = RegisterProperty<object>(c => c.UsesLoadConvertSmartDate);
+    public string UsesLoadConvertSmartDate
+    {
+      get { return GetPropertyConvert<object, string>(UsesLoadConvertSmartDateProperty); }
+      set { LoadPropertyConvert<object, string>(UsesLoadConvertSmartDateProperty, value); }
+    }
+
+    public static readonly PropertyInfo<object> UsesLoadConvertObjectProperty = RegisterProperty<object>(c => c.UsesLoadConvertObject);
+    public string UsesLoadConvertObject
+    {
+      get { return GetPropertyConvert<object, string>(UsesLoadConvertObjectProperty); }
+      set { LoadPropertyConvert<object, string>(UsesLoadConvertObjectProperty, value); }
+    }
+
+    #endregion
+
+    #endregion
+
+    #region Factory Methods
+
+    public static NullStringEditableRoot NewEditableRoot()
+    {
+      //return DataPortal.Create<NullStringEditableRoot>();
+      return new NullStringEditableRoot();
+    }
+
+    //public static NullStringEditableRoot GetEditableRoot(int id)
+    //{
+    //  return DataPortal.Fetch<NullStringEditableRoot>(id);
+    //}
+
+    //public static void DeleteEditableRoot(int id)
+    //{
+    //  DataPortal.Delete<NullStringEditableRoot>(id);
+    //}
+
+    private NullStringEditableRoot()
+    { /* Require use of factory methods */ }
+
+    #endregion
+
+    #region Data Access
+
+    [RunLocal]
+    protected override void DataPortal_Create()
+    {
+      // TODO: load default values
+      // omit this override if you have no defaults to set
+      base.DataPortal_Create();
+    }
+
+    //private void DataPortal_Fetch(int criteria)
+    //{
+    //  // TODO: load values
+    //}
+
+    //[Transactional(TransactionalTypes.TransactionScope)]
+    //protected override void DataPortal_Insert()
+    //{
+    //  // TODO: insert values
+    //}
+
+    //[Transactional(TransactionalTypes.TransactionScope)]
+    //protected override void DataPortal_Update()
+    //{
+    //  // TODO: update values
+    //}
+
+    //[Transactional(TransactionalTypes.TransactionScope)]
+    //protected override void DataPortal_DeleteSelf()
+    //{
+    //  DataPortal_Delete(this.Id);
+    //}
+
+    //[Transactional(TransactionalTypes.TransactionScope)]
+    //private void DataPortal_Delete(int criteria)
+    //{
+    //  // TODO: delete values
+    //}
+
+    #endregion
+  }
+}

--- a/Source/Csla.test/PropertyGetSet/NullStringPropertyGetSetTests.cs
+++ b/Source/Csla.test/PropertyGetSet/NullStringPropertyGetSetTests.cs
@@ -1,0 +1,508 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="PropertyGetSetTests.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: http://www.lhotka.net/cslanet/
+// </copyright>
+// <summary>no summary</summary>
+//-----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+#if NUNIT
+using NUnit.Framework;
+using TestClass = NUnit.Framework.TestFixtureAttribute;
+using TestInitialize = NUnit.Framework.SetUpAttribute;
+using TestCleanup = NUnit.Framework.TearDownAttribute;
+using TestMethod = NUnit.Framework.TestAttribute;
+#elif MSTEST
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+#endif
+
+namespace Csla.Test.PropertyGetSet
+{
+#if TESTING
+  //[System.Diagnostics.DebuggerNonUserCode]
+#endif
+  [TestClass]
+  public class NullStringPropertyGetSetTests
+  {
+#if SILVERLIGHT
+    [TestInitialize]
+    public void Setup()
+    {
+      Csla.DataPortal.ProxyTypeName = "Local"; // "Csla.DataPortalClient.WcfProxy, Csla";
+      Csla.ApplicationContext.PropertyChangedMode = ApplicationContext.PropertyChangedModes.Windows;
+    }
+#else
+    [TestInitialize]
+    public void Initialize()
+    {
+      Csla.ApplicationContext.PropertyChangedMode = ApplicationContext.PropertyChangedModes.Windows;
+    }
+#endif
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+    }
+
+    #region SetProperty and variations overrides - initialized EditableRoot
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyOfStringManaged_Initially_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      Assert.AreEqual(string.Empty, item.UsesSetManaged, "Freshly initialized string property should be string.empty");
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyOfStringBacking_Initially_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      Assert.AreEqual(string.Empty, item.UsesSetBacking, "Freshly initialized string property should be string.empty");
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_SetConvertPropertyManagedSmartDate_Initially_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      Assert.AreEqual(string.Empty, item.UsesSetConvertManagedSmartDate, "should be empty");
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_SetConvertPropertyBackingSmartDate_Initially_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      Assert.AreEqual(string.Empty, item.UsesSetConvertBackingSmartDate, "should be empty");
+    }
+
+    [Ignore]
+    [TestMethod]
+    public void NewEditableRoot_SetConvertPropertyManagedObject_Initially_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      Assert.AreEqual(string.Empty, item.UsesSetConvertManagedObject, "should be empty");
+    }
+
+    [Ignore]
+    [TestMethod]
+    public void NewEditableRoot_SetConvertPropertyBackingObject_Initially_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      Assert.AreEqual(string.Empty, item.UsesSetConvertBackingObject, "should be empty");
+    }
+
+    #endregion
+
+    #region SetProperty and variations overrides - manual set non-null values
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyOfStringManaged_AssignedValue_Equals_NonEmpty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesSetManaged = "Test String";
+      Assert.AreEqual("Test String", item.UsesSetManaged, "Should have value");
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyOfStringBacking_AssignedValue_Equals_NonEmpty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesSetBacking = "Test String";
+      Assert.AreEqual("Test String", item.UsesSetBacking, "should have value");
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyConvertManagedSmartDate_AssignedValue_Equals_NonEmpty()
+    {
+      var testDate = new DateTime(2013, 4, 1);
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesSetConvertManagedSmartDate = testDate.ToString();
+      Assert.AreEqual(testDate, DateTime.Parse(item.UsesSetConvertManagedSmartDate));
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyConvertBackingSmartDate_AssignedValue_Equals_NonEmpty()
+    {
+      var testDate = new DateTime(2013, 4, 1);
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesSetConvertBackingSmartDate = testDate.ToString();
+      Assert.AreEqual(testDate, DateTime.Parse(item.UsesSetConvertBackingSmartDate));
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyConvertManagedObject_AssignedValue_Equals_NonEmpty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesSetConvertManagedObject = "Test String";
+      Assert.AreEqual("Test String", item.UsesSetConvertManagedObject);
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyConvertBacking_AssignedValue_Equals_NonEmpty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesSetConvertBackingObject = "Test String";
+      Assert.AreEqual("Test String", item.UsesSetConvertBackingObject);
+    }
+
+    #endregion
+
+    #region SetProperty and variations overrides - manual set null, returns empty string
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyOfStringManaged_AssignedNull_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesSetManaged = null;
+      Assert.AreEqual(string.Empty, item.UsesSetManaged, "Should be string.Empty");
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyOfStringBacking_AssignedNull_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesSetBacking = null;
+      Assert.AreEqual(string.Empty, item.UsesSetBacking, "Should be string.Empty");
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyConvertManagedSmartDate_AssignedNull_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesSetConvertManagedSmartDate = null;
+      Assert.AreEqual(string.Empty, item.UsesSetConvertManagedSmartDate);
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyConvertBackingSmartDate_AssignedNull_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesSetConvertBackingSmartDate = null;
+      Assert.AreEqual(string.Empty, item.UsesSetConvertBackingSmartDate);
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyConvertManagedObject_AssignedNull_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesSetConvertManagedObject = null;
+      Assert.AreEqual(string.Empty, item.UsesSetConvertManagedObject);
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyConvertBackingObject_AssignedNull_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesSetConvertBackingObject = null;
+      Assert.AreEqual(string.Empty, item.UsesSetConvertBackingObject);
+    }
+
+    #endregion
+
+    #region SetProperty and variations overrides - manual set value then null, returns empty string
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyOfStringManaged_AssignedValueThenNull_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesSetManaged = "Initial String";
+      item.UsesSetManaged = null;
+      Assert.AreEqual(string.Empty, item.UsesSetManaged, "Should be string.Empty");
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyOfStringBacking_AssignedValueThenNull_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesSetBacking = "Initial String";
+      item.UsesSetBacking = null;
+      Assert.AreEqual(string.Empty, item.UsesSetBacking, "Should be string.Empty");
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyConvertManagedSmartDate_AssignedValueThenNull_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesSetConvertManagedSmartDate = new DateTime(2013, 4, 18).ToString();
+      item.UsesSetConvertManagedSmartDate = null;
+      Assert.AreEqual(string.Empty, item.UsesSetConvertManagedSmartDate);
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyConvertBackingSmartDate_AssignedValueThenNull_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesSetConvertBackingSmartDate = new DateTime(2013, 4, 18).ToString();
+      item.UsesSetConvertBackingSmartDate = null;
+      Assert.AreEqual(string.Empty, item.UsesSetConvertBackingSmartDate);
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyConvertManagedObject_AssignedValueThenNull_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesSetConvertManagedObject = "Initial String";
+      item.UsesSetConvertManagedObject = null;
+      Assert.AreEqual(string.Empty, item.UsesSetConvertManagedObject);
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyConvertBackingObject_AssignedValueThenNull_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesSetConvertBackingObject = "Initial String";
+      item.UsesSetConvertBackingObject = null;
+      Assert.AreEqual(string.Empty, item.UsesSetConvertBackingObject);
+    }
+
+    #endregion
+
+    #region SetProperty and variations overrides - manual set null then value, returns value
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyOfStringManaged_AssignedNullThenValue_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesSetManaged = null;
+      item.UsesSetManaged = "My String";
+      Assert.AreEqual("My String", item.UsesSetManaged, "should have value");
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyOfStringBacking_AssignedNullThenValue_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesSetBacking = null;
+      item.UsesSetBacking = "My String";
+      Assert.AreEqual("My String", item.UsesSetBacking, "should have value");
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyConvertManagedSmartDate_AssignedNullThenValue_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesSetConvertManagedSmartDate = null;
+      item.UsesSetConvertManagedSmartDate = new DateTime(2013, 4, 18).ToString();
+      Assert.AreEqual(new DateTime(2013, 4, 18), DateTime.Parse(item.UsesSetConvertManagedSmartDate));
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyConvertBackingSmartDate_AssignedNullThenValue_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesSetConvertBackingSmartDate = null;
+      item.UsesSetConvertBackingSmartDate = new DateTime(2013, 4, 18).ToString();
+      Assert.AreEqual(new DateTime(2013, 4, 18), DateTime.Parse(item.UsesSetConvertBackingSmartDate));
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyConvertManagedObject_AssignedNullThenValue_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesSetConvertManagedObject = null;
+      item.UsesSetConvertManagedObject = "My String";
+      Assert.AreEqual("My String", item.UsesSetConvertManagedObject);
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_SetPropertyConvertBackingObject_AssignedNullThenValue_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesSetConvertBackingObject = null;
+      item.UsesSetConvertBackingObject = "My String";
+      Assert.AreEqual("My String", item.UsesSetConvertBackingObject);
+    }
+
+    #endregion
+
+    #region LoadProperty and variations overrides - initialized EditableRoot
+
+    [TestMethod]
+    public void NewEditableRoot_LoadProperty_Initially_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      Assert.AreEqual(string.Empty, item.UsesLoad, "Freshly initialized string property should be string.empty");
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_LoadPropertyMarkDirty_Initially_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      Assert.AreEqual(string.Empty, item.UsesLoadMarkDirty, "Freshly initialized string property should be string.empty");
+    }
+
+    [Ignore]
+    [TestMethod]
+    public void NewEditableRoot_LoadPropertyConvertSmartDate_Initially_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      Assert.AreEqual(string.Empty, item.UsesLoadConvertSmartDate, "Freshly initialized string property should be string.empty");
+    }
+
+    [Ignore]
+    [TestMethod]
+    public void NewEditableRoot_LoadPropertyConvertObject_Initially_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      Assert.AreEqual(string.Empty, item.UsesLoadConvertObject, "Freshly initialized string property should be string.empty");
+    }
+
+    #endregion
+
+    #region LoadProperty and variations override - manual set non-null values
+
+    [TestMethod]
+    public void NewEditableRoot_LoadProperty_AssignedValue_Equals_NonEmpty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesLoad = "Test String";
+      Assert.AreEqual("Test String", item.UsesLoad, "Should have value");
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_LoadPropertyMarkDirty_AssignedValue_Equals_NonEmpty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesLoadMarkDirty = "Test String";
+      Assert.AreEqual("Test String", item.UsesLoadMarkDirty, "Should have value");
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_LoadPropertyConvertSmartDate_AssignedValue_Equals_NonEmpty()
+    {
+      var testDate = new DateTime(2013, 4, 1);
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesLoadConvertSmartDate = testDate.ToString();
+      Assert.AreEqual(testDate, DateTime.Parse(item.UsesLoadConvertSmartDate));
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_LoadPropertyConvertObject_AssignedValue_Equals_NonEmpty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesLoadConvertObject = "Test String";
+      Assert.AreEqual("Test String", item.UsesLoadConvertObject, "Should have value");
+    }
+
+    #endregion
+
+    #region LoadProperty and variations overrides - manual set null, returns empty string
+
+    [TestMethod]
+    public void NewEditableRoot_LoadProperty_AssignedNull_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesLoad = (string)null;
+      Assert.AreEqual(string.Empty, item.UsesLoad, "Should be string.Empty");
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_LoadPropertyMarkDirty_AssignedNull_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesLoadMarkDirty = (string)null;
+      Assert.AreEqual(string.Empty, item.UsesLoadMarkDirty, "Should be string.Empty");
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_LoadPropertyConvertSmartDate_AssignedNull_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesLoadConvertSmartDate = (string)null;
+      Assert.AreEqual(string.Empty, item.UsesLoadConvertSmartDate, "Should be string.Empty");
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_LoadPropertyConvertObject_AssignedNull_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesLoadConvertObject = (string)null;
+      Assert.AreEqual(string.Empty, item.UsesLoadConvertObject, "Should be string.Empty");
+    }
+
+    #endregion
+
+    #region LoadProperty and variations overrides - manual set value then null, returns empty string
+
+    [TestMethod]
+    public void NewEditableRoot_LoadProperty_AssignedValueThanNull_Equals_NonEmpty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesLoad = "Test String";
+      item.UsesLoad = (string)null;
+      Assert.AreEqual(string.Empty, item.UsesLoad, "Should be string.Empty");
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_LoadPropertyMarkDirty_AssignedValueThanNull_Equals_NonEmpty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesLoadMarkDirty = "Test String";
+      item.UsesLoadMarkDirty = (string)null;
+      Assert.AreEqual(string.Empty, item.UsesLoadMarkDirty, "Should be string.Empty");
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_LoadPropertyConvertSmartDate_AssignedValueThanNull_Equals_NonEmpty()
+    {
+      var testDate = new DateTime(2013, 4, 1);
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesLoadConvertSmartDate = testDate.ToString();
+      item.UsesLoadConvertSmartDate = (string)null;
+      Assert.AreEqual(string.Empty, item.UsesLoadConvertSmartDate, "Should be string.Empty");
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_LoadPropertyConvertObject_AssignedValueThanNull_Equals_NonEmpty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesLoadConvertObject = "Test String";
+      item.UsesLoadConvertObject = (string)null;
+      Assert.AreEqual(string.Empty, item.UsesLoadConvertObject, "Should be string.Empty");
+    }
+    #endregion
+
+    #region LoadProperty and variations override - manual set null then value, returns value
+
+    [TestMethod]
+    public void NewEditableRoot_LoadProperty_AssignedNullThanValue_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesLoad = (string)null;
+      item.UsesLoad = "Test String";
+      Assert.AreEqual("Test String", item.UsesLoad, "Should have value");
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_LoadPropertyMarkDirty_AssignedNullThanValue_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesLoadMarkDirty = (string)null;
+      item.UsesLoadMarkDirty = "Test String";
+      Assert.AreEqual("Test String", item.UsesLoadMarkDirty, "Should have value");
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_LoadPropertyConvertSmartDate_AssignedNullThanValue_Equals_Empty()
+    {
+      var testDate = new DateTime(2013, 4, 1);
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesLoadConvertSmartDate = (string)null;
+      item.UsesLoadConvertSmartDate = testDate.ToString();
+      Assert.AreEqual(testDate, DateTime.Parse(item.UsesLoadConvertSmartDate));
+    }
+
+    [TestMethod]
+    public void NewEditableRoot_LoadPropertyConvertObject_AssignedNullThanValue_Equals_Empty()
+    {
+      var item = NullStringEditableRoot.NewEditableRoot();
+      item.UsesLoadConvertObject = (string)null;
+      item.UsesLoadConvertObject = "Test String";
+      Assert.AreEqual("Test String", item.UsesLoadConvertObject, "Should have value");
+    }
+    #endregion
+
+  }
+}

--- a/Source/Csla.test/csla.test.csproj
+++ b/Source/Csla.test/csla.test.csproj
@@ -249,6 +249,8 @@
     <Compile Include="PropertyGetSet\EditableGetSetTopBase.cs" />
     <Compile Include="PropertyGetSet\EditableGetSetRuleValidation.cs" />
     <Compile Include="PropertyGetSet\EditableGetSetRuleValidationTests.cs" />
+    <Compile Include="PropertyGetSet\NullStringEditableRoot.cs" />
+    <Compile Include="PropertyGetSet\NullStringPropertyGetSetTests.cs" />
     <Compile Include="PropertyGetSet\PropertyGetSetTests.cs" />
     <Compile Include="PropertyInfo\PropertyInfoRoot.cs" />
     <Compile Include="PropertyInfo\PropertyInfoTests.cs" />

--- a/Source/Csla/Core/BusinessBase.cs
+++ b/Source/Csla/Core/BusinessBase.cs
@@ -2157,6 +2157,9 @@ namespace Csla.Core
 
         if (_bypassPropertyChecks || CanWriteProperty(propertyInfo, noAccess == Security.NoAccessBehavior.ThrowException))
         {
+          if (typeof(V) == typeof(string) && newValue == null)
+            newValue = Utilities.CoerceValue<V>(typeof(string), null, string.Empty);
+
           bool doChange = false;
           if (field == null)
           {
@@ -2165,8 +2168,6 @@ namespace Csla.Core
           }
           else
           {
-            if (typeof(V) == typeof(string) && newValue == null)
-              newValue = Utilities.CoerceValue<V>(typeof(string), null, string.Empty);
             if (!field.Equals(newValue))
               doChange = true;
           }
@@ -2319,8 +2320,6 @@ namespace Csla.Core
             else
               oldValue = (P)fieldData.Value;
           }
-          if (typeof(P) == typeof(string) && newValue == null)
-            newValue = Utilities.CoerceValue<P>(typeof(string), null, string.Empty);
           LoadPropertyValue<P>(propertyInfo, oldValue, newValue, !_bypassPropertyChecks);
         }
         catch (Exception ex)
@@ -2428,6 +2427,8 @@ namespace Csla.Core
           else
             oldValue = (P)fieldData.Value;
         }
+        if (typeof(F) == typeof(string) && newValue == null)
+          newValue = Utilities.CoerceValue<F>(typeof(string), null, string.Empty);
         LoadPropertyValue<P>(propertyInfo, oldValue, Utilities.CoerceValue<P>(typeof(F), oldValue, newValue), false);
       }
       catch (Exception ex)
@@ -2529,6 +2530,9 @@ namespace Csla.Core
             oldValue = (P)fieldData.Value;
         }
 
+        if (typeof(P) == typeof(string) && newValue == null)
+          newValue = Utilities.CoerceValue<P>(typeof(string), null, string.Empty);
+
         var valuesDiffer = ValuesDiffer(propertyInfo, newValue, oldValue);
         if (valuesDiffer)
         {
@@ -2593,6 +2597,9 @@ namespace Csla.Core
 
     private void LoadPropertyValue<P>(PropertyInfo<P> propertyInfo, P oldValue, P newValue, bool markDirty)
     {
+      if (typeof(P) == typeof(string) && newValue == null)
+        newValue = Utilities.CoerceValue<P>(typeof(string), null, string.Empty);
+      
       var valuesDiffer = ValuesDiffer(propertyInfo, newValue, oldValue);
 
       if (valuesDiffer)


### PR DESCRIPTION
LoadProperty/LoadPropertyConvert now sets null strings to empty which is consistent with SetProperty/SetPropertyConvert. This is important for data binding especially when SafeDataReader is not being used.
