### PR TITLE
UWP now uses Microsoft serialization  code

### DIFF
--- a/Source/Csla.Analyzers/Csla.Analyzers/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Analyzers/Csla.Analyzers/Properties/AssemblyInfo.cs
@@ -11,5 +11,5 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCulture("")]
 [assembly: InternalsVisibleTo("Csla.Analyzers.Tests")]
 
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Android/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Android/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using Android.App;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Axml.Android/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Axml.Android/Properties/AssemblyInfo.cs
@@ -24,5 +24,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Data.EF4.Net4.5/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Data.EF4.Net4.5/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Data.EF4.Net4.6/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Data.EF4.Net4.6/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Data.EF4.Net4/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Data.EF4.Net4/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Data.EF5.Net4.5/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Data.EF5.Net4.5/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Data.EF5.Net4.6/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Data.EF5.Net4.6/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Data.EF5.Net4/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Data.EF5.Net4/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Data.EF6.Net4.5/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Data.EF6.Net4.5/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Data.EF6.Net4.6/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Data.EF6.Net4.6/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Data.EF6.Net4/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Data.EF6.Net4/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Data.EF7.Net4.6/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Data.EF7.Net4.6/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Ios/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Ios/Properties/AssemblyInfo.cs
@@ -35,5 +35,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Iosui.Ios/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Iosui.Ios/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Net4.5/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Net4.5/Properties/AssemblyInfo.cs
@@ -42,5 +42,5 @@ using System.Windows;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Net4.6/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Net4.6/Properties/AssemblyInfo.cs
@@ -42,5 +42,5 @@ using System.Windows;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Net4/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Net4/Properties/AssemblyInfo.cs
@@ -42,5 +42,5 @@ using System.Windows;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.NetStandard1.5/Properties/AssemblyInfo.cs
+++ b/Source/Csla.NetStandard1.5/Properties/AssemblyInfo.cs
@@ -21,5 +21,5 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("b04b5ed0-8f76-44a0-af36-a8b91dc4a9ad")]
 
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.NetStandard1.6/Properties/AssemblyInfo.cs
+++ b/Source/Csla.NetStandard1.6/Properties/AssemblyInfo.cs
@@ -21,5 +21,5 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("b04b5ed0-8f76-44a0-af36-a8b91dc4a9ad")]
 
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Pcl/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Pcl/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Shared/Core/BusinessBase.cs
+++ b/Source/Csla.Shared/Core/BusinessBase.cs
@@ -3719,7 +3719,7 @@ namespace Csla.Core
 #if NETFX_CORE
     #region UndoableBase overrides
 
-#if !NETSTANDARD1_6
+#if !NETSTANDARD1_6 && !WINDOWS_UWP
     /// <summary>
     /// Copy object state.
     /// </summary>

--- a/Source/Csla.Shared/Core/UndoableBase.cs
+++ b/Source/Csla.Shared/Core/UndoableBase.cs
@@ -7,7 +7,7 @@
 //-----------------------------------------------------------------------
 #if NETFX_CORE || IOS || ANDROID
 using System;
-#if !NETSTANDARD1_6
+#if !NETSTANDARD1_6 && !WINDOWS_UWP
 using Csla.Serialization.Mobile;
 #endif
 using System.ComponentModel;
@@ -127,7 +127,7 @@ namespace Csla.Core
       if (this.EditLevel + 1 > parentEditLevel)
         throw new UndoException(string.Format(Resources.EditLevelMismatchException, "CopyState"), this.GetType().Name, null, this.EditLevel, parentEditLevel - 1);
 
-#if NETSTANDARD1_6
+#if NETSTANDARD1_6 || WINDOWS_UWP
       SerializationInfo state = new SerializationInfo(this.GetType(), null);
 #else
       SerializationInfo state = new SerializationInfo(0);
@@ -282,10 +282,10 @@ namespace Csla.Core
         child.CopyState(targetLevel, false);
     }
 
-      #endregion
+    #endregion
 
-#if !NETSTANDARD1_6
-      #region MobileObject overrides
+#if !NETSTANDARD1_6 && !WINDOWS_UWP
+    #region MobileObject overrides
 
     /// <summary>
     /// Gets the state of the object for serialization.
@@ -335,7 +335,7 @@ namespace Csla.Core
       base.OnSetState(info, mode);
     }
 
-      #endregion
+    #endregion
 #endif
   }
 }

