### PR TITLE
#310 Fix for issue: WebAPI - HttpProxy: Server-side DAL error not bubbling up to Client-side DataPortal

### DIFF
--- a/Source/Csla.Web.Mvc5/Server/Hosts/HttpPortal.cs
+++ b/Source/Csla.Web.Mvc5/Server/Hosts/HttpPortal.cs
@@ -63,11 +63,17 @@ namespace Csla.Server.Hosts
         result.GlobalContext = MobileFormatter.Serialize(dpr.GlobalContext);
         result.ObjectData = MobileFormatter.Serialize(dpr.ReturnObject);
       }
+      // RoyOg - 12/9/2014 The error caught here needs to be re-thrown, otherwise the error never makes it back to the client.
       catch (Exception ex)
       {
-        result.ErrorData = new HttpErrorInfo(ex);
+          result.ErrorData = new HttpErrorInfo(ex);
+          throw;
       }
-      return ConvertResponse(result);
+      finally
+      {
+          result = ConvertResponse(result);
+      }
+      return result;
     }
 
     /// <summary>
@@ -107,11 +113,17 @@ namespace Csla.Server.Hosts
         result.GlobalContext = MobileFormatter.Serialize(dpr.GlobalContext);
         result.ObjectData = MobileFormatter.Serialize(dpr.ReturnObject);
       }
+      // RoyOg - 12/9/2014 The error caught here needs to be re-thrown, otherwise the error never makes it back to the client.
       catch (Exception ex)
       {
-        result.ErrorData = new HttpErrorInfo(ex);
+          result.ErrorData = new HttpErrorInfo(ex);
+          throw;
       }
-      return ConvertResponse(result);
+      finally
+      {
+          result = ConvertResponse(result);
+      }
+      return result;
     }
 
     /// <summary>
@@ -146,11 +158,17 @@ namespace Csla.Server.Hosts
         result.GlobalContext = MobileFormatter.Serialize(dpr.GlobalContext);
         result.ObjectData = MobileFormatter.Serialize(dpr.ReturnObject);
       }
+      // RoyOg - 12/9/2014 The error caught here needs to be re-thrown, otherwise the error never makes it back to the client.
       catch (Exception ex)
       {
-        result.ErrorData = new HttpErrorInfo(ex);
+          result.ErrorData = new HttpErrorInfo(ex);
+          throw;
       }
-      return ConvertResponse(result);
+      finally
+      {
+          result = ConvertResponse(result);
+      }
+      return result;
     }
 
     /// <summary>
@@ -190,11 +208,17 @@ namespace Csla.Server.Hosts
         result.GlobalContext = MobileFormatter.Serialize(dpr.GlobalContext);
         result.ObjectData = MobileFormatter.Serialize(dpr.ReturnObject);
       }
+      // RoyOg - 12/9/2014 The error caught here needs to be re-thrown, otherwise the error never makes it back to the client.
       catch (Exception ex)
       {
-        result.ErrorData = new HttpErrorInfo(ex);
+          result.ErrorData = new HttpErrorInfo(ex);
+          throw;
       }
-      return ConvertResponse(result);
+      finally
+      {
+          result = ConvertResponse(result);
+      }
+      return result;
     }
 
     #region Criteria

--- a/Source/Csla.Web.Mvc5/Server/Hosts/HttpPortal.cs
+++ b/Source/Csla.Web.Mvc5/Server/Hosts/HttpPortal.cs
@@ -48,9 +48,9 @@ namespace Csla.Server.Hosts
 
         var objectType = Csla.Reflection.MethodCaller.GetType(request.TypeName, true);
         var context = new DataPortalContext(
-          (IPrincipal)MobileFormatter.Deserialize(request.Principal), 
-          true, 
-          request.ClientCulture, 
+          (IPrincipal)MobileFormatter.Deserialize(request.Principal),
+          true,
+          request.ClientCulture,
           request.ClientUICulture,
           (ContextDictionary)MobileFormatter.Deserialize(request.ClientContext),
           (ContextDictionary)MobileFormatter.Deserialize(request.GlobalContext));
@@ -63,15 +63,14 @@ namespace Csla.Server.Hosts
         result.GlobalContext = MobileFormatter.Serialize(dpr.GlobalContext);
         result.ObjectData = MobileFormatter.Serialize(dpr.ReturnObject);
       }
-      // RoyOg - 12/9/2014 The error caught here needs to be re-thrown, otherwise the error never makes it back to the client.
       catch (Exception ex)
       {
-          result.ErrorData = new HttpErrorInfo(ex);
-          throw;
+        result.ErrorData = new HttpErrorInfo(ex);
+        throw;
       }
       finally
       {
-          result = ConvertResponse(result);
+        result = ConvertResponse(result);
       }
       return result;
     }
@@ -113,15 +112,14 @@ namespace Csla.Server.Hosts
         result.GlobalContext = MobileFormatter.Serialize(dpr.GlobalContext);
         result.ObjectData = MobileFormatter.Serialize(dpr.ReturnObject);
       }
-      // RoyOg - 12/9/2014 The error caught here needs to be re-thrown, otherwise the error never makes it back to the client.
       catch (Exception ex)
       {
-          result.ErrorData = new HttpErrorInfo(ex);
-          throw;
+        result.ErrorData = new HttpErrorInfo(ex);
+        throw;
       }
       finally
       {
-          result = ConvertResponse(result);
+        result = ConvertResponse(result);
       }
       return result;
     }
@@ -158,15 +156,14 @@ namespace Csla.Server.Hosts
         result.GlobalContext = MobileFormatter.Serialize(dpr.GlobalContext);
         result.ObjectData = MobileFormatter.Serialize(dpr.ReturnObject);
       }
-      // RoyOg - 12/9/2014 The error caught here needs to be re-thrown, otherwise the error never makes it back to the client.
       catch (Exception ex)
       {
-          result.ErrorData = new HttpErrorInfo(ex);
-          throw;
+        result.ErrorData = new HttpErrorInfo(ex);
+        throw;
       }
       finally
       {
-          result = ConvertResponse(result);
+        result = ConvertResponse(result);
       }
       return result;
     }
@@ -208,15 +205,14 @@ namespace Csla.Server.Hosts
         result.GlobalContext = MobileFormatter.Serialize(dpr.GlobalContext);
         result.ObjectData = MobileFormatter.Serialize(dpr.ReturnObject);
       }
-      // RoyOg - 12/9/2014 The error caught here needs to be re-thrown, otherwise the error never makes it back to the client.
       catch (Exception ex)
       {
-          result.ErrorData = new HttpErrorInfo(ex);
-          throw;
+        result.ErrorData = new HttpErrorInfo(ex);
+        throw;
       }
       finally
       {
-          result = ConvertResponse(result);
+        result = ConvertResponse(result);
       }
       return result;
     }


### PR DESCRIPTION
This is a proposed fix for issue #310. This fix is for the WebAPI/HttpProxy. When, for example, the DB raises an error in the DAL, that error bubbles up to the instance of HttpPortal, but HttpPortal returns control to it's caller without re-throwing any errors it has caught. The result.Error, therefore,  never receives the error information and result gets serialized for return back to the client empty upon a service-side error.  This fix makes sure that the HttpPortal instance re-throws the error and solves the problem. With this fix, error information from DAL DB errors (or other server-side errors) does get packaged into the result instance and arrives at the calling client within result.Error which contains the needed information for client-side handling.

This fix has been tested, fairly extensively in Unit Tests using a remote  Csla Http portal, within a private project.

Roy