### PR TITLE
Adding static property DataPortalServer to DataPortalSelector

### DIFF
--- a/Source/Csla.Shared/Csla.Shared.projitems
+++ b/Source/Csla.Shared/Csla.Shared.projitems
@@ -232,6 +232,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Server\AuthorizeRequest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Server\ChildDataPortal.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Server\DataPortal.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Server\DataPortalBroker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Server\DataPortalContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Server\DataPortalException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Server\DataPortalExceptionHandler.cs" />

--- a/Source/Csla.Shared/Server/DataPortal.cs
+++ b/Source/Csla.Shared/Server/DataPortal.cs
@@ -175,12 +175,12 @@ namespace Csla.Server
 
             break;
           default:
-            portal = new DataPortalSelector();
+            portal = new DataPortalBroker();
             result = await portal.Create(objectType, criteria, context, isSync).ConfigureAwait(false);
             break;
         }
 #else
-        portal = new DataPortalSelector();
+        portal = new DataPortalBroker();
         result = await portal.Create(objectType, criteria, context, isSync).ConfigureAwait(false);
 #endif
         Complete(new InterceptArgs { ObjectType = objectType, Parameter = criteria, Result = result, Operation = DataPortalOperations.Create, IsSync = isSync });
@@ -264,12 +264,12 @@ namespace Csla.Server
             result = await portal.Fetch(objectType, criteria, context, isSync).ConfigureAwait(false);
             break;
           default:
-            portal = new DataPortalSelector();
+            portal = new DataPortalBroker();
             result = await portal.Fetch(objectType, criteria, context, isSync).ConfigureAwait(false);
             break;
         }
 #else
-        portal = new DataPortalSelector();
+        portal = new DataPortalBroker();
         result = await portal.Fetch(objectType, criteria, context, isSync).ConfigureAwait(false);
 #endif
         Complete(new InterceptArgs { ObjectType = objectType, Parameter = criteria, Result = result, Operation = DataPortalOperations.Fetch, IsSync = isSync });
@@ -401,12 +401,12 @@ namespace Csla.Server
             result = await portal.Update(obj, context, isSync).ConfigureAwait(false);
             break;
           default:
-            portal = new DataPortalSelector();
+            portal = new DataPortalBroker();
             result = await portal.Update(obj, context, isSync).ConfigureAwait(false);
             break;
         }
 #else
-        portal = new DataPortalSelector();
+        portal = new DataPortalBroker();
         result = await portal.Update(obj, context, isSync).ConfigureAwait(false);
 #endif
         Complete(new InterceptArgs { ObjectType = objectType, Parameter = obj, Result = result, Operation = operation, IsSync = isSync });
@@ -500,12 +500,12 @@ namespace Csla.Server
             result = await portal.Delete(objectType, criteria, context, isSync).ConfigureAwait(false);
             break;
           default:
-            portal = new DataPortalSelector();
+            portal = new DataPortalBroker();
             result = await portal.Delete(objectType, criteria, context, isSync).ConfigureAwait(false);
             break;
         }
 #else
-        portal = new DataPortalSelector();
+        portal = new DataPortalBroker();
         result = await portal.Delete(objectType, criteria, context, isSync).ConfigureAwait(false);
 #endif
         Complete(new InterceptArgs { ObjectType = objectType, Parameter = criteria, Result = result, Operation = DataPortalOperations.Delete, IsSync = isSync });

