### PR TITLE
small dutch language error in StringMaxLengthRule /Csla/Properties/Resources.nl.resx

### DIFF
--- a/Source/Csla/Properties/Resources.nl.resx
+++ b/Source/Csla/Properties/Resources.nl.resx
@@ -282,7 +282,7 @@
     <comment>{0} can not be less than {1}</comment>
   </data>
   <data name="StringMaxLengthRule" xml:space="preserve">
-    <value>{0} kan niet meer als {1} karakters hebben</value>
+    <value>{0} kan niet meer dan {1} karakters hebben</value>
     <comment>{0} can not exceed {1} characters</comment>
   </data>
   <data name="StringRequiredRule" xml:space="preserve">


### PR DESCRIPTION
I noticed a small language error in the dutch translation of the StringMaxLengthRule resource string.
It is a common dutch error to use 'als' when it should be 'dan'.
In this case it should be 'dan', see for instance http://taaladvies.net/taal/advies/vraag/354/ (Dutch)
