### PR TITLE
#342 ability to override event handler serialization decision

### DIFF
--- a/Source/Csla.test/Serialization/NonSerializedClass.cs
+++ b/Source/Csla.test/Serialization/NonSerializedClass.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Csla.Test.Serialization
+{
+  public class NonSerializedClass
+  {
+    public void Do()
+    {
+      Console.WriteLine("Property Changed");
+    }  
+  }
+}

--- a/Source/Csla.test/Serialization/OverrideSerializationRoot.cs
+++ b/Source/Csla.test/Serialization/OverrideSerializationRoot.cs
@@ -1,0 +1,26 @@
+using System;
+using System.ComponentModel;
+
+namespace Csla.Test.Serialization
+{
+  [Serializable()]
+  public class OverrideSerializationRoot : SerializationRoot
+  {
+    protected override bool ShouldHandlerSerialize(PropertyChangedEventHandler value)
+    {
+      if (value.Method.DeclaringType != null && value.Method.DeclaringType.Name == @"Action`2")
+      {
+        return false;
+      }
+      return base.ShouldHandlerSerialize(value);
+    }
+    protected override bool ShouldHandlerSerialize(PropertyChangingEventHandler value)
+    {
+      if (value.Method.DeclaringType != null && value.Method.DeclaringType.Name == @"Action`2")
+      {
+          return false;
+      }
+      return base.ShouldHandlerSerialize(value);
+    }
+  }
+}

--- a/Source/Csla.test/Serialization/SerializationTests.cs
+++ b/Source/Csla.test/Serialization/SerializationTests.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Linq;
 using System.ComponentModel;
 using System.Diagnostics;
+using Csla.Serialization;
 using Csla.Test.ValidationRules;
 using UnitDriven;
 
@@ -181,7 +182,48 @@ namespace Csla.Test.Serialization
 
       context.Assert.Success();
     }
