### PR TITLE
Fix for #302 Missing Microsoft.Net.Http NuGet dependency for framework 4.0

### DIFF
--- a/NuGet/Definition/Core.NuSpec
+++ b/NuGet/Definition/Core.NuSpec
@@ -24,10 +24,12 @@ Supports the creation of Class Library projects containing business domain class
       <group targetFramework="net40">
         <dependency id="Microsoft.Bcl.Async" version="1.0.165" />
         <dependency id="Microsoft.Bcl" version="1.1.6" />
+        <dependency id="Microsoft.Net.Http" version="2.2.28" />
       </group>
       <group targetFramework="sl50">
         <dependency id="Microsoft.Bcl.Async" version="1.0.165" />
         <dependency id="Microsoft.Bcl" version="1.1.6" />
+        <dependency id="Microsoft.Net.Http" version="2.2.28" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
Microsoft.Net.Http dependency added for framework 4.0