--- a/Source/Csla.Shared/Server/DataPortalBroker.cs
+++ b/Source/Csla.Shared/Server/DataPortalBroker.cs
@@ -1,0 +1,112 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="DataPortalBroker.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: http://www.lhotka.net/cslanet/
+// </copyright>
+// <summary>Allows interception of DataPortal call</summary>
+//-----------------------------------------------------------------------
+using System;
+using System.Threading.Tasks;
+
+namespace Csla.Server
+{
+  /// <summary>
+  /// Allows the Data Portal call to be intercepted by
+  /// a custom IDataPortalServer implementation.
+  /// </summary>
+  public class DataPortalBroker : IDataPortalServer
+  {
+    /// <summary>
+    /// Gets or sets a reference to a implementation of
+    /// IDataPortalServer to be used.
+    /// </summary>
+    public static IDataPortalServer DataPortalServer { get; set; }
+
+    /// <summary>
+    /// Create a new business object.
+    /// </summary>
+    /// <param name="objectType">Type of business object to create.</param>
+    /// <param name="criteria">Criteria object describing business object.</param>
+    /// <param name="context">
+    /// <see cref="Server.DataPortalContext" /> object passed to the server.
+    /// </param>
+    /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
+    public Task<DataPortalResult> Create(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    {
+      if (DataPortalServer != null)
+      {
+        return DataPortalServer.Create(objectType, criteria, context, isSync);
+      }
+      else
+      {
+        var dp = new DataPortalSelector();
+        return dp.Create(objectType, criteria, context, isSync);
+      }      
+    }
+
+    /// <summary>
+    /// Get an existing business object.
+    /// </summary>
+    /// <param name="objectType">Type of business object to retrieve.</param>
+    /// <param name="criteria">Criteria object describing business object.</param>
+    /// <param name="context">
+    /// <see cref="Server.DataPortalContext" /> object passed to the server.
+    /// </param>
+    /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
+    public Task<DataPortalResult> Fetch(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    {
+      if (DataPortalServer != null)
+      {
+        return DataPortalServer.Fetch(objectType, criteria, context, isSync);
+      }
+      else
+      {
+        var dp = new DataPortalSelector();
+        return dp.Fetch(objectType, criteria, context, isSync);
+      }
+    }
+
+    /// <summary>
+    /// Update a business object.
+    /// </summary>
+    /// <param name="obj">Business object to update.</param>
+    /// <param name="context">
+    /// <see cref="Server.DataPortalContext" /> object passed to the server.
+    /// </param>
+    /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
+    public Task<DataPortalResult> Update(object obj, DataPortalContext context, bool isSync)
+    {
+      if (DataPortalServer != null)
+      {
+        return DataPortalServer.Update(obj, context, isSync);
+      }
+      else
+      {
+        var dp = new DataPortalSelector();
+        return dp.Update(obj, context, isSync);
+      }
+    }
+
+    /// <summary>
+    /// Delete a business object.
+    /// </summary>
+    /// <param name="objectType">Type of business object to create.</param>
+    /// <param name="criteria">Criteria object describing business object.</param>
+    /// <param name="context">
+    /// <see cref="Server.DataPortalContext" /> object passed to the server.
+    /// </param>
+    /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
+    public Task<DataPortalResult> Delete(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    {
+      if (DataPortalServer != null)
+      {
+        return DataPortalServer.Delete(objectType, criteria, context, isSync);
+      }
+      else
+      {
+        var dp = new DataPortalSelector();
+        return dp.Delete(objectType, criteria, context, isSync);
+      }
+    }
+  }
+}

--- a/Source/Csla.Shared/Server/ServicedDataPortalReadCommitted.cs
+++ b/Source/Csla.Shared/Server/ServicedDataPortalReadCommitted.cs
@@ -43,7 +43,7 @@ namespace Csla.Server
     public async Task<DataPortalResult> Create(
       Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
-      var portal = new DataPortalSelector();
+      var portal = new DataPortalBroker();
       return await portal.Create(objectType, criteria, context, isSync).ConfigureAwait(false);
     }
 
@@ -64,7 +64,7 @@ namespace Csla.Server
     [AutoComplete(true)]
     public async Task<DataPortalResult> Fetch(Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
-      var portal = new DataPortalSelector();
+      var portal = new DataPortalBroker();
       return await portal.Fetch(objectType, criteria, context, isSync).ConfigureAwait(false);
     }
 
@@ -84,7 +84,7 @@ namespace Csla.Server
     [AutoComplete(true)]
     public async Task<DataPortalResult> Update(object obj, DataPortalContext context, bool isSync)
     {
-      var portal = new DataPortalSelector();
+      var portal = new DataPortalBroker();
       return await portal.Update(obj, context, isSync).ConfigureAwait(false);
     }
 
@@ -104,7 +104,7 @@ namespace Csla.Server
     [AutoComplete(true)]
     public async Task<DataPortalResult> Delete(Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
-      var portal = new DataPortalSelector();
+      var portal = new DataPortalBroker();
       return await portal.Delete(objectType, criteria, context, isSync).ConfigureAwait(false);
     }
   }

--- a/Source/Csla.Shared/Server/ServicedDataPortalReadUncommitted.cs
+++ b/Source/Csla.Shared/Server/ServicedDataPortalReadUncommitted.cs
@@ -43,7 +43,7 @@ namespace Csla.Server
     public async Task<DataPortalResult> Create(
       Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
-      var portal = new DataPortalSelector();
+      var portal = new DataPortalBroker();
       return await portal.Create(objectType, criteria, context, isSync).ConfigureAwait(false);
     }
 
@@ -64,7 +64,7 @@ namespace Csla.Server
     [AutoComplete(true)]
     public async Task<DataPortalResult> Fetch(Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
-      var portal = new DataPortalSelector();
+      var portal = new DataPortalBroker();
       return await portal.Fetch(objectType, criteria, context, isSync).ConfigureAwait(false);
     }
 
@@ -84,7 +84,7 @@ namespace Csla.Server
     [AutoComplete(true)]
     public async Task<DataPortalResult> Update(object obj, DataPortalContext context, bool isSync)
     {
-      var portal = new DataPortalSelector();
+      var portal = new DataPortalBroker();
       return await portal.Update(obj, context, isSync).ConfigureAwait(false);
     }
 
@@ -104,7 +104,7 @@ namespace Csla.Server
     [AutoComplete(true)]
     public async Task<DataPortalResult> Delete(Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
-      var portal = new DataPortalSelector();
+      var portal = new DataPortalBroker();
       return await portal.Delete(objectType, criteria, context, isSync).ConfigureAwait(false);
     }
   }

--- a/Source/Csla.Shared/Server/ServicedDataPortalRepeatableRead.cs
+++ b/Source/Csla.Shared/Server/ServicedDataPortalRepeatableRead.cs
@@ -43,7 +43,7 @@ namespace Csla.Server
     public async Task<DataPortalResult> Create(
       Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
-      var portal = new DataPortalSelector();
+      var portal = new DataPortalBroker();
       return await portal.Create(objectType, criteria, context, isSync).ConfigureAwait(false);
     }
 
@@ -64,7 +64,7 @@ namespace Csla.Server
     [AutoComplete(true)]
     public async Task<DataPortalResult> Fetch(Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
-      var portal = new DataPortalSelector();
+      var portal = new DataPortalBroker();
       return await portal.Fetch(objectType, criteria, context, isSync).ConfigureAwait(false);
     }
 
@@ -84,7 +84,7 @@ namespace Csla.Server
     [AutoComplete(true)]
     public async Task<DataPortalResult> Update(object obj, DataPortalContext context, bool isSync)
     {
-      var portal = new DataPortalSelector();
+      var portal = new DataPortalBroker();
       return await portal.Update(obj, context, isSync).ConfigureAwait(false);
     }
 
@@ -104,7 +104,7 @@ namespace Csla.Server
     [AutoComplete(true)]
     public async Task<DataPortalResult> Delete(Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
-      var portal = new DataPortalSelector();
+      var portal = new DataPortalBroker();
       return await portal.Delete(objectType, criteria, context, isSync).ConfigureAwait(false);
     }
   }

