### PR TITLE
#739 WcfProxy consistently uses DefaultBinding if enabled

### DIFF
--- a/Source/Csla.Shared/DataPortalClient/WcfProxy.cs
+++ b/Source/Csla.Shared/DataPortalClient/WcfProxy.cs
@@ -39,14 +39,28 @@ namespace Csla.DataPortalClient
       {
         if (_defaultBinding == null)
         {
-          _defaultBinding  = new BasicHttpBinding();
+#if !NETFX_CORE && !(IOS || ANDROID)
+          _defaultBinding = new WSHttpBinding();
+          WSHttpBinding binding = (WSHttpBinding)_defaultBinding;
+#else
+          _defaultBinding = new BasicHttpBinding();
           BasicHttpBinding binding = (BasicHttpBinding)_defaultBinding;
           binding.MaxBufferSize = int.MaxValue;
+#endif
           binding.MaxReceivedMessageSize = int.MaxValue;
+          binding.ReaderQuotas = new System.Xml.XmlDictionaryReaderQuotas()
+          {
+            MaxBytesPerRead = int.MaxValue,
+            MaxDepth = int.MaxValue,
+            MaxArrayLength = int.MaxValue,
+            MaxStringContentLength = int.MaxValue,
+            MaxNameTableCharCount = int.MaxValue
+          };
+
           binding.ReceiveTimeout = TimeSpan.FromMinutes(TimeoutInMinutes);
           binding.SendTimeout = TimeSpan.FromMinutes(TimeoutInMinutes);
           binding.OpenTimeout = TimeSpan.FromMinutes(TimeoutInMinutes);
-        }; 
+        } 
         return _defaultBinding; 
       }
       set { _defaultBinding = value; }
@@ -119,28 +133,17 @@ namespace Csla.DataPortalClient
     /// used by GetProxy() to create the WCF proxy
     /// object.
     /// </summary>
+    /// <remarks>
+    /// If DataPortalUrl is given, the factory will be created using it
+    /// and the default binding. Otherwise, it will use the endpoint
+    /// config from app/web.config.
+    /// </remarks>
     protected virtual ChannelFactory<IWcfPortal> GetChannelFactory()
     {
-      // if dataportal url is specified use this with default wsHttBinding
       if (!string.IsNullOrEmpty(ApplicationContext.DataPortalUrlString))
-      {
-        var binding = new WSHttpBinding()
-        { 
-          MaxReceivedMessageSize = int.MaxValue, 
-          ReaderQuotas = new System.Xml.XmlDictionaryReaderQuotas() 
-          {
-            MaxBytesPerRead = int.MaxValue,
-            MaxDepth = int.MaxValue,
-            MaxArrayLength = int.MaxValue,
-            MaxStringContentLength = int.MaxValue,
-            MaxNameTableCharCount = int.MaxValue
-          }
-        };
-        return new ChannelFactory<IWcfPortal>(binding, new EndpointAddress(ApplicationContext.DataPortalUrl));
-      }
-
-      // else return a channelfactory that uses the endpoint configuration in app.config/web.config
-      return new ChannelFactory<IWcfPortal>(EndPoint);
+        return new ChannelFactory<IWcfPortal>(Binding, new EndpointAddress(ApplicationContext.DataPortalUrl));
+      else
+        return new ChannelFactory<IWcfPortal>(EndPoint);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #739 

Moves the WSHttpBinding instantiation into the static DefaultBinding and uses it if a data portal is specified, mirroring the Android/iOS/RT behavior. Default binding for those frameworks is still BasicHttpBinding.