--- a/Source/Csla.Shared/Serialization/NonSerializedAttribute.cs
+++ b/Source/Csla.Shared/Serialization/NonSerializedAttribute.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD1_6
+﻿#if !NETSTANDARD1_6 && !WINDOWS_UWP
 #if NETFX_CORE
 //-----------------------------------------------------------------------
 // <copyright file="NonSerializedAttribute.cs" company="Marimer LLC">

--- a/Source/Csla.Shared/Serialization/SerializationAttribute.cs
+++ b/Source/Csla.Shared/Serialization/SerializationAttribute.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD1_6
+﻿#if !NETSTANDARD1_6 && !WINDOWS_UWP
 #if NETFX_CORE
 //-----------------------------------------------------------------------
 // <copyright file="SerializationAttribute.cs" company="Marimer LLC">

--- a/Source/Csla.Uwp/Csla.Uwp.nuget.props
+++ b/Source/Csla.Uwp/Csla.Uwp.nuget.props
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <RestoreSuccess Condition=" '$(RestoreSuccess)' == '' ">True</RestoreSuccess>
+    <RestoreTool Condition=" '$(RestoreTool)' == '' ">NuGet</RestoreTool>
+    <ProjectAssetsFile Condition=" '$(ProjectAssetsFile)' == '' ">C:\src\rdl\csla\Source\Csla.Uwp\project.lock.json</ProjectAssetsFile>
+    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
+    <NuGetPackageFolders Condition=" '$(NuGetPackageFolders)' == '' ">C:\Users\rocky\.nuget\packages\</NuGetPackageFolders>
+    <NuGetProjectStyle Condition=" '$(NuGetProjectStyle)' == '' ">ProjectJson</NuGetProjectStyle>
+    <NuGetToolVersion Condition=" '$(NuGetToolVersion)' == '' ">4.2.0</NuGetToolVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+  <ImportGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <Import Project="$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-x86\1.6.1\build\Microsoft.Net.Native.SharedLibrary-x86.props" Condition="Exists('$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-x86\1.6.1\build\Microsoft.Net.Native.SharedLibrary-x86.props')" />
+    <Import Project="$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-x64\1.6.1\build\Microsoft.Net.Native.SharedLibrary-x64.props" Condition="Exists('$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-x64\1.6.1\build\Microsoft.Net.Native.SharedLibrary-x64.props')" />
+    <Import Project="$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-arm\1.6.1\build\Microsoft.Net.Native.SharedLibrary-arm.props" Condition="Exists('$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-arm\1.6.1\build\Microsoft.Net.Native.SharedLibrary-arm.props')" />
+    <Import Project="$(NuGetPackageRoot)microsoft.net.native.compiler\1.6.2\build\Microsoft.Net.Native.Compiler.props" Condition="Exists('$(NuGetPackageRoot)microsoft.net.native.compiler\1.6.2\build\Microsoft.Net.Native.Compiler.props')" />
+  </ImportGroup>
+</Project>

--- a/Source/Csla.Uwp/Csla.Uwp.nuget.targets
+++ b/Source/Csla.Uwp/Csla.Uwp.nuget.targets
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+  <ImportGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <Import Project="$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-x86\1.6.1\build\Microsoft.Net.Native.SharedLibrary-x86.targets" Condition="Exists('$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-x86\1.6.1\build\Microsoft.Net.Native.SharedLibrary-x86.targets')" />
+    <Import Project="$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-x64\1.6.1\build\Microsoft.Net.Native.SharedLibrary-x64.targets" Condition="Exists('$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-x64\1.6.1\build\Microsoft.Net.Native.SharedLibrary-x64.targets')" />
+    <Import Project="$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-arm\1.6.1\build\Microsoft.Net.Native.SharedLibrary-arm.targets" Condition="Exists('$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-arm\1.6.1\build\Microsoft.Net.Native.SharedLibrary-arm.targets')" />
+    <Import Project="$(NuGetPackageRoot)microsoft.net.native.compiler\1.6.2\build\Microsoft.Net.Native.Compiler.targets" Condition="Exists('$(NuGetPackageRoot)microsoft.net.native.compiler\1.6.2\build\Microsoft.Net.Native.Compiler.targets')" />
+  </ImportGroup>
+</Project>

--- a/Source/Csla.Uwp/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Uwp/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]
 [assembly: ComVisible(false)]

--- a/Source/Csla.Uwp/project.json
+++ b/Source/Csla.Uwp/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0"
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.3.3",
+    "System.Runtime.Serialization.Formatters": "4.3.0"
   },
   "frameworks": {
     "uap10.0": {}

--- a/Source/Csla.Validation.Android/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Validation.Android/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]
 

