### PR TITLE
Add ReadOnlyBase support to CSLA0007 and CSLA0008 analyzers

### DIFF
--- a/Source/Csla.Analyzers/Csla.Analyzers.Tests/Extensions/IMethodSymbolExtensionsTests.cs
+++ b/Source/Csla.Analyzers/Csla.Analyzers.Tests/Extensions/IMethodSymbolExtensionsTests.cs
@@ -125,6 +125,16 @@ namespace Csla.Analyzers.Tests.Extensions
     }
 
     [TestMethod]
+    public async Task IsPropertyInfoManagementMethodForLoadPropertyMarkDirty()
+    {
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LoadPropertyMarkDirty, typeof(BusinessBase<>))).IsPropertyInfoManagementMethod());
+
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LoadPropertyMarkDirty, typeof(ManagedObjectBase))).IsPropertyInfoManagementMethod());
+    }
+
+    [TestMethod]
     public async Task IsPropertyInfoManagementMethodForReadProperty()
     {
       Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(

--- a/Source/Csla.Analyzers/Csla.Analyzers.Tests/Extensions/IMethodSymbolExtensionsTests.cs
+++ b/Source/Csla.Analyzers/Csla.Analyzers.Tests/Extensions/IMethodSymbolExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis;
+using Csla.Core;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -36,98 +37,143 @@ namespace Csla.Analyzers.Tests.Extensions
     public async Task IsPropertyInfoManagementMethodForMethodThatIsNotAPropertyInfoManagementMethod()
     {
       Assert.IsFalse((await this.GetMethodReferenceSymbolAsync(
-        this._propertyInfoManagementPath, "Something")).IsPropertyInfoManagementMethod());
-    }
-
-    [TestMethod]
-    public async Task IsPropertyInfoManagementMethodForGetProperty()
-    {
-      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
-        this._propertyInfoManagementPath, CslaMemberConstants.Properties.GetProperty)).IsPropertyInfoManagementMethod());
-    }
-
-    [TestMethod]
-    public async Task IsPropertyInfoManagementMethodForGetPropertyConvert()
-    {
-      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
-        this._propertyInfoManagementPath, CslaMemberConstants.Properties.GetPropertyConvert)).IsPropertyInfoManagementMethod());
-    }
-
-    [TestMethod]
-    public async Task IsPropertyInfoManagementMethodForLazyGetProperty()
-    {
-      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
-        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LazyGetProperty)).IsPropertyInfoManagementMethod());
-    }
-
-    [TestMethod]
-    public async Task IsPropertyInfoManagementMethodForLazyGetPropertyAsync()
-    {
-      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
-        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LazyGetPropertyAsync)).IsPropertyInfoManagementMethod());
-    }
-
-    [TestMethod]
-    public async Task IsPropertyInfoManagementMethodForLazyReadProperty()
-    {
-      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
-        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LazyReadProperty)).IsPropertyInfoManagementMethod());
-    }
-
-    [TestMethod]
-    public async Task IsPropertyInfoManagementMethodForLazyReadPropertyAsync()
-    {
-      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
-        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LazyReadPropertyAsync)).IsPropertyInfoManagementMethod());
-    }
-
-    [TestMethod]
-    public async Task IsPropertyInfoManagementMethodForLoadProperty()
-    {
-      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
-        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LoadProperty)).IsPropertyInfoManagementMethod());
-    }
-
-    [TestMethod]
-    public async Task IsPropertyInfoManagementMethodForLoadPropertyAsync()
-    {
-      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
-        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LoadPropertyAsync)).IsPropertyInfoManagementMethod());
-    }
-
-    [TestMethod]
-    public async Task IsPropertyInfoManagementMethodForLoadPropertyConvert()
-    {
-      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
-        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LoadPropertyConvert)).IsPropertyInfoManagementMethod());
-    }
-
-    [TestMethod]
-    public async Task IsPropertyInfoManagementMethodForReadProperty()
-    {
-      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
-        this._propertyInfoManagementPath, CslaMemberConstants.Properties.ReadProperty)).IsPropertyInfoManagementMethod());
-    }
-
-    [TestMethod]
-    public async Task IsPropertyInfoManagementMethodForReadPropertyConvert()
-    {
-      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
-        this._propertyInfoManagementPath, CslaMemberConstants.Properties.ReadPropertyConvert)).IsPropertyInfoManagementMethod());
+        this._propertyInfoManagementPath, "Something", typeof(BusinessBase<>))).IsPropertyInfoManagementMethod());
     }
 
     [TestMethod]
     public async Task IsPropertyInfoManagementMethodForSetProperty()
     {
       Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
-        this._propertyInfoManagementPath, CslaMemberConstants.Properties.SetProperty)).IsPropertyInfoManagementMethod());
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.SetProperty, typeof(BusinessBase<>))).IsPropertyInfoManagementMethod());
     }
 
     [TestMethod]
     public async Task IsPropertyInfoManagementMethodForSetPropertyConvert()
     {
       Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
-        this._propertyInfoManagementPath, CslaMemberConstants.Properties.SetPropertyConvert)).IsPropertyInfoManagementMethod());
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.SetPropertyConvert, typeof(BusinessBase<>))).IsPropertyInfoManagementMethod());
+    }
+
+    [TestMethod]
+    public async Task IsPropertyInfoManagementMethodForGetProperty()
+    {
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.GetProperty, typeof(BusinessBase<>))).IsPropertyInfoManagementMethod());
+
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.GetProperty, typeof(ReadOnlyBase<>))).IsPropertyInfoManagementMethod());
+    }
+
+    [TestMethod]
+    public async Task IsPropertyInfoManagementMethodForGetPropertyConvert()
+    {
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.GetPropertyConvert, typeof(BusinessBase<>))).IsPropertyInfoManagementMethod());
+
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.GetPropertyConvert, typeof(ReadOnlyBase<>))).IsPropertyInfoManagementMethod());
+    }
+
+    [TestMethod]
+    public async Task IsPropertyInfoManagementMethodForLazyGetProperty()
+    {
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LazyGetProperty, typeof(BusinessBase<>))).IsPropertyInfoManagementMethod());
+
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LazyGetProperty, typeof(ReadOnlyBase<>))).IsPropertyInfoManagementMethod());
+    }
+
+    [TestMethod]
+    public async Task IsPropertyInfoManagementMethodForLazyGetPropertyAsync()
+    {
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LazyGetPropertyAsync, typeof(BusinessBase<>))).IsPropertyInfoManagementMethod());
+
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LazyGetPropertyAsync, typeof(ReadOnlyBase<>))).IsPropertyInfoManagementMethod());
+    }
+
+    [TestMethod]
+    public async Task IsPropertyInfoManagementMethodForLazyReadProperty()
+    {
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LazyReadProperty, typeof(BusinessBase<>))).IsPropertyInfoManagementMethod());
+
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LazyReadProperty, typeof(ReadOnlyBase<>))).IsPropertyInfoManagementMethod());
+    }
+
+    [TestMethod]
+    public async Task IsPropertyInfoManagementMethodForLazyReadPropertyAsync()
+    {
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LazyReadPropertyAsync, typeof(BusinessBase<>))).IsPropertyInfoManagementMethod());
+
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LazyReadPropertyAsync, typeof(ReadOnlyBase<>))).IsPropertyInfoManagementMethod());
+    }
+
+    [TestMethod]
+    public async Task IsPropertyInfoManagementMethodForLoadPropertyAsync()
+    {
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LoadPropertyAsync, typeof(BusinessBase<>))).IsPropertyInfoManagementMethod());
+
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LoadPropertyAsync, typeof(ReadOnlyBase<>))).IsPropertyInfoManagementMethod());
+    }
+
+    [TestMethod]
+    public async Task IsPropertyInfoManagementMethodForReadProperty()
+    {
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.ReadProperty, typeof(BusinessBase<>))).IsPropertyInfoManagementMethod());
+
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.ReadProperty, typeof(ReadOnlyBase<>))).IsPropertyInfoManagementMethod());
+
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.ReadProperty, typeof(ManagedObjectBase))).IsPropertyInfoManagementMethod());
+    }
+
+    [TestMethod]
+    public async Task IsPropertyInfoManagementMethodForReadPropertyConvert()
+    {
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.ReadPropertyConvert, typeof(BusinessBase<>))).IsPropertyInfoManagementMethod());
+
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.ReadPropertyConvert, typeof(ReadOnlyBase<>))).IsPropertyInfoManagementMethod());
+
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.ReadPropertyConvert, typeof(ManagedObjectBase))).IsPropertyInfoManagementMethod());
+    }
+
+    [TestMethod]
+    public async Task IsPropertyInfoManagementMethodForLoadProperty()
+    {
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LoadProperty, typeof(BusinessBase<>))).IsPropertyInfoManagementMethod());
+
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LoadProperty, typeof(ReadOnlyBase<>))).IsPropertyInfoManagementMethod());
+
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LoadProperty, typeof(ManagedObjectBase))).IsPropertyInfoManagementMethod());
+    }
+
+    [TestMethod]
+    public async Task IsPropertyInfoManagementMethodForLoadPropertyConvert()
+    {
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LoadPropertyConvert, typeof(BusinessBase<>))).IsPropertyInfoManagementMethod());
+
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LoadPropertyConvert, typeof(ReadOnlyBase<>))).IsPropertyInfoManagementMethod());
+
+      Assert.IsTrue((await this.GetMethodReferenceSymbolAsync(
+        this._propertyInfoManagementPath, CslaMemberConstants.Properties.LoadPropertyConvert, typeof(ManagedObjectBase))).IsPropertyInfoManagementMethod());
     }
 
     [TestMethod]
