### PR TITLE
#287 Add "Unspecified" TransactionIsolationLevel enumeration and make it...

### DIFF
--- a/Source/Csla/ApplicationContext.cs
+++ b/Source/Csla/ApplicationContext.cs
@@ -685,7 +685,7 @@ namespace Csla
         string tmp = ConfigurationManager.AppSettings["CslaDefaultTransactionIsolationLevel"];
         if (string.IsNullOrEmpty(tmp))
         {
-          return TransactionIsolationLevel.Serializable;
+          return TransactionIsolationLevel.Unspecified;
         }
         return (TransactionIsolationLevel)Enum.Parse(typeof(TransactionIsolationLevel), tmp);
       }

--- a/Source/Csla/Server/TransactionalDataPortal.cs
+++ b/Source/Csla/Server/TransactionalDataPortal.cs
@@ -80,6 +80,8 @@ namespace Csla.Server
     {
       switch (transactionIsolationLevel)
       {
+        case TransactionIsolationLevel.Unspecified:
+          return IsolationLevel.Unspecified;
         case TransactionIsolationLevel.Serializable:
           return IsolationLevel.Serializable;
         case TransactionIsolationLevel.RepeatableRead:
@@ -89,7 +91,7 @@ namespace Csla.Server
         case TransactionIsolationLevel.ReadUncommitted:
           return IsolationLevel.ReadUncommitted;
         default:
-          return IsolationLevel.Serializable;
+          return IsolationLevel.Unspecified;
       }
     }
 

--- a/Source/Csla/TransactionIsolationLevel.cs
+++ b/Source/Csla/TransactionIsolationLevel.cs
@@ -13,6 +13,12 @@ namespace Csla
   public enum TransactionIsolationLevel
   {
     /// <summary>
+    /// Shows that different isolation level than the one specified is being used, but 
+    /// the level cannot be determined. An exception is thrown if this value is set.
+    /// Default.
+    /// </summary>
+    Unspecified,
+    /// <summary>
     /// Prevents updating or inserting until the transaction is complete.
     /// </summary>
     Serializable,


### PR DESCRIPTION
... the default (parity with default `System.Transactions` behaviour)