--- a/Source/Csla.Validation.Ios/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Validation.Ios/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Validation.Net4.5/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Validation.Net4.5/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Validation.Net4.6/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Validation.Net4.6/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Validation.Net4/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Validation.Net4/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Validation.Uwp/Csla.Validation.Uwp.nuget.props
+++ b/Source/Csla.Validation.Uwp/Csla.Validation.Uwp.nuget.props
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <RestoreSuccess Condition=" '$(RestoreSuccess)' == '' ">True</RestoreSuccess>
+    <RestoreTool Condition=" '$(RestoreTool)' == '' ">NuGet</RestoreTool>
+    <ProjectAssetsFile Condition=" '$(ProjectAssetsFile)' == '' ">C:\src\rdl\csla\Source\Csla.Validation.Uwp\project.lock.json</ProjectAssetsFile>
+    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
+    <NuGetPackageFolders Condition=" '$(NuGetPackageFolders)' == '' ">C:\Users\rocky\.nuget\packages\</NuGetPackageFolders>
+    <NuGetProjectStyle Condition=" '$(NuGetProjectStyle)' == '' ">ProjectJson</NuGetProjectStyle>
+    <NuGetToolVersion Condition=" '$(NuGetToolVersion)' == '' ">4.2.0</NuGetToolVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+  <ImportGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <Import Project="$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-x86\1.6.1\build\Microsoft.Net.Native.SharedLibrary-x86.props" Condition="Exists('$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-x86\1.6.1\build\Microsoft.Net.Native.SharedLibrary-x86.props')" />
+    <Import Project="$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-x64\1.6.1\build\Microsoft.Net.Native.SharedLibrary-x64.props" Condition="Exists('$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-x64\1.6.1\build\Microsoft.Net.Native.SharedLibrary-x64.props')" />
+    <Import Project="$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-arm\1.6.1\build\Microsoft.Net.Native.SharedLibrary-arm.props" Condition="Exists('$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-arm\1.6.1\build\Microsoft.Net.Native.SharedLibrary-arm.props')" />
+    <Import Project="$(NuGetPackageRoot)microsoft.net.native.compiler\1.6.2\build\Microsoft.Net.Native.Compiler.props" Condition="Exists('$(NuGetPackageRoot)microsoft.net.native.compiler\1.6.2\build\Microsoft.Net.Native.Compiler.props')" />
+  </ImportGroup>
+</Project>

--- a/Source/Csla.Validation.Uwp/Csla.Validation.Uwp.nuget.targets
+++ b/Source/Csla.Validation.Uwp/Csla.Validation.Uwp.nuget.targets
@@ -4,7 +4,6 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <ImportGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
-    <Import Project="$(NuGetPackageRoot)nuspec.referencegenerator\1.3.3\build\dotnet\NuSpec.ReferenceGenerator.targets" Condition="Exists('$(NuGetPackageRoot)nuspec.referencegenerator\1.3.3\build\dotnet\NuSpec.ReferenceGenerator.targets')" />
     <Import Project="$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-x86\1.6.1\build\Microsoft.Net.Native.SharedLibrary-x86.targets" Condition="Exists('$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-x86\1.6.1\build\Microsoft.Net.Native.SharedLibrary-x86.targets')" />
     <Import Project="$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-x64\1.6.1\build\Microsoft.Net.Native.SharedLibrary-x64.targets" Condition="Exists('$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-x64\1.6.1\build\Microsoft.Net.Native.SharedLibrary-x64.targets')" />
     <Import Project="$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-arm\1.6.1\build\Microsoft.Net.Native.SharedLibrary-arm.targets" Condition="Exists('$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-arm\1.6.1\build\Microsoft.Net.Native.SharedLibrary-arm.targets')" />

--- a/Source/Csla.Validation.Uwp/project.json
+++ b/Source/Csla.Validation.Uwp/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0"
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.3.3"
   },
   "frameworks": {
     "uap10.0": {}

--- a/Source/Csla.Web.Mvc4.Net4.5/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Web.Mvc4.Net4.5/Properties/AssemblyInfo.cs
@@ -34,5 +34,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Web.Mvc4.Net4/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Web.Mvc4.Net4/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Web.Mvc5.Net4.5/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Web.Mvc5.Net4.5/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Web.Mvc5.Net4.6/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Web.Mvc5.Net4.6/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Web.Net4.5/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Web.Net4.5/Properties/AssemblyInfo.cs
@@ -34,5 +34,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Web.Net4.6/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Web.Net4.6/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Web.Net4/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Web.Net4/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Windows.Net4.5/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Windows.Net4.5/Properties/AssemblyInfo.cs
@@ -41,5 +41,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Windows.Net4.6/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Windows.Net4.6/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Windows.Net4/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Windows.Net4/Properties/AssemblyInfo.cs
@@ -41,5 +41,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/Csla.Xaml.Net4.5/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Xaml.Net4.5/Properties/AssemblyInfo.cs
@@ -44,8 +44,8 @@ using System.Windows.Markup;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]
 
 
 [assembly: ThemeInfo(ResourceDictionaryLocation.SourceAssembly, ResourceDictionaryLocation.SourceAssembly)]