@@ -456,10 +502,10 @@ namespace Csla.Analyzers.Tests.Extensions
       return null;
     }
 
-    private async Task<IMethodSymbol> GetMethodReferenceSymbolAsync(string file, string name)
+    private async Task<IMethodSymbol> GetMethodReferenceSymbolAsync(string file, string name, Type type)
     {
       var results = await IMethodSymbolExtensionsTests.ParseFileAsync(
-        file, MetadataReference.CreateFromFile(typeof(BusinessBase<>).Assembly.Location));
+        file, MetadataReference.CreateFromFile(type.Assembly.Location));
 
       foreach (var invocation in results.Item2.DescendantNodes().OfType<InvocationExpressionSyntax>())
       {

--- a/Source/Csla.Analyzers/Csla.Analyzers.Tests/Targets/IMethodSymbolExtensionsTests/IsPropertyInfoManagementMethod.cs
+++ b/Source/Csla.Analyzers/Csla.Analyzers.Tests/Targets/IMethodSymbolExtensionsTests/IsPropertyInfoManagementMethod.cs
@@ -12,6 +12,7 @@
       this.LoadProperty(null, null);
       this.LoadPropertyAsync<string>(null, null);
       this.LoadPropertyConvert<string, string>(null, null);
+      this.LoadPropertyMarkDirty(null, null);
       this.ReadProperty(null);
       this.ReadPropertyConvert<string, string>(null);
       this.LazyGetProperty<string>(null, null);

--- a/Source/Csla.Analyzers/Csla.Analyzers/CslaMemberConstants.cs
+++ b/Source/Csla.Analyzers/Csla.Analyzers/CslaMemberConstants.cs
@@ -46,6 +46,7 @@
       public const string IMobileObject = "IMobileObject";
       public const string IPropertyInfo = "IPropertyInfo";
       public const string ManagedObjectBase = "ManagedObjectBase";
+      public const string ReadOnlyBase = "ReadOnlyBase";
     }
 
     public const string AssemblyName = "Csla";