--- a/Source/Csla.Shared/Server/ServicedDataPortalSerializable.cs
+++ b/Source/Csla.Shared/Server/ServicedDataPortalSerializable.cs
@@ -43,7 +43,7 @@ namespace Csla.Server
     public async Task<DataPortalResult> Create(
       Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
-      var portal = new DataPortalSelector();
+      var portal = new DataPortalBroker();
       return await portal.Create(objectType, criteria, context, isSync).ConfigureAwait(false);
     }
 
@@ -64,7 +64,7 @@ namespace Csla.Server
     [AutoComplete(true)]
     public async Task<DataPortalResult> Fetch(Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
-      var portal = new DataPortalSelector();
+      var portal = new DataPortalBroker();
       return await portal.Fetch(objectType, criteria, context, isSync).ConfigureAwait(false);
     }
 
@@ -84,7 +84,7 @@ namespace Csla.Server
     [AutoComplete(true)]
     public async Task<DataPortalResult> Update(object obj, DataPortalContext context, bool isSync)
     {
-      var portal = new DataPortalSelector();
+      var portal = new DataPortalBroker();
       return await portal.Update(obj, context, isSync).ConfigureAwait(false);
     }
 
@@ -104,7 +104,7 @@ namespace Csla.Server
     [AutoComplete(true)]
     public async Task<DataPortalResult> Delete(Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
-      var portal = new DataPortalSelector();
+      var portal = new DataPortalBroker();
       return await portal.Delete(objectType, criteria, context, isSync).ConfigureAwait(false);
     }
   }

