### PR TITLE
Addresses #1196 Add ability to pass criteria via authorization context

### DIFF
--- a/Source/Csla.Shared/DataPortalT.cs
+++ b/Source/Csla.Shared/DataPortalT.cs
@@ -85,7 +85,7 @@ namespace Csla
       {
         DataPortal.OnDataPortalInitInvoke(null);
 
-        if (!Csla.Rules.BusinessRules.HasPermission(Rules.AuthorizationActions.CreateObject, objectType))
+        if (!Csla.Rules.BusinessRules.HasPermission(Rules.AuthorizationActions.CreateObject, objectType, criteria))
           throw new Csla.Security.SecurityException(string.Format(
             Resources.UserNotAuthorizedException,
             "create",
@@ -305,7 +305,7 @@ namespace Csla
       {
         DataPortal.OnDataPortalInitInvoke(null);
 
-        if (!Csla.Rules.BusinessRules.HasPermission(Rules.AuthorizationActions.GetObject, objectType))
+        if (!Csla.Rules.BusinessRules.HasPermission(Rules.AuthorizationActions.GetObject, objectType, criteria))
           throw new Csla.Security.SecurityException(string.Format(
             Resources.UserNotAuthorizedException,
             "get",
@@ -841,7 +841,7 @@ namespace Csla
       {
         DataPortal.OnDataPortalInitInvoke(null);
 
-        if (!Csla.Rules.BusinessRules.HasPermission(Rules.AuthorizationActions.DeleteObject, objectType))
+        if (!Csla.Rules.BusinessRules.HasPermission(Rules.AuthorizationActions.DeleteObject, objectType, criteria))
           throw new Csla.Security.SecurityException(string.Format(Resources.UserNotAuthorizedException,
             "delete",
             objectType.Name));

--- a/Source/Csla.Shared/Rules/AuthorizationContext.cs
+++ b/Source/Csla.Shared/Rules/AuthorizationContext.cs
@@ -40,6 +40,11 @@ namespace Csla.Rules
     public bool HasPermission { get; set; }
 
     /// <summary>
+    /// Gets an object which is the criteria specified in the data portal call, if any.
+    /// </summary>
+    public object Criteria { get; internal set; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="AuthorizationContext"/> class.
     /// </summary>
     public AuthorizationContext()

--- a/Source/Csla.Shared/Rules/BusinessRules.cs
+++ b/Source/Csla.Shared/Rules/BusinessRules.cs
@@ -290,7 +290,20 @@ namespace Csla.Rules
     {
       objectType = ApplicationContext.DataPortalActivator.ResolveType(objectType);
       // no object specified so must use RuleSet from ApplicationContext
-      return HasPermission(action, null, objectType, ApplicationContext.RuleSet);
+      return HasPermission(action, null, objectType, null, ApplicationContext.RuleSet);
+    }
+
+    /// <summary>
+    /// Checks per-type authorization rules.
+    /// </summary>
+    /// <param name="action">Authorization action.</param>
+    /// <param name="objectType">Type of business object.</param>
+    /// <param name="criteria">The criteria object provided.</param>
+    public static bool HasPermission(AuthorizationActions action, Type objectType, object criteria)
+    {
+      objectType = ApplicationContext.DataPortalActivator.ResolveType(objectType);
+      // no object specified so must use RuleSet from ApplicationContext
+      return HasPermission(action, null, objectType, criteria, ApplicationContext.RuleSet);
     }
 
     /// <summary>
@@ -304,7 +317,7 @@ namespace Csla.Rules
     /// </returns>
     public static bool HasPermission(AuthorizationActions action, Type objectType, string ruleSet)
     {
-      return HasPermission(action, null, objectType, ruleSet);
+      return HasPermission(action, null, objectType, null, ruleSet);
     }
 
     /// <summary>
@@ -314,7 +327,7 @@ namespace Csla.Rules
     /// <param name="obj">Business object instance.</param>
     public static bool HasPermission(AuthorizationActions action, object obj)
     {
-      return HasPermission(action, obj, obj.GetType(), ApplicationContext.RuleSet);
+      return HasPermission(action, obj, obj.GetType(), null, ApplicationContext.RuleSet);
     }
 
     /// <summary>
@@ -328,10 +341,10 @@ namespace Csla.Rules
     /// </returns>
     public static bool HasPermission(AuthorizationActions action, object obj, string ruleSet)
     {
-      return HasPermission(action, obj, obj.GetType(), ruleSet);
+      return HasPermission(action, obj, obj.GetType(), null, ruleSet);
     }
 
-    private static bool HasPermission(AuthorizationActions action, object obj, Type objType, string ruleSet)
+    private static bool HasPermission(AuthorizationActions action, object obj, Type objType, object criteria, string ruleSet)
     {
 
       if (action == AuthorizationActions.ReadProperty ||
@@ -344,7 +357,7 @@ namespace Csla.Rules
         AuthorizationRuleManager.GetRulesForType(objType, ruleSet).Rules.FirstOrDefault(c => c.Element == null && c.Action == action);
       if (rule != null)
       {
-        var context = new AuthorizationContext { Rule = rule, Target = obj, TargetType = objType };
+        var context = new AuthorizationContext { Rule = rule, Target = obj, TargetType = objType, Criteria = criteria };
         rule.Execute(context);
         result = context.HasPermission;
       }

--- a/Source/Csla.test/Authorization/AuthRuleExpectsCriteria.cs
+++ b/Source/Csla.test/Authorization/AuthRuleExpectsCriteria.cs
@@ -1,4 +1,11 @@
-﻿using Csla.Rules;
+﻿//-----------------------------------------------------------------------
+// <copyright file="AuthRuleExpectsCriteria.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>no summary</summary>
+//-----------------------------------------------------------------------
+using Csla.Rules;
 
 namespace Csla.Test.Authorization 
 {

--- a/Source/Csla.test/Authorization/AuthRuleExpectsCriteria.cs
+++ b/Source/Csla.test/Authorization/AuthRuleExpectsCriteria.cs
@@ -1,0 +1,16 @@
+﻿using Csla.Rules;
+
+namespace Csla.Test.Authorization 
+{
+  public class AuthRuleExpectsCriteria : AuthorizationRule 
+  {
+    public AuthRuleExpectsCriteria(AuthorizationActions action) : base(action) 
+    {
+    }
+    
+    protected override void Execute(AuthorizationContext context) 
+    {
+      context.HasPermission = context.Criteria is PermissionRootWithCriteria.Criteria;
+    }
+  }
+}

--- a/Source/Csla.test/Authorization/AuthTests.cs
+++ b/Source/Csla.test/Authorization/AuthTests.cs
@@ -489,6 +489,74 @@ namespace Csla.Test.Authorization
         Csla.ApplicationContext.DataPortalActivator = null;
       }
     }
+
+    [TestMethod]
+    public void PerTypeAuthCreateWithCriteria() {
+      Assert.IsTrue(
+        BusinessRules.HasPermission(
+          AuthorizationActions.CreateObject,
+          typeof(PermissionRootWithCriteria),
+          new PermissionRootWithCriteria.Criteria()));
+
+      Assert.IsFalse(
+        BusinessRules.HasPermission(
+          AuthorizationActions.CreateObject,
+          typeof(PermissionRootWithCriteria),
+          new object()));
+
+    
+      Assert.IsFalse(
+        BusinessRules.HasPermission(
+          AuthorizationActions.CreateObject,
+          typeof(PermissionRootWithCriteria),
+          (object)null));
+    }
+
+    [TestMethod]
+    public void PerTypeAuthFetchWithCriteria() 
+    {
+      Assert.IsTrue(
+        BusinessRules.HasPermission(
+          AuthorizationActions.GetObject,
+          typeof(PermissionRootWithCriteria),
+          new PermissionRootWithCriteria.Criteria()));
+
+      Assert.IsFalse(
+        BusinessRules.HasPermission(
+          AuthorizationActions.GetObject,
+          typeof(PermissionRootWithCriteria),
+          new object()));
+
+    
+      Assert.IsFalse(
+        BusinessRules.HasPermission(
+          AuthorizationActions.GetObject,
+          typeof(PermissionRootWithCriteria),
+          (object)null));
+    }
+  
+    [TestMethod]
+    public void PerTypeAuthDeleteWithCriteria() 
+    {
+      Assert.IsTrue(
+        BusinessRules.HasPermission(
+          AuthorizationActions.DeleteObject,
+          typeof(PermissionRootWithCriteria),
+          new PermissionRootWithCriteria.Criteria()));
+
+      Assert.IsFalse(
+        BusinessRules.HasPermission(
+          AuthorizationActions.DeleteObject,
+          typeof(PermissionRootWithCriteria),
+          new object()));
+
+    
+      Assert.IsFalse(
+        BusinessRules.HasPermission(
+          AuthorizationActions.DeleteObject,
+          typeof(PermissionRootWithCriteria),
+          (object)null));
+    }
   }
 
   public class PerTypeAuthDPActivator : Server.IDataPortalActivator

--- a/Source/Csla.test/Authorization/PermissionRootWithCriteria.cs
+++ b/Source/Csla.test/Authorization/PermissionRootWithCriteria.cs
@@ -1,8 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿//-----------------------------------------------------------------------
+// <copyright file="PermissionRootWithCriteria.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>no summary</summary>
+//-----------------------------------------------------------------------
+using System;
 using Csla.Rules;
 
 namespace Csla.Test.Authorization 

--- a/Source/Csla.test/Authorization/PermissionRootWithCriteria.cs
+++ b/Source/Csla.test/Authorization/PermissionRootWithCriteria.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Csla.Rules;
+
+namespace Csla.Test.Authorization 
+{
+  [Serializable()]
+  public class PermissionRootWithCriteria : BusinessBase<PermissionRootWithCriteria>
+  {
+    public static void AddObjectAuthorizationRules() {
+      Csla.Rules.BusinessRules.AddRule(
+        typeof(PermissionRootWithCriteria),
+        new AuthRuleExpectsCriteria(AuthorizationActions.CreateObject));
+      Csla.Rules.BusinessRules.AddRule(
+        typeof(PermissionRootWithCriteria),
+        new AuthRuleExpectsCriteria(AuthorizationActions.GetObject));
+      Csla.Rules.BusinessRules.AddRule(
+        typeof(PermissionRootWithCriteria),
+        new AuthRuleExpectsCriteria(AuthorizationActions.DeleteObject));
+    }
+
+    public class Criteria { }
+  }
+}

--- a/Source/Csla.test/csla.test.csproj
+++ b/Source/Csla.test/csla.test.csproj
@@ -102,7 +102,9 @@
     <Compile Include="AppContext\SimpleRoot.cs" />
     <Compile Include="AppContext\TestContext.cs" />
     <Compile Include="AppDomainTests\AppDomainTests.cs" />
+    <Compile Include="Authorization\AuthRuleExpectsCriteria.cs" />
     <Compile Include="Authorization\AuthTests.cs" />
+    <Compile Include="Authorization\PermissionRootWithCriteria.cs" />
     <Compile Include="Authorization\PermissionsRoot.cs" />
     <Compile Include="Authorization\PermissionsRoot2.cs" />
     <Compile Include="Authorization\PerTypeAuthClasses.cs" />


### PR DESCRIPTION
Addresses #1196, including the criteria sent to the data portal through the authorization context for per-type rules so that auth rules may have more information to determine permissions.
