### PR TITLE
#286

### DIFF
--- a/Samples/NET/cs/RootChildGrandchildWinFormTest/RootChildGrandchildWinFormTest/RootChildGrandchildWinFormTest.csproj
+++ b/Samples/NET/cs/RootChildGrandchildWinFormTest/RootChildGrandchildWinFormTest/RootChildGrandchildWinFormTest.csproj
@@ -15,7 +15,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <OldToolsVersion>3.5</OldToolsVersion>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
@@ -31,7 +31,8 @@
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -42,6 +43,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -51,6 +53,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Csla">

--- a/Samples/NET/cs/RootChildGrandchildWinFormTest/RootChildGrandchildWinFormTest/app.config
+++ b/Samples/NET/cs/RootChildGrandchildWinFormTest/RootChildGrandchildWinFormTest/app.config
@@ -1,3 +1,9 @@
 <?xml version="1.0"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0,Profile=Client"/></startup></configuration>
+  <appSettings>
+    <add key="CslaPropertyChangedMode" value="Windows"/>
+  </appSettings>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+  </startup>
+</configuration>


### PR DESCRIPTION
The RootChildGrandchildWinFormTest sample does not have the proper CslaPropertyChangedMode set and thus the BindingSource.CurrentChanged is called very often. With correct setting the BindingSource.CurrentChanged is called as should be. 