--- a/Source/Csla.Shared/Server/TransactionalDataPortal.cs
+++ b/Source/Csla.Shared/Server/TransactionalDataPortal.cs
@@ -55,7 +55,7 @@ namespace Csla.Server
       DataPortalResult result;
       using (TransactionScope tr = CreateTransactionScope())
       {
-        var portal = new DataPortalSelector();
+        var portal = new DataPortalBroker();
         result = await portal.Create(objectType, criteria, context, isSync).ConfigureAwait(false);
         tr.Complete();
       }
@@ -117,7 +117,7 @@ namespace Csla.Server
       DataPortalResult result;
       using (TransactionScope tr = CreateTransactionScope())
       {
-        var portal = new DataPortalSelector();
+        var portal = new DataPortalBroker();
         result = await portal.Fetch(objectType, criteria, context, isSync).ConfigureAwait(false);
         tr.Complete();
       }
@@ -144,7 +144,7 @@ namespace Csla.Server
       DataPortalResult result;
       using (TransactionScope tr = CreateTransactionScope())
       {
-        var portal = new DataPortalSelector();
+        var portal = new DataPortalBroker();
         result = await portal.Update(obj, context, isSync).ConfigureAwait(false);
         tr.Complete();
       }
@@ -171,7 +171,7 @@ namespace Csla.Server
       DataPortalResult result;
       using (TransactionScope tr = CreateTransactionScope())
       {
-        var portal = new DataPortalSelector();
+        var portal = new DataPortalBroker();
         result = await portal.Delete(objectType, criteria, context, isSync).ConfigureAwait(false);
         tr.Complete();
       }

