### PR TITLE
Fixes #1080

### DIFF
--- a/Source/Csla.Shared/BusinessListBase.cs
+++ b/Source/Csla.Shared/BusinessListBase.cs
@@ -640,7 +640,6 @@ namespace Csla
     protected override void OnGetState(SerializationInfo info)
     {
       info.AddValue("Csla.BusinessListBase._isChild", _isChild);
-      info.AddValue("Csla.BusinessListBase._editLevel", _editLevel);
       info.AddValue("Csla.Core.BusinessBase._identity", _identity);
       base.OnGetState(info);
     }
@@ -656,7 +655,7 @@ namespace Csla
     protected override void OnSetState(SerializationInfo info)
     {
       _isChild = info.GetValue<bool>("Csla.BusinessListBase._isChild");
-      _editLevel = info.GetValue<int>("Csla.BusinessListBase._editLevel");
+      _editLevel = 0;
       _identity = info.GetValue<int>("Csla.Core.BusinessBase._identity");
       base.OnSetState(info);
     }

--- a/Source/Csla.Shared/Core/FieldManager/FieldDataManager.cs
+++ b/Source/Csla.Shared/Core/FieldManager/FieldDataManager.cs
@@ -521,7 +521,7 @@ namespace Csla.Core.FieldManager
       // serialize the state and stack it
       using (MemoryStream buffer = new MemoryStream())
       {
-        var formatter = SerializationFormatterFactory.GetFormatter();
+        var formatter = SerializationFormatterFactory.GetNativeFormatter();
         formatter.Serialize(buffer, state);
         _stateStack.Push(buffer.ToArray());
       }
@@ -557,7 +557,7 @@ namespace Csla.Core.FieldManager
         using (MemoryStream buffer = new MemoryStream(_stateStack.Pop()))
         {
           buffer.Position = 0;
-          var formatter = SerializationFormatterFactory.GetFormatter();
+          var formatter = SerializationFormatterFactory.GetNativeFormatter();
           state = (IFieldData[])(formatter.Deserialize(buffer));
         }
 

--- a/Source/Csla.Shared/Core/UndoableBase.cs
+++ b/Source/Csla.Shared/Core/UndoableBase.cs
@@ -482,7 +482,7 @@ namespace Csla.Core
       using (MemoryStream buffer = new MemoryStream())
       {
         ISerializationFormatter formatter =
-          SerializationFormatterFactory.GetFormatter();
+          SerializationFormatterFactory.GetNativeFormatter();
         formatter.Serialize(buffer, state);
         _stateStack.Push(buffer.ToArray());
       }
@@ -535,7 +535,7 @@ namespace Csla.Core
         {
           buffer.Position = 0;
           ISerializationFormatter formatter =
-            SerializationFormatterFactory.GetFormatter();
+            SerializationFormatterFactory.GetNativeFormatter();
           state = (MobileDictionary<string, object>)formatter.Deserialize(buffer);
         }
 

--- a/Source/Csla.Shared/Serialization/SerializationFormatterFactory.cs
+++ b/Source/Csla.Shared/Serialization/SerializationFormatterFactory.cs
@@ -37,5 +37,24 @@ namespace Csla.Serialization
       else
         return new Csla.Serialization.Mobile.MobileFormatter();
     }
+
+    /// <summary>
+    /// <para>
+    /// Creates a serialization formatter that is compatible with the platform on which the current process is running.
+    /// </para>
+    /// <para>
+    /// This method will ignore the settings in <see cref="ApplicationContext.SerializationFormatter"/> and
+    /// <see cref="ConfigurationManager.AppSettings"/> and should only be used for operations for which data will be
+    /// serialized and deserialized in the same process without crossing a data portal boundary (i.e. n-level undo).
+    /// </para>
+    /// </summary>
+    internal static ISerializationFormatter GetNativeFormatter()
+    {
+#if (ANDROID || IOS) || NETFX_CORE || NETSTANDARD2_0
+      return new Csla.Serialization.Mobile.MobileFormatter();
+#else
+      return new NetDataContractSerializerWrapper();
+#endif
+    }
   }
 }

