### PR TITLE
Fix Samples\SimpleNTier - WpfUI missing references

### DIFF
--- a/Samples/SimpleNTier/WpfUI/WpfUI.csproj
+++ b/Samples/SimpleNTier/WpfUI/WpfUI.csproj
@@ -50,14 +50,12 @@
       <HintPath>..\packages\CSLA-WPF.4.8.1\lib\net461\Csla.Xaml.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Expression.Interactions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Dependencies\Net\Microsoft.Expression.Interactions.dll</HintPath>
+      <HintPath>..\packages\Blend.Interctivity.WPF.v4.0.1.0.3\lib\net40\Microsoft.Expression.Interactions.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Windows.Interactivity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Dependencies\Net\System.Windows.Interactivity.dll</HintPath>
+      <HintPath>..\packages\Blend.Interctivity.WPF.v4.0.1.0.3\lib\net40\System.Windows.Interactivity.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />

--- a/Samples/SimpleNTier/WpfUI/packages.config
+++ b/Samples/SimpleNTier/WpfUI/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Blend.Interctivity.WPF.v4.0" version="1.0.3" targetFramework="net461" />
   <package id="BXF" version="1.2.0.0" targetFramework="net45" requireReinstallation="true" />
   <package id="CSLA-Core" version="4.8.1" targetFramework="net461" />
   <package id="CSLA-WPF" version="4.8.1" targetFramework="net461" />


### PR DESCRIPTION
WpfUI project has 2 missing references: Microsoft.Expression.Interactions. dll and System.Windows.Interactivity.dll. I found 1st in Source\Dependencies\Expression\WPF (different path than in .csproj), 2nd isn't in csla repo.
This 2nd .dll could be added here and path to Dependencies folder fixed, but there is "Blend.Interctivity.WPF.v4.0" NuGet package which contains exactly these 2 .dlls so I used it.
