### PR TITLE
Blazor validation component, including new unit tests project

### DIFF
--- a/Source/Csla.Blazor.Test/Csla.Blazor.Test.csproj
+++ b/Source/Csla.Blazor.Test/Csla.Blazor.Test.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+
+    <ApplicationIcon />
+
+    <OutputType>Library</OutputType>
+
+    <StartupObject />
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Csla.Blazor\Csla.Blazor.csproj" />
+    <ProjectReference Include="..\Csla.NetStandard2.0\Csla.NetStandard2.0.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Source/Csla.Blazor.Test/EditContextCslaExtensionsTests.cs
+++ b/Source/Csla.Blazor.Test/EditContextCslaExtensionsTests.cs
@@ -1,0 +1,132 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Csla.Blazor.Test.Fakes;
+using Microsoft.AspNetCore.Components.Forms;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Csla.Blazor.Test
+{
+	[TestClass]
+	public class EditContextCslaExtensionsTests
+	{
+
+		[TestMethod]
+		public void ValidateModel_EmptyLastName_OneValidationMessage()
+		{
+      // Arrange
+      FakePerson person = GetValidFakePerson();
+      EditContext editContext = new EditContext(person);
+      editContext.AddCslaValidation();
+
+      // Set last name to an invalid value
+      person.LastName = string.Empty;
+
+      // Act
+      editContext.Validate();
+      IEnumerable<string> messages = editContext.GetValidationMessages();
+
+      // Assert
+      Assert.AreEqual(1, messages.Count(), "Incorrect number of validation messages returned!");
+
+		}
+
+    [TestMethod]
+    public void ValidateModel_ExcessiveFirstNameEmptyLastName_TwoValidationMessages()
+    {
+      // Arrange
+      FakePerson person = GetValidFakePerson();
+      EditContext editContext = new EditContext(person);
+      editContext.AddCslaValidation();
+
+      // Set first and last names to invalid values
+      person.FirstName = "This text is more than twenty five characters long";
+      person.LastName = string.Empty;
+
+      // Act
+      editContext.Validate();
+      IEnumerable<string> messages = editContext.GetValidationMessages();
+
+      // Assert
+      Assert.AreEqual(2, messages.Count(), "Incorrect number of validation messages returned!");
+
+    }
+
+    [TestMethod]
+    public void ValidateModel_NeitherTelephoneProvided_TwoValidationMessages()
+    {
+      // Arrange
+      FakePerson person = GetValidFakePerson();
+      EditContext editContext = new EditContext(person);
+      editContext.AddCslaValidation();
+
+      // Set both phone numbers to invalid values
+      person.HomeTelephone = "";
+      person.MobileTelephone = "";
+
+      // Act
+      editContext.Validate();
+      IEnumerable<string> messages = editContext.GetValidationMessages();
+
+      // Assert
+      Assert.AreEqual(2, messages.Count(), "Incorrect number of validation messages returned!");
+
+    }
+
+    [TestMethod]
+    public void ValidateField_ExcessiveFirstNameEmptyLastName_OneValidationMessageForFirstName()
+    {
+      // Arrange
+      FakePerson person = GetValidFakePerson();
+      EditContext editContext = new EditContext(person);
+      editContext.AddCslaValidation();
+
+      // Set first and last names to invalid values
+      person.FirstName = "This text is more than twenty five characters long";
+      person.LastName = string.Empty;
+
+      // Act
+      editContext.Validate();
+      IEnumerable<string> messages = editContext.GetValidationMessages(new FieldIdentifier(person, "FirstName"));
+
+      // Assert
+      Assert.AreEqual(1, messages.Count(), "Incorrect number of validation messages returned!");
+
+    }
+
+    [TestMethod]
+    public void ValidateField_NeitherTelephoneProvided_OneValidationMessageForHomeTelephone()
+    {
+      // Arrange
+      FakePerson person = GetValidFakePerson();
+      EditContext editContext = new EditContext(person);
+      editContext.AddCslaValidation();
+
+      // Set both phone numbers to invalid values
+      person.HomeTelephone = "";
+      person.MobileTelephone = "";
+
+      // Act
+      editContext.Validate();
+      IEnumerable<string> messages = editContext.GetValidationMessages(new FieldIdentifier(person, "HomeTelephone"));
+
+      // Assert
+      Assert.AreEqual(1, messages.Count(), "Incorrect number of validation messages returned!");
+
+    }
+
+    #region Helper Methods
+
+    FakePerson GetValidFakePerson()
+    {
+      FakePerson person = FakePerson.NewFakePerson();
+
+      person.LastName = "Smith";
+      person.HomeTelephone = "01234 567890";
+
+      return person;
+    }
+
+    #endregion
+
+  }
+}