--- a/Source/Csla.test/BasicModern/BasicModernTests.cs
+++ b/Source/Csla.test/BasicModern/BasicModernTests.cs
@@ -20,7 +20,26 @@ namespace Csla.Test.BasicModern
   public class BasicModernTests
   {
     [TestMethod]
-    
+    public void BeginEditWorksWithMobileSerializer()
+    {
+      var oldSetting = Configuration.ConfigurationManager.AppSettings["CslaSerializationFormatter"];
+      try
+      {
+        Configuration.ConfigurationManager.AppSettings.Set("CslaSerializationFormatter", "MobileFormatter");
+
+        var graph = Root.NewRoot();
+        graph.BeginEdit();
+
+        //Use a simple assert here to show that this code is reachable without throwing an exception.
+        Assert.IsTrue(true);
+      }
+      finally
+      {
+        Configuration.ConfigurationManager.AppSettings.Set("CslaSerializationFormatter", oldSetting);
+      }
+    }
+
+    [TestMethod]
     public void CreateGraph()
     {
       var graph = Root.NewRoot();

--- a/Source/Csla.test/BasicModern/BasicModernTests.cs
+++ b/Source/Csla.test/BasicModern/BasicModernTests.cs
@@ -20,18 +20,64 @@ namespace Csla.Test.BasicModern
   public class BasicModernTests
   {
     [TestMethod]
-    public void BeginEditWorksWithMobileSerializer()
+    public void EditLevelsWorkWithMobileFormatter()
     {
       var oldSetting = Configuration.ConfigurationManager.AppSettings["CslaSerializationFormatter"];
       try
       {
         Configuration.ConfigurationManager.AppSettings.Set("CslaSerializationFormatter", "MobileFormatter");
 
-        var graph = Root.NewRoot();
-        graph.BeginEdit();
+        var root = Root.NewRoot();
 
-        //Use a simple assert here to show that this code is reachable without throwing an exception.
-        Assert.IsTrue(true);
+        var originalRootId = root.Id;
+
+        root.BeginEdit();
+        root.Id = originalRootId + 1;
+        root.CancelEdit();
+
+        Assert.AreEqual(originalRootId, root.Id);
+
+        root.BeginEdit();
+        root.Id = originalRootId + 1;
+        root.ApplyEdit();
+
+        Assert.AreEqual(originalRootId + 1, root.Id);
+      }
+      finally
+      {
+        Configuration.ConfigurationManager.AppSettings.Set("CslaSerializationFormatter", oldSetting);
+      }
+    }
+
+    [TestMethod]
+    public void CloneWorkswithMobileFormatter()
+    {
+      var oldSetting = Configuration.ConfigurationManager.AppSettings["CslaSerializationFormatter"];
+      try
+      {
+        Configuration.ConfigurationManager.AppSettings.Set("CslaSerializationFormatter", "MobileFormatter");
+
+        var original = Root.NewRoot();
+
+        original.Name = "Test Root";
+
+        var child = original.Children.AddNew();
+
+        child.Name = "TestChild";
+
+        var copy = original.Clone();
+
+        Assert.IsFalse(ReferenceEquals(original, copy));
+        Assert.AreEqual(original.Id, copy.Id);
+        Assert.AreEqual(original.IsDirty, copy.IsDirty);
+        Assert.AreEqual(original.IsSelfDirty, copy.IsSelfDirty);
+        
+        for(var i = 0; i < original.Children.Count; i++)
+        {
+          Assert.IsFalse(ReferenceEquals(original.Children[i], copy.Children[i]));
+          Assert.AreEqual(original.Children[i].Name, copy.Children[i].Name);
+          Assert.AreEqual(original.Children[i].IsDirty, copy.Children[i].IsDirty);
+        }
       }
       finally
       {

--- a/Source/Csla.test/Serialization/SerializationTests.cs
+++ b/Source/Csla.test/Serialization/SerializationTests.cs
@@ -475,13 +475,6 @@ namespace Csla.Test.Serialization
     
     public void DCEditLevels()
     {
-      System.Configuration.ConfigurationManager.AppSettings["CslaSerializationFormatter"] =
-        "NetDataContractSerializer";
-      Assert.AreEqual(
-        Csla.ApplicationContext.SerializationFormatters.NetDataContractSerializer,
-        Csla.ApplicationContext.SerializationFormatter,
-        "Formatter should be NetDataContractSerializer");
-
       DCRoot root = new DCRoot();
       root.BeginEdit();
       root.Data = 123;

--- a/Source/Csla.test/ViewModelTests/TestViewModel.cs
+++ b/Source/Csla.test/ViewModelTests/TestViewModel.cs
@@ -2,11 +2,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Csla.Xaml;
 
 namespace Csla.Test.ViewModelTests
 {
   public class TestViewModel<T> : ViewModel<T>
   {
+    public void Save() => DoSave();
   }
 }

--- a/Source/Csla.test/ViewModelTests/ViewModelTests.cs
+++ b/Source/Csla.test/ViewModelTests/ViewModelTests.cs
@@ -57,5 +57,33 @@ namespace Csla.Test.ViewModelTests
       Assert.IsFalse(viewModel.CanSave);
       Assert.IsFalse(viewModel.CanDelete);
     }
+
+    [TestMethod]
+    public void ViewModelBaseDoSaveWorksWithMobileFormatter()
+    {
+      var oldSetting = Configuration.ConfigurationManager.AppSettings["CslaSerializationFormatter"];
+      try
+      {
+        Configuration.ConfigurationManager.AppSettings.Set("CslaSerializationFormatter", "MobileFormatter");
+
+        var root = BasicModern.Root.NewRoot();
+
+        var viewModel = new TestViewModel<BasicModern.Root>();
+
+        viewModel.Model = root;
+        viewModel.Model.Name = "root";
+
+        var child = viewModel.Model.Children.AddNew();
+        child.Name = "child";
+
+        viewModel.Save();
+
+        Assert.IsNull(viewModel.Error);
+      } 
+      finally
+      {
+        Configuration.ConfigurationManager.AppSettings.Set("CslaSerializationFormatter", oldSetting);
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixed issue with BeginEdit caused by using MobileFormatter in .NET Framework.

Detailed description of the PR can be found in [this comment](https://github.com/MarimerLLC/csla/issues/1080#issuecomment-474013266) on the issue. #1080