--- a/Source/Csla.test/DataPortal/CustomDataPortalServer.cs
+++ b/Source/Csla.test/DataPortal/CustomDataPortalServer.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Threading.Tasks;
+
+using Csla.Server;
+
+namespace Csla.Test.DataPortal
+{
+  public class CustomDataPortalServer : IDataPortalServer
+  {
+    public async Task<DataPortalResult> Create(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    {
+      var dp = new DataPortalSelector();
+      var result = await dp.Create(objectType, criteria, context, isSync).ConfigureAwait(false);
+
+      ApplicationContext.GlobalContext["CustomDataPortalServer"] = "Create Called";
+
+      return result;
+    }
+
+    public async Task<DataPortalResult> Fetch(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    {
+      var dp = new DataPortalSelector();
+      var result = await dp.Fetch(objectType, criteria, context, isSync).ConfigureAwait(false);
+
+      ApplicationContext.GlobalContext["CustomDataPortalServer"] = "Fetch Called";
+
+      return result;
+    }
+
+    public async Task<DataPortalResult> Update(object obj, DataPortalContext context, bool isSync)
+    {
+      var dp = new DataPortalSelector();
+      var result = await dp.Update(obj, context, isSync).ConfigureAwait(false);
+
+      ApplicationContext.GlobalContext["CustomDataPortalServer"] = "Update Called";
+
+      return result;
+    }
+
+    public async Task<DataPortalResult> Delete(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    {
+      var dp = new DataPortalSelector();
+      var result = await dp.Delete(objectType, criteria, context, isSync).ConfigureAwait(false);
+
+      ApplicationContext.GlobalContext["CustomDataPortalServer"] = "Delete Called";
+
+      return result;
+    }
+  }
+}

--- a/Source/Csla.test/DataPortal/DataPortalTests.cs
+++ b/Source/Csla.test/DataPortal/DataPortalTests.cs
@@ -287,6 +287,54 @@ namespace Csla.Test.DataPortal
         }
 
         [TestMethod]
+        public void DataPortalBrokerTests()
+        {
+          ApplicationContext.GlobalContext.Clear();
+          Csla.Server.DataPortalBroker.DataPortalServer = new CustomDataPortalServer();
+
+          try
+          {
+            var single = Csla.Test.DataPortalTest.Single.NewObject();
+
+            Assert.AreEqual(ApplicationContext.GlobalContext["Single"], "Created");
+            Assert.AreEqual(ApplicationContext.GlobalContext["CustomDataPortalServer"], "Create Called");
+
+            ApplicationContext.GlobalContext.Clear();
+
+            single.Save();
+
+            Assert.AreEqual(ApplicationContext.GlobalContext["Single"], "Inserted");
+            Assert.AreEqual(ApplicationContext.GlobalContext["CustomDataPortalServer"], "Update Called");
+
+            ApplicationContext.GlobalContext.Clear();
+
+            single = Csla.Test.DataPortalTest.Single.GetObject(1);
+
+            Assert.AreEqual(ApplicationContext.GlobalContext["Single"], "Fetched");
+            Assert.AreEqual(ApplicationContext.GlobalContext["CustomDataPortalServer"], "Fetch Called");
+
+            ApplicationContext.GlobalContext.Clear();
+
+            single.Save();
+
+            Assert.AreEqual(ApplicationContext.GlobalContext["Single"], "Updated");
+            Assert.AreEqual(ApplicationContext.GlobalContext["CustomDataPortalServer"], "Update Called");
+
+            ApplicationContext.GlobalContext.Clear();
+
+            Csla.Test.DataPortalTest.Single.DeleteObject(1);
+
+            Assert.AreEqual(ApplicationContext.GlobalContext["Single"], "Deleted");
+            Assert.AreEqual(ApplicationContext.GlobalContext["CustomDataPortalServer"], "Delete Called");
+          }
+          finally
+          {
+            ApplicationContext.GlobalContext.Clear();
+            Csla.Server.DataPortalBroker.DataPortalServer = null;
+          }
+        }
+
+        [TestMethod]
         public void CallDataPortalOverrides()
         {
             Csla.ApplicationContext.GlobalContext.Clear();

--- a/Source/Csla.test/csla.test.csproj
+++ b/Source/Csla.test/csla.test.csproj
@@ -161,6 +161,7 @@
     <Compile Include="DataPortal\AsynchDataPortalTest.cs" />
     <Compile Include="DataPortal\ChildEntity.cs" />
     <Compile Include="DataPortal\ChildEntityList.cs" />
+    <Compile Include="DataPortal\CustomDataPortalServer.cs" />
     <Compile Include="DataPortal\DataPortalExceptionTest.cs" />
     <Compile Include="DataPortal\InterceptorTests.cs" />
     <Compile Include="DataPortal\Legacy.cs" />


### PR DESCRIPTION
I've noticed that in my Root objects there's a lot of "On Save" logic in the DoInsertUpdate() that is outside the scope of persisting the object.  Ideally, I'd like this logic out of my business layer and configured via my DI container.  Then I would slip in the logic using an implementation of IDataPortalServer between DatatPortalSelector and SimpeDataPortal.

Any feedback on my problem/pr is appreciated.  Thanks!