### PR TITLE
#923: DataAnnotation(..) conditional compile symbols removed

### DIFF
--- a/Source/Csla.Validation.Shared/CommonRules.cs
+++ b/Source/Csla.Validation.Shared/CommonRules.cs
@@ -1430,31 +1430,21 @@ namespace Csla.Validation
     public static bool DataAnnotation(object target, RuleArgs e)
     {
       var args = (DataAnnotationRuleArgs)e;
-      object pValue = Utilities.CallByName(
-        target, e.PropertyName, CallType.Get);
-#if (ANDROID || IOS) || NETFX_PHONE
-      var ctx = new System.ComponentModel.DataAnnotations.ValidationContext(target, null, null);
+      object pValue = Utilities.CallByName(target, e.PropertyName, CallType.Get);
+
+      var ctx = new System.ComponentModel.DataAnnotations.ValidationContext(target, null, null)
+      {
+        MemberName = RuleArgs.GetPropertyName(e)
+      };
+
       var result = args.Attribute.GetValidationResult(pValue, ctx);
+
       if (result != null)
       {
         e.Description = result.ErrorMessage;
         return false;
       }
-#elif NETFX_CORE
-      var ctx = new System.ComponentModel.DataAnnotations.ValidationContext(target, null);
-      var result = args.Attribute.GetValidationResult(pValue, ctx);
-      if (result != null)
-      {
-        e.Description = result.ErrorMessage;
-        return false;
-      }
-#else
-      if (!args.Attribute.IsValid(pValue))
-      {
-        e.Description = args.Attribute.FormatErrorMessage(RuleArgs.GetPropertyName(e));
-        return false;
-      }
-#endif
+
       return true;
     }
 


### PR DESCRIPTION
CommonRules.DataAnnotation(..) method's [ValidationContext] is only initialized and used when [ANDROID] [IOS] [NETFX_PHONE] or [NETFX_CORE] are defined. I think there is no need to run different code for each case.

[GetValidationResult], [IsValid(object)] and [IsValid(object, ValidationContext)] are programmed so as to handle backward compatibility.