--- a/Source/Csla.Blazor.Test/Fakes/FakePerson.cs
+++ b/Source/Csla.Blazor.Test/Fakes/FakePerson.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text;
+using Csla.Blazor.Test.Rules;
+
+namespace Csla.Blazor.Test.Fakes
+{
+  [Serializable()]
+  public class FakePerson : BusinessBase<FakePerson>
+  {
+    public static PropertyInfo<string> FirstNameProperty = RegisterProperty<string>(c => c.FirstName);
+    public static PropertyInfo<string> LastNameProperty = RegisterProperty<string>(c => c.LastName);
+    public static PropertyInfo<string> HomeTelephoneProperty = RegisterProperty<string>(c => c.HomeTelephone);
+    public static PropertyInfo<string> MobileTelephoneProperty = RegisterProperty<string>(c => c.MobileTelephone);
+
+    #region Properties 
+
+    [MaxLength(25)]
+    public string FirstName
+    {
+      get { return GetProperty(FirstNameProperty); }
+      set { SetProperty(FirstNameProperty, value); }
+    }
+
+    [Required]
+    [MaxLength(25)]
+    public string LastName
+    {
+      get { return GetProperty(LastNameProperty); }
+      set { SetProperty(LastNameProperty, value); }
+    }
+
+    public string HomeTelephone
+    {
+      get { return GetProperty(HomeTelephoneProperty); }
+      set { SetProperty(HomeTelephoneProperty, value); }
+    }
+
+    public string MobileTelephone
+    {
+      get { return GetProperty(MobileTelephoneProperty); }
+      set { SetProperty(MobileTelephoneProperty, value); }
+    }
+
+    #endregion
+
+    #region Factory Methods
+
+    public static FakePerson NewFakePerson()
+    {
+      return DataPortal.Create<FakePerson>();
+    }
+
+    #endregion
+
+    #region Business Rules
+
+    protected override void AddBusinessRules()
+    {
+      base.AddBusinessRules();
+      BusinessRules.AddRule(new OneOfSeveralStringsRequiredRule(HomeTelephoneProperty, MobileTelephoneProperty));
+    }
+
+    #endregion
+
+    #region Data Access
+
+    [RunLocal]
+    protected override void DataPortal_Create()
+    {
+      // Trigger object checks
+      CheckObjectRules();
+    }
+
+    #endregion
+
+  }
+}

--- a/Source/Csla.Blazor.Test/Rules/OneOfSeveralStringsRequiredRule.cs
+++ b/Source/Csla.Blazor.Test/Rules/OneOfSeveralStringsRequiredRule.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Csla.Core;
+using Csla.Rules;
+
+namespace Csla.Blazor.Test.Rules
+{
+  /// <summary>
+  /// Business rule for when one of two strings must be provided
+  /// </summary>
+  public class OneOfSeveralStringsRequiredRule : PropertyRule
+  {
+
+    /// <summary>
+    /// Creates an instance of the rule.
+    /// </summary>
+    /// <param name="affectedProperties">Array of properties to which the rule applies.</param>
+    public OneOfSeveralStringsRequiredRule(params IPropertyInfo[] affectedProperties)
+      : base(affectedProperties[0])
+    {
+      foreach (IPropertyInfo affectedProperty in affectedProperties)
+      {
+        InputProperties.Add(affectedProperty);
+      }
+    }
+
+    /// <summary>
+    /// Creates an instance of the rule.
+    /// </summary>
+    /// <param name="affectedProperties">Array of properties to which the rule applies.</param>
+    /// <param name="message">The message.</param>
+    public OneOfSeveralStringsRequiredRule(string message, params IPropertyInfo[] affectedProperties)
+      : this(affectedProperties)
+    {
+      MessageText = message;
+    }
+
+    /// <summary>
+    /// Creates an instance of the rule.
+    /// </summary>
+    /// <param name="affectedProperties">Array of properties to which the rule applies.</param>
+    /// <param name="messageDelegate">The localizable message.</param>
+    public OneOfSeveralStringsRequiredRule(Func<string> messageDelegate, params IPropertyInfo[] affectedProperties)
+      : this(affectedProperties)
+    {
+      MessageDelegate = messageDelegate;
+    }
+
+    public RuleSeverity Severity { get; set; } = RuleSeverity.Error;
+
+    /// <summary>
+    /// Gets the error message.
+    /// </summary>
+    /// <value></value>
+    protected override string GetMessage()
+    {
+      return HasMessageDelegate ? base.MessageText : "One of the properties must be provided";
+    }
+
+    /// <summary>
+    /// Rule implementation.
+    /// </summary>
+    /// <param name="context">Rule context.</param>
+    protected override void Execute(IRuleContext context)
+    {
+      bool valueProvided = false;
+
+      // Iterate all of the properties and see if any of them have a value
+      foreach (var value in context.InputPropertyValues.Values)
+      {
+        if (value != null && !string.IsNullOrWhiteSpace(value.ToString()))
+        {
+          // Property has a value, so the rule is satisfied
+          valueProvided = true;
+          break;
+        }
+      }
+
+      if (!valueProvided)
+      {
+        // Rule not satisfied, so report it as such
+        foreach (IPropertyInfo propertyInfo in InputProperties)
+        { 
+          var message = string.Format(GetMessage(), propertyInfo.FriendlyName);
+          context.Results.Add(new RuleResult(RuleName, propertyInfo, message) { Severity = Severity });
+        }
+      }
+    }
+  }
+
+}

