### PR TITLE
Fix #1125 edit level mismatch

### DIFF
--- a/Source/Csla.Shared/BusinessListBase.cs
+++ b/Source/Csla.Shared/BusinessListBase.cs
@@ -604,7 +604,6 @@ namespace Csla
 
       // we are coming up one edit level
       _editLevel -= 1;
-      if (_editLevel < 0) _editLevel = 0;
 
       // cascade the call to all child objects
       foreach (C child in this)
@@ -623,6 +622,8 @@ namespace Csla
         if (child.EditLevelAdded > _editLevel)
           DeletedList.RemoveAt(index);
       }
+      
+      if (_editLevel < 0) _editLevel = 0;
     }
 
     #endregion

--- a/Source/Csla.test/BusinessListBase/BusinessListBaseTests.cs
+++ b/Source/Csla.test/BusinessListBase/BusinessListBaseTests.cs
@@ -74,6 +74,32 @@ namespace Csla.Test.BusinessListBase
     }
 
     [TestMethod]
+    public void AcceptChangesAndSaveAfterCloneUsingMobileFormatter()
+    {
+      var oldSetting = Configuration.ConfigurationManager.AppSettings["CslaSerializationFormatter"];
+      try
+      {
+        Configuration.ConfigurationManager.AppSettings.Set("CslaSerializationFormatter", "MobileFormatter");
+
+        var rootList = Csla.DataPortal.Create<RootList>();
+        rootList.BeginEdit();
+        var child = rootList.AddNew();
+
+        rootList = rootList.Clone();
+
+        rootList.ApplyEdit();
+
+        Assert.IsTrue(rootList.IsDirty);
+        rootList = rootList.Save();
+        Assert.IsFalse(rootList.IsDirty);
+      }
+      finally
+      {
+        Configuration.ConfigurationManager.AppSettings.Set("CslaSerializationFormatter", oldSetting);
+      }
+    }
+
+    [TestMethod]
     public void UndoRootAcceptAdd()
     {
       var obj = Csla.DataPortal.Create<RootList>();


### PR DESCRIPTION
Fixes #1125. 
Added a unit test to demonstrate the issue with **BusinessListBase.AcceptChanges** when using the **MobileFormatter**. Changed the order of operations for setting negative edit levels to 0 during **AcceptChanges** so that the value passed to **child.AcceptChanges** matches what is expected by the argument validation in **UndoableBase**.
