### PR TITLE
AllowSerializableAttributeOnEnums

### DIFF
--- a/Source/Csla.Shared/Serialization/SerializationAttribute.cs
+++ b/Source/Csla.Shared/Serialization/SerializationAttribute.cs
@@ -14,7 +14,7 @@ namespace System
   /// Indicates that an object may be
   /// serialized by the MobileFormatter.
   /// </summary>
-  [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+  [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum)]
   public class SerializableAttribute : Attribute
   {
   }


### PR DESCRIPTION
Allows SerializableAttribute to be applied to enums, to reduce friction porting to PCL/Xamarin.