--- a/Source/Csla.Blazor/Csla.Blazor.csproj
+++ b/Source/Csla.Blazor/Csla.Blazor.csproj
@@ -1,7 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <RazorLangVersion>3.0</RazorLangVersion>
     <Version>5.0.0.0</Version>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
@@ -26,6 +27,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Csla.NetStandard2.0\Csla.NetStandard2.0.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.0.0-preview9.19424.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.0.0-preview9.19424.4" />
   </ItemGroup>
 
 </Project>

--- a/Source/Csla.Blazor/CslaValidator.cs
+++ b/Source/Csla.Blazor/CslaValidator.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
+
+namespace Csla.Blazor
+{
+
+  /// <summary>
+  /// Class offering integration of CSLA validation into Blazor edit forms
+  /// This is a component with no visible behaviour; it simply requests hook up of validation
+  /// </summary>
+  public class CslaValidator : ComponentBase
+  {
+    
+    [CascadingParameter]
+    public EditContext CurrentEditContext { get; set; }
+
+    protected override void OnInitialized()
+    {
+      // Check that the EditContext parameter has been made available
+      if (CurrentEditContext == null)
+      {
+        // No cascading parameter is available; we are probably not inside an EditForm component
+        throw new InvalidOperationException($"{nameof(CslaValidator)} requires a cascading " +
+          $"parameter of type {nameof(EditContext)}. For example, you can use {nameof(CslaValidator)} " +
+          $"inside an EditForm.");
+      }
+
+      // Wire up validation to the context we have been provided
+      CurrentEditContext.AddCslaValidation();
+    }
+  }
+}

--- a/Source/Csla.Blazor/EditContextCslaExtensions.cs
+++ b/Source/Csla.Blazor/EditContextCslaExtensions.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Csla.Core;
+using Csla.Rules;
+using Microsoft.AspNetCore.Components.Forms;
+
+namespace Csla.Blazor
+{
+	public static class EditContextCslaExtensions
+	{
+    /// <summary>
+    /// Adds validation support to the <see cref="EditContext"/> for objects implementing ICheckRules.
+    /// </summary>
+    /// <param name="editContext">The <see cref="EditContext"/>.</param>
+    public static EditContext AddCslaValidation(this EditContext editContext)
+    {
+      if (editContext == null)
+      {
+        throw new ArgumentNullException(nameof(editContext));
+      }
+
+      var messages = new ValidationMessageStore(editContext);
+
+      // Perform object-level validation on request
+      editContext.OnValidationRequested +=
+          (sender, eventArgs) => ValidateModel((EditContext)sender, messages);
+
+      // Perform per-field validation on each field edit
+      editContext.OnFieldChanged +=
+          (sender, eventArgs) => ValidateField(editContext, messages, eventArgs.FieldIdentifier);
+
+      return editContext;
+    }
+
+    /// <summary>
+    /// Method to perform validation on the model as a whole
+    /// Applies changes to the validation store provided as a parameter
+    /// </summary>
+    /// <param name="editContext">The EditContext provided by the form doing the editing</param>
+    /// <param name="messages">The validation message store to be updated during validation</param>
+    private static void ValidateModel(EditContext editContext, ValidationMessageStore messages)
+    {
+      ICheckRules model = editContext.Model as ICheckRules;
+
+      // Get access to the model via the required interface
+      model = editContext.Model as ICheckRules;
+
+      // Check if the model was provided, and correctly cast
+      if (model == null)
+      {
+        throw new ArgumentException("Model is null, or does not implement ICheckRules!");
+      }
+
+      // Transfer results to the ValidationMessageStore
+      messages.Clear();
+      foreach (var brokenRule in model.GetBrokenRules())
+      {
+        // Add a new message for each broken rule
+        messages.Add(new FieldIdentifier(model, brokenRule.Property), brokenRule.Description);
+      }
+
+      // Inform consumers that the state may have changed
+      editContext.NotifyValidationStateChanged();
+    }
+
+    /// <summary>
+    /// Method to perform validation on a single property of the model being edit
+    /// Applies changes to the validation store provided as a parameter
+    /// </summary>
+    /// <param name="editContext">The EditContext provided by the form doing the editing</param>
+    /// <param name="messages">The validation message store to be updated during validation</param>
+    /// <param name="fieldIdentifier">Identifier that indicates the field being validated</param>
+    private static void ValidateField(EditContext editContext, ValidationMessageStore messages, in FieldIdentifier fieldIdentifier)
+    {
+      ICheckRules model;
+
+      // Get access to the model via the required interface
+      model = editContext.Model as ICheckRules;
+
+      // Check if the model was provided, and correctly cast
+      if (model == null)
+      {
+        throw new ArgumentException("Model is null, or does not implement ICheckRules!");
+      }
+
+      // Transfer any broken rules for the required property to the store
+      messages.Clear(fieldIdentifier);
+      foreach (BrokenRule brokenRule in model.GetBrokenRules())
+      {
+        if (fieldIdentifier.FieldName.Equals(brokenRule.Property))
+        {
+          // Add a message for each broken rule on the property under validation
+          messages.Add(fieldIdentifier, brokenRule.Description);
+        }
+      }
+
+      // We have to notify even if there were no messages before and are still no messages now,
+      // because the "state" that changed might be the completion of some async validation task
+      editContext.NotifyValidationStateChanged();
+    }
+  }
+}