--- a/Source/Csla.Xaml.Net4.6/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Xaml.Net4.6/Properties/AssemblyInfo.cs
@@ -34,8 +34,8 @@ using System.Windows.Markup;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]
 
 [assembly: ThemeInfo(ResourceDictionaryLocation.SourceAssembly, ResourceDictionaryLocation.SourceAssembly)]
 

--- a/Source/Csla.Xaml.Net4/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Xaml.Net4/Properties/AssemblyInfo.cs
@@ -44,8 +44,8 @@ using System.Windows.Markup;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]
 
 
 [assembly: ThemeInfo(ResourceDictionaryLocation.SourceAssembly, ResourceDictionaryLocation.SourceAssembly)]

--- a/Source/Csla.Xaml.Uwp/Csla.Xaml.NuSpec
+++ b/Source/Csla.Xaml.Uwp/Csla.Xaml.NuSpec
@@ -21,18 +21,18 @@ Supports the creation of UWP applications.
     <language>en-US</language>
     <dependencies>
       <group targetFramework="uap10.0">
-        <dependency id="System.Collections" version="4.0.10" />
+        <dependency id="System.Collections" version="4.3.0" />
         <dependency id="System.ComponentModel.Annotations" version="4.0.10" />
         <dependency id="System.Diagnostics.Debug" version="4.0.10" />
         <dependency id="System.Linq" version="4.0.0" />
         <dependency id="System.Linq.Expressions" version="4.0.10" />
         <dependency id="System.ObjectModel" version="4.0.10" />
-        <dependency id="System.Reflection" version="4.0.10" />
+        <dependency id="System.Reflection" version="4.3.0" />
         <dependency id="System.Reflection.TypeExtensions" version="4.0.0" />
-        <dependency id="System.Runtime" version="4.0.20" />
+        <dependency id="System.Runtime" version="4.3.0" />
         <dependency id="System.Runtime.InteropServices.WindowsRuntime" version="4.0.0" />
         <dependency id="System.Threading" version="4.0.10" />
-        <dependency id="System.Threading.Tasks" version="4.0.10" />
+        <dependency id="System.Threading.Tasks" version="4.3.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Source/Csla.Xaml.Uwp/Csla.Xaml.NuSpec
+++ b/Source/Csla.Xaml.Uwp/Csla.Xaml.NuSpec
@@ -22,16 +22,16 @@ Supports the creation of UWP applications.
     <dependencies>
       <group targetFramework="uap10.0">
         <dependency id="System.Collections" version="4.3.0" />
-        <dependency id="System.ComponentModel.Annotations" version="4.0.10" />
-        <dependency id="System.Diagnostics.Debug" version="4.0.10" />
-        <dependency id="System.Linq" version="4.0.0" />
-        <dependency id="System.Linq.Expressions" version="4.0.10" />
-        <dependency id="System.ObjectModel" version="4.0.10" />
+        <dependency id="System.ComponentModel.Annotations" version="4.1.0" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.11" />
+        <dependency id="System.Linq" version="4.1.0" />
+        <dependency id="System.Linq.Expressions" version="4.1.0" />
+        <dependency id="System.ObjectModel" version="4.0.12" />
         <dependency id="System.Reflection" version="4.3.0" />
-        <dependency id="System.Reflection.TypeExtensions" version="4.0.0" />
+        <dependency id="System.Reflection.TypeExtensions" version="4.1.0" />
         <dependency id="System.Runtime" version="4.3.0" />
-        <dependency id="System.Runtime.InteropServices.WindowsRuntime" version="4.0.0" />
-        <dependency id="System.Threading" version="4.0.10" />
+        <dependency id="System.Runtime.InteropServices.WindowsRuntime" version="4.0.1" />
+        <dependency id="System.Threading" version="4.0.11" />
         <dependency id="System.Threading.Tasks" version="4.3.0" />
       </group>
     </dependencies>