-    
+
+    [TestMethod()]
+    public void TestSerializableEventsActionFails()
+    {
+      var root = new SerializationRoot();
+      var nonSerClass = new NonSerializedClass();
+      Action<object, PropertyChangedEventArgs> h = (sender, eventArgs) => { nonSerClass.Do(); };
+      var method = typeof (Action<object, PropertyChangedEventArgs>).GetMethod("Invoke");
+      var delgate = (PropertyChangedEventHandler)(object)method.CreateDelegate(typeof (PropertyChangedEventHandler), h);
+      root.PropertyChanged += delgate;
+      var b = new BinaryFormatterWrapper();
+      try
+      {
+        b.Serialize(new MemoryStream(), root);
+        Assert.Fail("Serialization should have thrown an exception");
+      }
+      catch (System.Runtime.Serialization.SerializationException ex)
+      {
+        // serialization failed as expected
+      }
+    }
+
+    [TestMethod()]
+    public void TestSerializableEventsActionSucceeds()
+    {
+      var root = new OverrideSerializationRoot();
+      var nonSerClass = new NonSerializedClass();
+
+      Action<object, PropertyChangedEventArgs> h = (sender, eventArgs) => { nonSerClass.Do(); };
+      var method = typeof (Action<object, PropertyChangedEventArgs>).GetMethod("Invoke");
+      var delgate = (PropertyChangedEventHandler)(object)method.CreateDelegate(typeof (PropertyChangedEventHandler), h);
+      root.PropertyChanged += delgate;
+
+      Action<object, PropertyChangingEventArgs> h1 = (sender, eventArgs) => { nonSerClass.Do(); };
+      var method1 = typeof(Action<object, PropertyChangingEventArgs>).GetMethod("Invoke");
+      var delgate1 = (PropertyChangingEventHandler)(object)method1.CreateDelegate(typeof(PropertyChangingEventHandler), h1);
+      root.PropertyChanging += delgate1;
+
+      var b = new BinaryFormatterWrapper();
+      b.Serialize(new MemoryStream(), root);
+    }
+
     [TestMethod()]
     public void TestValidationRulesAfterSerialization()
     {

--- a/Source/Csla.test/csla.test.csproj
+++ b/Source/Csla.test/csla.test.csproj
@@ -258,6 +258,8 @@
     <Compile Include="Serialization\BinaryReaderWriterTestClass.cs" />
     <Compile Include="Serialization\DCRoot.cs" />
     <Compile Include="Serialization\nonSerializableEventHandler.cs" />
+    <Compile Include="Serialization\NonSerializedClass.cs" />
+    <Compile Include="Serialization\OverrideSerializationRoot.cs" />
     <Compile Include="Serialization\SerializationRoot.cs" />
     <Compile Include="Serialization\SerializationTests.cs" />
     <Compile Include="Serialization\TestEventSink.cs" />

--- a/Source/Csla/Core/BindableBase.cs
+++ b/Source/Csla/Core/BindableBase.cs
@@ -43,9 +43,7 @@ namespace Csla.Core
     {
       add
       {
-        if (value.Method.IsPublic && 
-           (value.Method.DeclaringType.IsSerializable || 
-            value.Method.IsStatic))
+        if (ShouldHandlerSerialize(value))
           _serializableChangedHandlers = (PropertyChangedEventHandler)
             System.Delegate.Combine(_serializableChangedHandlers, value);
         else
@@ -54,15 +52,26 @@ namespace Csla.Core
       }
       remove
       {
-        if (value.Method.IsPublic && 
-           (value.Method.DeclaringType.IsSerializable || 
-            value.Method.IsStatic))
+          if (ShouldHandlerSerialize(value))
           _serializableChangedHandlers = (PropertyChangedEventHandler)
             System.Delegate.Remove(_serializableChangedHandlers, value);
         else
           _nonSerializableChangedHandlers = (PropertyChangedEventHandler)
             System.Delegate.Remove(_nonSerializableChangedHandlers, value);
       }
+    }
+
+    /// <summary>
+    /// Override this method to change the default logic for determining 
+    /// if the event handler should be serialized
+    /// </summary>
+    /// <param name="value">the event handler to review</param>
+    /// <returns></returns>
+    protected virtual bool ShouldHandlerSerialize(PropertyChangedEventHandler value)
+    {
+      return value.Method.IsPublic &&
+             value.Method.DeclaringType != null &&
+             (value.Method.DeclaringType.IsSerializable || value.Method.IsStatic);
     }
 
     /// <summary>
@@ -116,6 +125,19 @@ namespace Csla.Core
     }
 
     /// <summary>
+    /// Override this method to change the default logic for determining 
+    /// if the event handler should be serialized
+    /// </summary>
+    /// <param name="value">the event handler to review</param>
+    /// <returns></returns>
+    protected virtual bool ShouldHandlerSerialize(PropertyChangingEventHandler value)
+    {
+        return value.Method.IsPublic &&
+               value.Method.DeclaringType != null &&
+               (value.Method.DeclaringType.IsSerializable || value.Method.IsStatic);
+    }
+
+    /// <summary>
     /// Call this method to raise the PropertyChanged event
     /// for a specific property.
     /// </summary>
@@ -148,9 +170,7 @@ namespace Csla.Core
     {
       add
       {
-        if (value.Method.IsPublic &&
-           (value.Method.DeclaringType.IsSerializable ||
-            value.Method.IsStatic))
+          if (ShouldHandlerSerialize(value))
           _serializableChangingHandlers = (PropertyChangingEventHandler)
             System.Delegate.Combine(_serializableChangingHandlers, value);
         else
@@ -159,9 +179,7 @@ namespace Csla.Core
       }
       remove
       {
-        if (value.Method.IsPublic &&
-           (value.Method.DeclaringType.IsSerializable ||
-            value.Method.IsStatic))
+          if (ShouldHandlerSerialize(value))
           _serializableChangingHandlers = (PropertyChangingEventHandler)
             System.Delegate.Remove(_serializableChangingHandlers, value);
         else


### PR DESCRIPTION
allows a class inheriting from BindableBase to override the decision
logic that is used to determine if the property changed/changing event
handlers should be included in serialization or not.