### PR TITLE
Hide BusinessBase.BypassPropertyChecks from the debugger

### DIFF
--- a/Source/Csla.Shared/Core/BusinessBase.cs
+++ b/Source/Csla.Shared/Core/BusinessBase.cs
@@ -3608,6 +3608,7 @@ namespace Csla.Core
     /// without raising PropertyChanged events
     /// and checking user rights.
     /// </summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     protected internal BypassPropertyChecksObject BypassPropertyChecks
     {
       get


### PR DESCRIPTION
This fixes an issue I've been having with VS 2015, which now shows nonpublic properties at the top of the list when examining an object. VS will immediately get this property's value when you inspect a business object, but never disposes it, causing the object's reference count to permanently remain above zero and preventing SetProperty from running rules.