--- a/Source/Csla.Blazor/EditContextCslaExtensions.cs
+++ b/Source/Csla.Blazor/EditContextCslaExtensions.cs
@@ -7,8 +7,8 @@ using Microsoft.AspNetCore.Components.Forms;
 
 namespace Csla.Blazor
 {
-	public static class EditContextCslaExtensions
-	{
+  public static class EditContextCslaExtensions
+  {
     /// <summary>
     /// Adds validation support to the <see cref="EditContext"/> for objects implementing ICheckRules.
     /// </summary>

--- a/Source/csla.test.sln
+++ b/Source/csla.test.sln
@@ -90,6 +90,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Csla.Windows.NetCoreApp3.0"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Csla.Xaml.NetCoreApp3.0", "Csla.Xaml.NetCoreApp3.0\Csla.Xaml.NetCoreApp3.0.csproj", "{BE377EAD-D926-4220-953F-E097A8B4D77C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Csla.Blazor.Test", "Csla.Blazor.Test\Csla.Blazor.Test.csproj", "{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Csla.Data.EF6.Shared\Csla.Data.EF6.Shared.projitems*{11b64b3b-e639-4f05-8633-511cdca7d7a9}*SharedItemsImports = 4
@@ -1411,6 +1413,46 @@ Global
 		{BE377EAD-D926-4220-953F-E097A8B4D77C}.Testing|x64.Build.0 = Debug|Any CPU
 		{BE377EAD-D926-4220-953F-E097A8B4D77C}.Testing|x86.ActiveCfg = Debug|Any CPU
 		{BE377EAD-D926-4220-953F-E097A8B4D77C}.Testing|x86.Build.0 = Debug|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Debug|ARM.Build.0 = Debug|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Debug|x64.Build.0 = Debug|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Debug|x86.Build.0 = Debug|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Mono Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Mono Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Mono Debug|ARM.ActiveCfg = Debug|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Mono Debug|ARM.Build.0 = Debug|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Mono Debug|x64.ActiveCfg = Debug|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Mono Debug|x64.Build.0 = Debug|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Mono Debug|x86.ActiveCfg = Debug|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Mono Debug|x86.Build.0 = Debug|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Mono Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Mono Release|Any CPU.Build.0 = Release|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Mono Release|ARM.ActiveCfg = Release|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Mono Release|ARM.Build.0 = Release|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Mono Release|x64.ActiveCfg = Release|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Mono Release|x64.Build.0 = Release|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Mono Release|x86.ActiveCfg = Release|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Mono Release|x86.Build.0 = Release|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Release|ARM.ActiveCfg = Release|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Release|ARM.Build.0 = Release|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Release|x64.ActiveCfg = Release|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Release|x64.Build.0 = Release|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Release|x86.ActiveCfg = Release|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Release|x86.Build.0 = Release|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Testing|Any CPU.ActiveCfg = Debug|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Testing|Any CPU.Build.0 = Debug|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Testing|ARM.ActiveCfg = Debug|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Testing|ARM.Build.0 = Debug|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Testing|x64.ActiveCfg = Debug|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Testing|x64.Build.0 = Debug|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Testing|x86.ActiveCfg = Debug|Any CPU
+		{BBAFDD06-47D5-4D0F-95F0-A4CB5687DB7F}.Testing|x86.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Blazor validation component that is compatible with Blazor's built in EditForm/EditContext editing mechanisms. This validator offers support for extended validation concepts available to CSLA objects, such as business rules that incorporate multiple properties.

This first implementation exposes all validation rules without considering the complexity of severity.

Submission associated with feature request #1283