--- a/Source/Csla.Analyzers/Csla.Analyzers/Extensions/IMethodSymbolExtensions.cs
+++ b/Source/Csla.Analyzers/Csla.Analyzers/Extensions/IMethodSymbolExtensions.cs
@@ -8,16 +8,19 @@ namespace Csla.Analyzers.Extensions
     {
       return @this != null &&
         ((@this.ContainingType.Name == CslaMemberConstants.Types.BusinessBase &&
-          (@this.Name == CslaMemberConstants.Properties.GetProperty ||
-          @this.Name == CslaMemberConstants.Properties.GetPropertyConvert ||
-          @this.Name == CslaMemberConstants.Properties.LazyGetProperty ||
-          @this.Name == CslaMemberConstants.Properties.LazyGetPropertyAsync ||
-          @this.Name == CslaMemberConstants.Properties.LazyReadProperty ||
-          @this.Name == CslaMemberConstants.Properties.LazyReadPropertyAsync ||
-          @this.Name == CslaMemberConstants.Properties.LoadPropertyAsync ||
-          @this.Name == CslaMemberConstants.Properties.SetProperty ||
+          (@this.Name == CslaMemberConstants.Properties.SetProperty ||
           @this.Name == CslaMemberConstants.Properties.SetPropertyConvert)) ||
         ((@this.ContainingType.Name == CslaMemberConstants.Types.BusinessBase ||
+          @this.ContainingType.Name == CslaMemberConstants.Types.ReadOnlyBase) &&
+            (@this.Name == CslaMemberConstants.Properties.GetProperty ||
+            @this.Name == CslaMemberConstants.Properties.GetPropertyConvert ||
+            @this.Name == CslaMemberConstants.Properties.LazyGetProperty ||
+            @this.Name == CslaMemberConstants.Properties.LazyGetPropertyAsync ||
+            @this.Name == CslaMemberConstants.Properties.LazyReadProperty ||
+            @this.Name == CslaMemberConstants.Properties.LazyReadPropertyAsync ||
+            @this.Name == CslaMemberConstants.Properties.LoadPropertyAsync)) ||
+        ((@this.ContainingType.Name == CslaMemberConstants.Types.BusinessBase ||
+          @this.ContainingType.Name == CslaMemberConstants.Types.ReadOnlyBase ||
           @this.ContainingType.Name == CslaMemberConstants.Types.ManagedObjectBase) &&
             (@this.Name == CslaMemberConstants.Properties.ReadProperty ||
             @this.Name == CslaMemberConstants.Properties.ReadPropertyConvert ||

--- a/Source/Csla.Analyzers/Csla.Analyzers/Extensions/IMethodSymbolExtensions.cs
+++ b/Source/Csla.Analyzers/Csla.Analyzers/Extensions/IMethodSymbolExtensions.cs
@@ -20,6 +20,9 @@ namespace Csla.Analyzers.Extensions
             @this.Name == CslaMemberConstants.Properties.LazyReadPropertyAsync ||
             @this.Name == CslaMemberConstants.Properties.LoadPropertyAsync)) ||
         ((@this.ContainingType.Name == CslaMemberConstants.Types.BusinessBase ||
+          @this.ContainingType.Name == CslaMemberConstants.Types.ManagedObjectBase) &&
+            @this.Name == CslaMemberConstants.Properties.LoadPropertyMarkDirty) ||
+        ((@this.ContainingType.Name == CslaMemberConstants.Types.BusinessBase ||
           @this.ContainingType.Name == CslaMemberConstants.Types.ReadOnlyBase ||
           @this.ContainingType.Name == CslaMemberConstants.Types.ManagedObjectBase) &&
             (@this.Name == CslaMemberConstants.Properties.ReadProperty ||

--- a/Source/Csla.Analyzers/Csla.Analyzers/FindSetOrLoadInvocationsWalker.cs
+++ b/Source/Csla.Analyzers/Csla.Analyzers/FindSetOrLoadInvocationsWalker.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using Csla.Analyzers.Extensions;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -15,15 +16,9 @@ namespace Csla.Analyzers
 
     public override void VisitInvocationExpression(InvocationExpressionSyntax node)
     {
-      var invocationSymbol = this.Model.GetSymbolInfo(node).Symbol;
+      var invocationSymbol = this.Model.GetSymbolInfo(node).Symbol as IMethodSymbol;
 
-      if (invocationSymbol != null && invocationSymbol.ContainingType.Name == CslaMemberConstants.Types.BusinessBase &&
-        (invocationSymbol.Name == CslaMemberConstants.Properties.SetProperty ||
-        invocationSymbol.Name == CslaMemberConstants.Properties.SetPropertyConvert ||
-        invocationSymbol.Name == CslaMemberConstants.Properties.LoadProperty ||
-        invocationSymbol.Name == CslaMemberConstants.Properties.LoadPropertyAsync ||
-        invocationSymbol.Name == CslaMemberConstants.Properties.LoadPropertyConvert ||
-        invocationSymbol.Name == CslaMemberConstants.Properties.LoadPropertyMarkDirty))
+      if (invocationSymbol.IsPropertyInfoManagementMethod())
       {
         this.Invocation = node;
       }


### PR DESCRIPTION
This addresses [#856](https://github.com/MarimerLLC/csla/issues/856) by adding ReadOnlyBase support to the analyzers for CSLA0007 (Evaluate Properties for Simplicity) and CSLA0008 (Evaluate Managed Backing Fields).