### PR TITLE
#1004 Centralize connection strings in tests

### DIFF
--- a/Source/Csla.Data.EF4.Test/Csla.Data.EF4.Test.csproj
+++ b/Source/Csla.Data.EF4.Test/Csla.Data.EF4.Test.csproj
@@ -70,6 +70,11 @@
     <Compile Include="TestContext.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\config\testConnectionStrings.config">
+      <Link>testConnectionStrings.config</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <SubType>Designer</SubType>
+    </None>
     <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="Properties\Settings.settings">

--- a/Source/Csla.Data.EF4.Test/DbContextTests.cs
+++ b/Source/Csla.Data.EF4.Test/DbContextTests.cs
@@ -3,6 +3,7 @@ using System.Configuration;
 using System.Data;
 using System.Data.Entity.Infrastructure;
 using System.Linq;
+using Csla.Test;
 using Csla.Test.Data;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -10,13 +11,7 @@ namespace Csla.Data.EF4.Test
 {
     [TestClass]
     public class DbContextTests
-    {
-        private const string TestDBConnection = "Csla.Test.Properties.Settings.DataPortalTestDatabaseConnectionString";
-        private const string InvalidTestDBConnection = "Csla.Test.Properties.Settings.DataPortalTestDatabaseConnectionStringXXXXXXX";
-
-        private const string ConnectionWithMissingDB = "DataPortalTestDatabaseConnectionString_with_invalid_DB_value";
-        private const string EntityConnectionWithMissingDB = "DataPortalTestDatabaseEntities_with_invalid_DB_value";
-
+    {   
         [ClassInitialize]
         public static void InitDbContextDatabase(TestContext context)
         {
@@ -42,7 +37,7 @@ namespace Csla.Data.EF4.Test
         
         public void ConnectionSetting_with_Invalid_DB_Throws_ConfigurationErrorsException_for_DbContextDataContext()
         {
-            var conn = ConfigurationManager.ConnectionStrings[EntityConnectionWithMissingDB].ConnectionString;
+            var conn = WellKnownValues.EntityConnectionWithMissingDB;
             using (var context = new DataPortalTestDatabaseEntities(conn))
             {
                 using (

--- a/Source/Csla.Data.EF4.Test/app.config
+++ b/Source/Csla.Data.EF4.Test/app.config
@@ -3,17 +3,13 @@
   <configSections>
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
   </configSections>
-  <connectionStrings>
-    <add name="Csla.Test.Properties.Settings.DataPortalTestDatabaseConnectionString" connectionString="Data Source=(LocalDB)\v11.0;AttachDbFilename=|DataDirectory|DataPortalTestDatabase.mdf;Integrated Security=True" providerName="System.Data.SqlClient"/>
-    <add name="DataPortalTestDatabaseEntities" connectionString="metadata=res://*/Data.TestEFContext.csdl|res://*/Data.TestEFContext.ssdl|res://*/Data.TestEFContext.msl;provider=System.Data.SqlClient;provider connection string=&quot;Data Source=(LocalDB)\v11.0;AttachDbFilename=|DataDirectory|\DataPortalTestDatabase.mdf;Integrated Security=True;MultipleActiveResultSets=True&quot;" providerName="System.Data.EntityClient"/>
-    <add name="DataPortalTestDatabaseConnectionString_with_invalid_DB_value" connectionString="Data Source=(LocalDB)\v11.0;AttachDbFilename=|DataDirectory|NoSuchDB.mdf;Integrated Security=True" providerName="System.Data.SqlClient"/>
-    <add name="DataPortalTestDatabaseEntities_with_invalid_DB_value" connectionString="metadata=res://*/Data.TestEFContext.csdl|res://*/Data.TestEFContext.ssdl|res://*/Data.TestEFContext.msl;provider=System.Data.SqlClient;provider connection string=&quot;Data Source=(LocalDB)\v11.0;AttachDbFilename=|DataDirectory|\NoSuchDB.mdf;Integrated Security=True;MultipleActiveResultSets=True&quot;" providerName="System.Data.EntityClient"/>
-    <!--<add name="DataPortalDbContext" connectionString="Data Source=(LocalDB)\v11.0;AttachDbFilename=|DataDirectory|\DataPortalTestDatabase.mdf;Integrated Security=True;User Instance=True;MultipleActiveResultSets=True" providerName="System.Data.EntityClient"/>-->
-  </connectionStrings>
+  
+  <connectionStrings configSource="testConnectionStrings.config"/>
+  
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework">
       <parameters>
-        <parameter value="Data Source=(LocalDB)\v11.0; Integrated Security=True; MultipleActiveResultSets=True"/>
+        <parameter value="Data Source=(LocalDB)\MSSQLLocalDB; Integrated Security=True; MultipleActiveResultSets=True"/>
       </parameters>
     </defaultConnectionFactory>
   </entityFramework>

--- a/Source/Csla.Data.EF5.Test/Csla.Data.EF5.Test.csproj
+++ b/Source/Csla.Data.EF5.Test/Csla.Data.EF5.Test.csproj
@@ -80,6 +80,10 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\config\testConnectionStrings.config">
+      <Link>testConnectionStrings.config</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>

--- a/Source/Csla.Data.EF5.Test/DbContextTests.cs
+++ b/Source/Csla.Data.EF5.Test/DbContextTests.cs
@@ -3,6 +3,7 @@ using System.Configuration;
 using System.Data;
 using System.Data.Entity.Infrastructure;
 using System.Linq;
+using Csla.Test;
 using Csla.Test.Data;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -11,7 +12,7 @@ namespace Csla.Data.EF5.Test
     [TestClass]
     public class DbContextTests
     {
-        private const string TestDBConnection = "Csla.Test.Properties.Settings.DataPortalTestDatabaseConnectionString";
+        private const string TestDBConnection = nameof(WellKnownValues.DataPortalTestDatabase);
         private const string InvalidTestDBConnection = "Csla.Test.Properties.Settings.DataPortalTestDatabaseConnectionStringXXXXXXX";
 
         private const string ConnectionWithMissingDB = "DataPortalTestDatabaseConnectionString_with_invalid_DB_value";
@@ -42,7 +43,7 @@ namespace Csla.Data.EF5.Test
         
         public void ConnectionSetting_with_Invalid_DB_Throws_ConfigurationErrorsException_for_DbContextDataContext()
         {
-            var conn = ConfigurationManager.ConnectionStrings[EntityConnectionWithMissingDB].ConnectionString;
+            var conn = WellKnownValues.EntityConnectionWithMissingDB;
             using (var context = new DataPortalTestDatabaseEntities(conn))
             {
                 using (

--- a/Source/Csla.Data.EF5.Test/app.config
+++ b/Source/Csla.Data.EF5.Test/app.config
@@ -3,17 +3,11 @@
   <configSections>
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
   </configSections>
-  <connectionStrings>
-    <add name="Csla.Test.Properties.Settings.DataPortalTestDatabaseConnectionString" connectionString="Data Source=(LocalDB)\v11.0;AttachDbFilename=|DataDirectory|DataPortalTestDatabase.mdf;Integrated Security=True" providerName="System.Data.SqlClient"/>
-    <add name="DataPortalTestDatabaseEntities" connectionString="metadata=res://*/Data.TestEFContext.csdl|res://*/Data.TestEFContext.ssdl|res://*/Data.TestEFContext.msl;provider=System.Data.SqlClient;provider connection string=&quot;Data Source=(LocalDB)\v11.0;AttachDbFilename=|DataDirectory|\DataPortalTestDatabase.mdf;Integrated Security=True;MultipleActiveResultSets=True&quot;" providerName="System.Data.EntityClient"/>
-    <add name="DataPortalTestDatabaseConnectionString_with_invalid_DB_value" connectionString="Data Source=(LocalDB)\v11.0;AttachDbFilename=|DataDirectory|NoSuchDB.mdf;Integrated Security=True" providerName="System.Data.SqlClient"/>
-    <add name="DataPortalTestDatabaseEntities_with_invalid_DB_value" connectionString="metadata=res://*/Data.TestEFContext.csdl|res://*/Data.TestEFContext.ssdl|res://*/Data.TestEFContext.msl;provider=System.Data.SqlClient;provider connection string=&quot;Data Source=(LocalDB)\v11.0;AttachDbFilename=|DataDirectory|\NoSuchDB.mdf;Integrated Security=True;MultipleActiveResultSets=True&quot;" providerName="System.Data.EntityClient"/>
-    <!--<add name="DataPortalDbContext" connectionString="Data Source=(LocalDB)\v11.0;AttachDbFilename=|DataDirectory|\DataPortalTestDatabase.mdf;Integrated Security=True;User Instance=True;MultipleActiveResultSets=True" providerName="System.Data.EntityClient"/>-->
-  </connectionStrings>
+  <connectionStrings configSource="testConnectionStrings.config"/>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework">
       <parameters>
-        <parameter value="Data Source=(LocalDB)\v11.0; Integrated Security=True; MultipleActiveResultSets=True"/>
+        <parameter value="Data Source=(LocalDB)\MSSQLLocalDB; Integrated Security=True; MultipleActiveResultSets=True"/>
       </parameters>
     </defaultConnectionFactory>
   </entityFramework>

--- a/Source/Csla.test/Data/ContextTests.cs
+++ b/Source/Csla.test/Data/ContextTests.cs
@@ -29,11 +29,11 @@ namespace Csla.Test.Data
   [TestClass]
   public class ContextTests
   {
-    private const string TestDBConnection = "Csla.Test.Properties.Settings.DataPortalTestDatabaseConnectionString";
-    private const string InvalidTestDBConnection = "Csla.Test.Properties.Settings.DataPortalTestDatabaseConnectionStringXXXXXXX";
+    private const string TestDBConnection = nameof(WellKnownValues.DataPortalTestDatabase);
+    private const string InvalidTestDBConnection = "DataPortalTestDatabaseConnectionStringXXXXXXX";
 
-    private const string ConnectionWithMissingDB = "DataPortalTestDatabaseConnectionString_with_invalid_DB_value";
-    private const string EntityConnectionWithMissingDB = "DataPortalTestDatabaseEntities_with_invalid_DB_value";
+    private const string ConnectionWithMissingDB = nameof(WellKnownValues.DataPortalTestDatabaseWithInvalidDBValue);
+    
 
     #region Invalid connection strings
     [TestMethod]
@@ -96,7 +96,7 @@ namespace Csla.Test.Data
     [TestCategory("SkipWhenLiveUnitTesting")]
     public void ConnectionSetting_with_Invalid_DB_Throws_ConfigurationErrorsException_for_EntitiesContextDataContext()
     {
-      using (var objectContextManager = ObjectContextManager<DataPortalTestDatabaseEntities>.GetManager(EntityConnectionWithMissingDB, true))
+      using (var objectContextManager = ObjectContextManager<DataPortalTestDatabaseEntities>.GetManager(WellKnownValues.EntityConnectionWithMissingDBConnectionStringName, true))
       {
         Assert.IsNotNull(objectContextManager);
         //Throws EntityException
@@ -145,7 +145,7 @@ namespace Csla.Test.Data
     [TestCategory("SkipWhenLiveUnitTesting")]
     public void Table2_retreived_through_LingToEntitiesDataContext_has_records()
     {
-      using (var objectContextManager = ObjectContextManager<DataPortalTestDatabaseEntities>.GetManager("DataPortalTestDatabaseEntities", true))
+      using (var objectContextManager = ObjectContextManager<DataPortalTestDatabaseEntities>.GetManager(nameof(WellKnownValues.DataPortalTestDatabaseEntities), true))
       {
         Assert.IsNotNull(objectContextManager);
 

--- a/Source/Csla.test/Data/TransactionContextUser.cs
+++ b/Source/Csla.test/Data/TransactionContextUser.cs
@@ -65,7 +65,7 @@ namespace Csla.Test.Data
 
     protected void Child_DeleteSelf()
     {
-      using (TransactionManager<SqlConnection, SqlTransaction> manager = TransactionManager<SqlConnection, SqlTransaction>.GetManager("Csla.Test.Properties.Settings.DataPortalTestDatabaseConnectionString", true))
+      using (TransactionManager<SqlConnection, SqlTransaction> manager = TransactionManager<SqlConnection, SqlTransaction>.GetManager(nameof(WellKnownValues.DataPortalTestDatabase), true))
       {
         using (SqlCommand command = new SqlCommand("Delete From Table2 Where FirstName = '" + ReadProperty(firstNameProperty) + "' And LastName = '" + ReadProperty(lastNameProperty) + "' And SmallColumn = '" + ReadProperty(smallColumnProperty) + "'", manager.Transaction.Connection, manager.Transaction))
         {
@@ -76,7 +76,7 @@ namespace Csla.Test.Data
 
     protected void Child_Insert()
     {
-      using (TransactionManager<SqlConnection, SqlTransaction> manager = TransactionManager<SqlConnection, SqlTransaction>.GetManager("Csla.Test.Properties.Settings.DataPortalTestDatabaseConnectionString", true))
+      using (TransactionManager<SqlConnection, SqlTransaction> manager = TransactionManager<SqlConnection, SqlTransaction>.GetManager(nameof(WellKnownValues.DataPortalTestDatabase), true))
       {
         using (SqlCommand command = new SqlCommand("INSERT INTO Table2(FirstName, LastName, SmallColumn) VALUES('" + ReadProperty(firstNameProperty) + "', '" + ReadProperty(lastNameProperty) + "', '" + ReadProperty(smallColumnProperty) + "')", manager.Transaction.Connection, manager.Transaction))
         {

--- a/Source/Csla.test/Data/TransactionContextUserList.cs
+++ b/Source/Csla.test/Data/TransactionContextUserList.cs
@@ -14,7 +14,7 @@ namespace Csla.Test.Data
   [Serializable]
   public class TransactionContextUserList : BusinessBindingListBase<TransactionContextUserList, TransactionContextUser>
   {
-    public const string TestDBConnection = "Csla.Test.Properties.Settings.DataPortalTestDatabaseConnectionString";
+    public const string TestDBConnection = nameof(WellKnownValues.DataPortalTestDatabase);
 
     protected override object AddNewCore()
     {

--- a/Source/Csla.test/DataPortal/DataPortalTests.cs
+++ b/Source/Csla.test/DataPortal/DataPortalTests.cs
@@ -27,11 +27,8 @@ namespace Csla.Test.DataPortal
 {
     [TestClass()]
     public class DataPortalTests
-    {
-        //pull from ConfigurationManager
-        private const string CONNECTION_STRING =
-            "Data Source=.\\SQLEXPRESS;AttachDbFilename=|DataDirectory|DataPortalTestDatabase.mdf;Integrated Security=True;User Instance=True";
-
+    {   
+        private static string CONNECTION_STRING = WellKnownValues.DataPortalTestDatabase;
         public void ClearDataBase()
         {
             SqlConnection cn = new SqlConnection(CONNECTION_STRING);

--- a/Source/Csla.test/DataPortal/ESTransactionalRoot.cs
+++ b/Source/Csla.test/DataPortal/ESTransactionalRoot.cs
@@ -20,7 +20,7 @@ namespace Csla.Test.DataPortal
     #region "Business methods"
 
     //get the configurationmanager to work right
-    public static string CONNECTION_STRING = ConfigurationManager.ConnectionStrings["Csla.Test.Properties.Settings.DataPortalTestDatabaseConnectionString"].ConnectionString;
+    public static string CONNECTION_STRING = WellKnownValues.DataPortalTestDatabase;
 
     public static PropertyInfo<int> IDProperty = RegisterProperty<int>(c => c.ID);
     public int ID

--- a/Source/Csla.test/DataPortal/TransactionalRoot.cs
+++ b/Source/Csla.test/DataPortal/TransactionalRoot.cs
@@ -20,7 +20,7 @@ namespace Csla.Test.DataPortal
         #region "Business methods"
 
         //get the configurationmanager to work right
-        public static string CONNECTION_STRING = ConfigurationManager.ConnectionStrings["Csla.Test.Properties.Settings.DataPortalTestDatabaseConnectionString"].ConnectionString;
+        //public static string CONNECTION_STRING = WellKnownValues.ConnectionStrings.DataPortalTestDatabase;
 
         public static PropertyInfo<int> IDProperty = RegisterProperty<int>(c => c.ID);
         public int ID
@@ -131,7 +131,7 @@ namespace Csla.Test.DataPortal
         [Transactional(TransactionalTypes.TransactionScope)]
         protected override void DataPortal_Insert()
         {
-            SqlConnection cn = new SqlConnection(CONNECTION_STRING);
+            SqlConnection cn = new SqlConnection(WellKnownValues.DataPortalTestDatabase);
             string firstName = this.FirstName;
             string lastName = this.LastName;
             string smallColumn = this.SmallColumn;

--- a/Source/Csla.test/Properties/Settings.Designer.cs
+++ b/Source/Csla.test/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Csla.Test.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.5.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -31,17 +31,6 @@ namespace Csla.Test.Properties {
         public string DataPortalTestDatabaseConnectionString {
             get {
                 return ((string)(this["DataPortalTestDatabaseConnectionString"]));
-            }
-        }
-        
-        [global::System.Configuration.ApplicationScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.SpecialSettingAttribute(global::System.Configuration.SpecialSetting.ConnectionString)]
-        [global::System.Configuration.DefaultSettingValueAttribute("Data Source=.\\SQLEXPRESS;AttachDbFilename=|DataDirectory|\\DataPortalTestDatabase." +
-            "mdf;Integrated Security=True;User Instance=True")]
-        public string DataPortalTestDatabaseConnectionString1 {
-            get {
-                return ((string)(this["DataPortalTestDatabaseConnectionString1"]));
             }
         }
     }

--- a/Source/Csla.test/Properties/Settings.settings
+++ b/Source/Csla.test/Properties/Settings.settings
@@ -10,13 +10,5 @@
 &lt;/SerializableConnectionString&gt;</DesignTimeValue>
       <Value Profile="(Default)">Data Source=.\SQLEXPRESS;AttachDbFilename=|DataDirectory|DataPortalTestDatabase.mdf;Integrated Security=True;User Instance=True</Value>
     </Setting>
-    <Setting Name="DataPortalTestDatabaseConnectionString1" Type="(Connection string)" Scope="Application">
-      <DesignTimeValue Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
-&lt;SerializableConnectionString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;
-  &lt;ConnectionString&gt;Data Source=.\SQLEXPRESS;AttachDbFilename=|DataDirectory|\DataPortalTestDatabase.mdf;Integrated Security=True;User Instance=True&lt;/ConnectionString&gt;
-  &lt;ProviderName&gt;System.Data.SqlClient&lt;/ProviderName&gt;
-&lt;/SerializableConnectionString&gt;</DesignTimeValue>
-      <Value Profile="(Default)">Data Source=.\SQLEXPRESS;AttachDbFilename=|DataDirectory|\DataPortalTestDatabase.mdf;Integrated Security=True;User Instance=True</Value>
-    </Setting>
   </Settings>
 </SettingsFile>

--- a/Source/Csla.test/SafeDataReader/SafeDataReaderTests.cs
+++ b/Source/Csla.test/SafeDataReader/SafeDataReaderTests.cs
@@ -40,8 +40,8 @@ namespace Csla.Test.SafeDataReader
         Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
       }
 
-        //pull from ConfigurationManager
-      private static string CONNECTION_STRING = ConfigurationManager.ConnectionStrings["Csla.Test.Properties.Settings.DataPortalTestDatabaseConnectionString"].ConnectionString;
+    private static string CONNECTION_STRING = WellKnownValues.DataPortalTestDatabase;
+
 
         public void ClearDataBase()
         {

--- a/Source/Csla.test/WellKnownValues.cs
+++ b/Source/Csla.test/WellKnownValues.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Csla.Test
+{
+  public class WellKnownValues
+  {
+    private static System.Configuration.Configuration AppConfig = ConfigurationManager.OpenExeConfiguration(Assembly.GetExecutingAssembly().Location);
+
+    static WellKnownValues()
+    {
+      ConnectionStringSettingsCollection conStrings = AppConfig.ConnectionStrings.ConnectionStrings;
+      DataPortalTestDatabase = conStrings["DataPortalTestDatabase"].ConnectionString;
+      DataPortalTestDatabaseWithInvalidDBValue = conStrings["DataPortalTestDatabaseWithInvalidDBValue"].ConnectionString;
+      DataPortalTestDatabaseEntities = conStrings["DataPortalTestDatabaseEntities"].ConnectionString;
+      EntityConnectionWithMissingDB = conStrings["DataPortalTestDatabaseEntitiesWithInvalidDBValue"].ConnectionString;
+    }
+
+    public static string EntityConnectionWithMissingDBConnectionStringName = "DataPortalTestDatabaseEntitiesWithInvalidDBValue";
+    public static string EntityConnectionWithMissingDB {get;} 
+    public static string DataPortalTestDatabaseEntities { get; } 
+    public static string DataPortalTestDatabaseWithInvalidDBValue { get; } 
+
+    public static string DataPortalTestDatabase { get; }
+    public static string TestLinqToSqlContextDataContext { get; }
+  }
+}

--- a/Source/Csla.test/app.config
+++ b/Source/Csla.test/app.config
@@ -3,12 +3,7 @@
   <configSections>
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
   </configSections>
-  <connectionStrings>
-    <add name="Csla.Test.Properties.Settings.DataPortalTestDatabaseConnectionString" connectionString="Data Source=(LocalDB)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|DataPortalTestDatabase.mdf;Integrated Security=True;Connect Timeout=30" providerName="System.Data.SqlClient"/>
-    <add name="DataPortalTestDatabaseEntities" connectionString="metadata=res://*/Data.TestEFContext.csdl|res://*/Data.TestEFContext.ssdl|res://*/Data.TestEFContext.msl;provider=System.Data.SqlClient;provider connection string=&quot;Data Source=(LocalDB)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|DataPortalTestDatabase.mdf;Integrated Security=True;Connect Timeout=30;MultipleActiveResultSets=True&quot;" providerName="System.Data.EntityClient"/>
-    <add name="DataPortalTestDatabaseConnectionString_with_invalid_DB_value" connectionString="Data Source=(LocalDB)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|NoSuchDB.mdf;Integrated Security=True" providerName="System.Data.SqlClient"/>
-    <add name="DataPortalTestDatabaseEntities_with_invalid_DB_value" connectionString="metadata=res://*/Data.TestEFContext.csdl|res://*/Data.TestEFContext.ssdl|res://*/Data.TestEFContext.msl;provider=System.Data.SqlClient;provider connection string=&quot;Data Source=(LocalDB)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\NoSuchDB.mdf;Integrated Security=True;MultipleActiveResultSets=True&quot;" providerName="System.Data.EntityClient"/>
-  </connectionStrings>
+  <connectionStrings configSource="testConnectionStrings.config"/>
   <appSettings>
     <add key="CslaAuthorizationProvider" value="Csla.Testing.Business.DataPortal.AuthorizeDataPortalStub, Csla.Testing.Business"/>
     <add key="ClientSettingsProvider.ServiceUri" value=""/>

--- a/Source/Csla.test/csla.test.csproj
+++ b/Source/Csla.test/csla.test.csproj
@@ -352,6 +352,7 @@
     <Compile Include="ValidationRules\ValidationTests.cs" />
     <Compile Include="ViewModelTests\TestViewModel.cs" />
     <Compile Include="ViewModelTests\ViewModelTests.cs" />
+    <Compile Include="WellKnownValues.cs" />
     <Compile Include="Windows\ActionExtenderTests.cs" />
     <Compile Include="Windows\BindingRefreshTests.cs" />
     <Compile Include="Windows\EditablePerson.cs" />
@@ -364,6 +365,11 @@
     <Compile Include="Windows\ReadWriteAuthorizationTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\config\testConnectionStrings.config">
+      <Link>testConnectionStrings.config</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <SubType>Designer</SubType>
+    </None>
     <None Include="app.config" />
     <None Include="DataPortalTestDatabaseDataSet.xsc">
       <DependentUpon>DataPortalTestDatabaseDataSet.xsd</DependentUpon>

--- a/Source/config/testConnectionStrings.config
+++ b/Source/config/testConnectionStrings.config
@@ -1,0 +1,12 @@
+<connectionStrings>
+  <clear/>
+  <add name="DataPortalTestDatabase" connectionString="Data Source=(LocalDB)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\DataPortalTestDatabase.mdf;Integrated Security=True;"
+    providerName="System.Data.SqlClient" />
+  <add name="DataPortalTestDatabaseEntities" connectionString="metadata=res://*/Data.TestEFContext.csdl|res://*/Data.TestEFContext.ssdl|res://*/Data.TestEFContext.msl;provider=System.Data.SqlClient;provider connection string=&quot;Data Source=(LocalDB)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\DataPortalTestDatabase.mdf;Integrated Security=True;Connect Timeout=30;MultipleActiveResultSets=True&quot;"
+    providerName="System.Data.EntityClient" />
+  <add name="DataPortalTestDatabaseWithInvalidDBValue" connectionString="Data Source=(LocalDB)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\NoSuchDB.mdf;Integrated Security=True"
+    providerName="System.Data.SqlClient" />
+  <add name="DataPortalTestDatabaseEntitiesWithInvalidDBValue"
+    connectionString="metadata=res://*/Data.TestEFContext.csdl|res://*/Data.TestEFContext.ssdl|res://*/Data.TestEFContext.msl;provider=System.Data.SqlClient;provider connection string=&quot;Data Source=(LocalDB)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\NoSuchDB.mdf;Integrated Security=True;MultipleActiveResultSets=True&quot;"
+    providerName="System.Data.EntityClient" /> 
+</connectionStrings>  


### PR DESCRIPTION
Extract connection strings into separate 'testConnectionStrings.config' file
Use testConfigurationStrings across the app.config files in tests.
Extract connection string names into WellKnownValues and update tests to use it
Update DataSource to (LocalDB)\MSSQLLocalDB