--- a/Source/Csla.Xaml.Uwp/Csla.Xaml.Uwp.nuget.props
+++ b/Source/Csla.Xaml.Uwp/Csla.Xaml.Uwp.nuget.props
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <RestoreSuccess Condition=" '$(RestoreSuccess)' == '' ">True</RestoreSuccess>
+    <RestoreTool Condition=" '$(RestoreTool)' == '' ">NuGet</RestoreTool>
+    <ProjectAssetsFile Condition=" '$(ProjectAssetsFile)' == '' ">C:\src\rdl\csla\Source\Csla.Xaml.Uwp\project.lock.json</ProjectAssetsFile>
+    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
+    <NuGetPackageFolders Condition=" '$(NuGetPackageFolders)' == '' ">C:\Users\rocky\.nuget\packages\</NuGetPackageFolders>
+    <NuGetProjectStyle Condition=" '$(NuGetProjectStyle)' == '' ">ProjectJson</NuGetProjectStyle>
+    <NuGetToolVersion Condition=" '$(NuGetToolVersion)' == '' ">4.2.0</NuGetToolVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+  <ImportGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <Import Project="$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-x86\1.6.1\build\Microsoft.Net.Native.SharedLibrary-x86.props" Condition="Exists('$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-x86\1.6.1\build\Microsoft.Net.Native.SharedLibrary-x86.props')" />
+    <Import Project="$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-x64\1.6.1\build\Microsoft.Net.Native.SharedLibrary-x64.props" Condition="Exists('$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-x64\1.6.1\build\Microsoft.Net.Native.SharedLibrary-x64.props')" />
+    <Import Project="$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-arm\1.6.1\build\Microsoft.Net.Native.SharedLibrary-arm.props" Condition="Exists('$(NuGetPackageRoot)microsoft.net.native.sharedlibrary-arm\1.6.1\build\Microsoft.Net.Native.SharedLibrary-arm.props')" />
+    <Import Project="$(NuGetPackageRoot)microsoft.net.native.compiler\1.6.2\build\Microsoft.Net.Native.Compiler.props" Condition="Exists('$(NuGetPackageRoot)microsoft.net.native.compiler\1.6.2\build\Microsoft.Net.Native.Compiler.props')" />
+  </ImportGroup>
+</Project>

--- a/Source/Csla.Xaml.Uwp/Csla.Xaml.Uwp.nuget.targets
+++ b/Source/Csla.Xaml.Uwp/Csla.Xaml.Uwp.nuget.targets
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
-    <RestoreSuccess Condition=" '$(RestoreSuccess)' == '' ">True</RestoreSuccess>
+    <RestoreSuccess Condition=" '$(RestoreSuccess)' == '' ">False</RestoreSuccess>
     <RestoreTool Condition=" '$(RestoreTool)' == '' ">NuGet</RestoreTool>
-    <ProjectAssetsFile Condition=" '$(ProjectAssetsFile)' == '' ">E:\src\rdl\csla\Source\Csla.Xaml.Uwp\project.lock.json</ProjectAssetsFile>
+    <ProjectAssetsFile Condition=" '$(ProjectAssetsFile)' == '' ">C:\src\rdl\csla\Source\Csla.Xaml.Uwp\project.lock.json</ProjectAssetsFile>
     <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
     <NuGetPackageFolders Condition=" '$(NuGetPackageFolders)' == '' ">C:\Users\rocky\.nuget\packages\</NuGetPackageFolders>
     <NuGetProjectStyle Condition=" '$(NuGetProjectStyle)' == '' ">ProjectJson</NuGetProjectStyle>

--- a/Source/Csla.Xaml.Uwp/project.json
+++ b/Source/Csla.Xaml.Uwp/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0",
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.3.3",
     "NuSpec.ReferenceGenerator": "1.3.3"
   },
   "frameworks": {

--- a/Source/Csla.Xaml.Xamarin/Properties/AssemblyInfo.cs
+++ b/Source/Csla.Xaml.Xamarin/Properties/AssemblyInfo.cs
@@ -26,5 +26,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.6.601.0")]
-[assembly: AssemblyFileVersion("4.6.601.0")]
+[assembly: AssemblyVersion("4.6.602.0")]
+[assembly: AssemblyFileVersion("4.6.602.0")]

--- a/Source/csla.build.sln
+++ b/Source/csla.build.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.7
+VisualStudioVersion = 15.0.26430.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{207BA2D1-EB2E-45A0-9F82-4B7975EDD8C6}"
 	ProjectSection(SolutionItems) = preProject


### PR DESCRIPTION
#737  UWP now uses Microsoft serialization  code

* Add reference to System.Runtime.Serialization.Formatters
* Use compiler directive so UWP project no longer uses the CSLA
serialization attributes, etc.