### PR TITLE
#1370 - Blazor Sample show authentication and authorisation

### DIFF
--- a/Samples/BlazorExample/BlazorExample/Client/App.razor
+++ b/Samples/BlazorExample/BlazorExample/Client/App.razor
@@ -1,6 +1,10 @@
 ﻿<Router AppAssembly="@typeof(Program).Assembly">
   <Found Context="routeData">
-    <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+    <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
+      <Authorizing>
+       <p>Authorising..</p>
+      </Authorizing>
+    </AuthorizeRouteView>
   </Found>
   <NotFound>
     <LayoutView Layout="@typeof(MainLayout)">

--- a/Samples/BlazorExample/BlazorExample/Client/BlazorExample.Client.csproj
+++ b/Samples/BlazorExample/BlazorExample/Client/BlazorExample.Client.csproj
@@ -11,13 +11,20 @@
 
   <ItemGroup>
     <PackageReference Include="Csla.Blazor" Version="5.1.0-R19100901" />
+    <PackageReference Include="Csla.Blazor" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.0.0-preview9.19424.4" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.0.0-preview9.19424.4" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.HttpClient" Version="3.0.0-preview9.19424.4" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.DevServer" Version="3.0.0-preview9.19424.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="3.0.0" />
+
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\BlazorExample.Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Components\" />
   </ItemGroup>
 
 </Project>

--- a/Samples/BlazorExample/BlazorExample/Client/BlazorExample.Client.csproj
+++ b/Samples/BlazorExample/BlazorExample/Client/BlazorExample.Client.csproj
@@ -10,8 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Csla.Blazor" Version="5.1.0-R19100901" />
-    <PackageReference Include="Csla.Blazor" Version="5.0.0" />
+    <PackageReference Include="Csla.Blazor" Version="5.1.0-R19101002" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.0.0-preview9.19424.4" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.0.0-preview9.19424.4" PrivateAssets="all" />

--- a/Samples/BlazorExample/BlazorExample/Client/CurrentUserAuthenticationStateProvider.cs
+++ b/Samples/BlazorExample/BlazorExample/Client/CurrentUserAuthenticationStateProvider.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components.Authorization;
+using static BlazorExample.Client.CurrentUserService;
+
+namespace BlazorExample.Client
+{
+  public class CurrentUserAuthenticationStateProvider : AuthenticationStateProvider, IDisposable
+  {
+    private readonly CurrentUserService _currentUserService;
+
+    public CurrentUserAuthenticationStateProvider(CurrentUserService currentUserService)
+    {
+      _currentUserService = currentUserService;
+      _currentUserService.CurrentUserChanged += _currentUserService_CurrentUserChanged;
+    }
+
+    private void _currentUserService_CurrentUserChanged(object sender, CurrentUserChangedEventArgs e)
+    {
+      var authState = Task<AuthenticationState>.FromResult(new AuthenticationState(e.NewUser));
+      NotifyAuthenticationStateChanged(authState);
+    }
+
+    public override Task<AuthenticationState> GetAuthenticationStateAsync()
+    {
+      //Note: Your implementation of this depends on your authentication model.
+      // For example, perhaps you want to cache a JWT, and then peridocically renew it by re-sending a request to the server etc.
+      // In this sample app we keep things very simple.
+      return Task.FromResult(new AuthenticationState(_currentUserService.CurrentUser));
+    }
+
+    #region IDisposable Support
+    private bool disposedValue = false; // To detect redundant calls
+
+    protected virtual void Dispose(bool disposing)
+    {
+      if (!disposedValue)
+      {
+        if (disposing)
+        {
+          _currentUserService.CurrentUserChanged -= _currentUserService_CurrentUserChanged;
+        }
+
+        disposedValue = true;
+      }
+    }
+
+    // This code added to correctly implement the disposable pattern.
+    public void Dispose()
+    {
+      // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+      Dispose(true);
+    }
+    #endregion
+  }
+}

--- a/Samples/BlazorExample/BlazorExample/Client/CurrentUserService.cs
+++ b/Samples/BlazorExample/BlazorExample/Client/CurrentUserService.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Security.Claims;
+
+namespace BlazorExample.Client
+{
+  /// <summary>
+  /// This service provides the application with a place to set who the current user is. It
+  /// raises an event when the current user changes.
+  /// </summary>
+  public class CurrentUserService
+  {
+    private ClaimsPrincipal _currentUser;
+
+    public event EventHandler<CurrentUserChangedEventArgs> CurrentUserChanged;
+
+    public CurrentUserService()
+    {
+      CurrentUser = new ClaimsPrincipal(new ClaimsIdentity());
+    }
+
+    public ClaimsPrincipal CurrentUser
+    {
+      get
+      {
+        return _currentUser;
+      }
+      set
+      {
+        _currentUser = value;
+        CurrentUserChanged?.Invoke(this, new CurrentUserChangedEventArgs() { NewUser = value });
+      }
+    }
+    public class CurrentUserChangedEventArgs : EventArgs
+    {
+      public ClaimsPrincipal NewUser { get; set; }
+    }
+  }
+}

--- a/Samples/BlazorExample/BlazorExample/Client/Pages/EditPerson.razor
+++ b/Samples/BlazorExample/BlazorExample/Client/Pages/EditPerson.razor
@@ -3,6 +3,7 @@
 @using BlazorExample.Shared
 @inject Csla.Blazor.ViewModel<PersonEdit> vm
 @inject NavigationManager NavigationManager
+@attribute [Authorize]
 
 <h1>Edit Person</h1>
 

--- a/Samples/BlazorExample/BlazorExample/Client/Pages/Login.razor
+++ b/Samples/BlazorExample/BlazorExample/Client/Pages/Login.razor
@@ -1,0 +1,45 @@
+﻿@page "/login"
+
+@inject CurrentUserService CurrentUserService
+
+<h1>Login</h1>
+
+<AuthorizeView>
+  <Authorized>
+    <p>You are logged in.</p>
+    <span></span>
+    <button class="btn btn-primary" @onclick="HandleLogout">Logout</button>
+  </Authorized>
+  <NotAuthorized>
+    <button class="btn btn-primary" @onclick="HandleLogin">Login</button>
+  </NotAuthorized>
+</AuthorizeView>
+
+@code {
+
+  [CascadingParameter]
+  public Task<AuthenticationState> AuthState { get; set; }
+
+  public void HandleLogin()
+  {
+    Console.WriteLine("logging in");
+    var claims = new Claim[]
+    {
+        new Claim(ClaimTypes.Name, "Test User"),
+        new Claim(ClaimTypes.Role, "Admin"),
+    };
+
+    var identity = new ClaimsIdentity(claims, "Test", ClaimTypes.Name, ClaimTypes.Role);
+
+    CurrentUserService.CurrentUser = new System.Security.Claims.ClaimsPrincipal(identity);
+    StateHasChanged();
+    Console.WriteLine("logged in");
+  }
+
+  public void HandleLogout()
+  {
+    var identity = new ClaimsIdentity();
+    CurrentUserService.CurrentUser = new System.Security.Claims.ClaimsPrincipal(identity);
+    StateHasChanged();
+  }
+}

--- a/Samples/BlazorExample/BlazorExample/Client/Shared/NavMenu.razor
+++ b/Samples/BlazorExample/BlazorExample/Client/Shared/NavMenu.razor
@@ -22,16 +22,33 @@
         <span class="oi oi-list-rich" aria-hidden="true"></span> Fetch data
       </NavLink>
     </li>
-    <li class="nav-item px-3">
-      <NavLink class="nav-link" href="editperson">
-        <span class="oi oi-list-rich" aria-hidden="true"></span> Add person
-      </NavLink>
-    </li>
+    <AuthorizeView>
+      <li class="nav-item px-3">
+        <NavLink class="nav-link" href="editperson">
+          <span class="oi oi-list-rich" aria-hidden="true"></span> Add person
+        </NavLink>
+      </li>
+    </AuthorizeView>
     <li class="nav-item px-3">
       <NavLink class="nav-link" href="listpersons">
         <span class="oi oi-list-rich" aria-hidden="true"></span> List people
       </NavLink>
     </li>
+    <li>
+      <AuthorizeView>
+        <Authorized>
+          <NavLink class="nav-link" href="login">
+            <span class="oi oi-person" aria-hidden="true"></span> Logout
+          </NavLink>
+        </Authorized>
+        <NotAuthorized>
+          <NavLink class="nav-link" href="login">
+            <span class="oi oi-person" aria-hidden="true"></span> Login
+          </NavLink>
+        </NotAuthorized>
+      </AuthorizeView>
+    </li>
+    
   </ul>
 </div>
 

--- a/Samples/BlazorExample/BlazorExample/Client/Startup.cs
+++ b/Samples/BlazorExample/BlazorExample/Client/Startup.cs
@@ -1,5 +1,6 @@
 using Csla;
 using Csla.Configuration;
+using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Builder;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -12,14 +13,28 @@ namespace BlazorExample.Client
       services.AddCsla();
       services.AddTransient(typeof(IDataPortal<>), typeof(DataPortal<>));
       services.AddTransient(typeof(Csla.Blazor.ViewModel<>), typeof(Csla.Blazor.ViewModel<>));
+
+      services.AddAuthorizationCore();
+      services.AddSingleton<AuthenticationStateProvider, CurrentUserAuthenticationStateProvider>();
+      services.AddSingleton<CurrentUserService>();
+
     }
 
     public void Configure(IComponentsApplicationBuilder app)
     {
       app.AddComponent<App>("app");
 
+      // detect when the authentication state changes, and update Csla ApplicationContext.User
+      var authStateProvider = app.Services.GetRequiredService<AuthenticationStateProvider>();
+      authStateProvider.AuthenticationStateChanged += AuthStateProvider_AuthenticationStateChanged;
+
       app.UseCsla((c) =>
         c.DataPortal().DefaultProxy(typeof(Csla.DataPortalClient.HttpProxy), "/api/DataPortal"));
+    }
+
+    private void AuthStateProvider_AuthenticationStateChanged(System.Threading.Tasks.Task<AuthenticationState> task)
+    {
+      Csla.ApplicationContext.User = task.Result.User;
     }
   }
 }

--- a/Samples/BlazorExample/BlazorExample/Client/_Imports.razor
+++ b/Samples/BlazorExample/BlazorExample/Client/_Imports.razor
@@ -2,7 +2,10 @@
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.JSInterop
 @using BlazorExample.Client
 @using BlazorExample.Client.Shared
+@using System.Security.Claims
+@using Microsoft.AspNetCore.Authorization
 @using Csla.AspNetCore.Razor.TagHelpers

--- a/Samples/BlazorExample/BlazorExample/Client/_Imports.razor
+++ b/Samples/BlazorExample/BlazorExample/Client/_Imports.razor
@@ -8,4 +8,3 @@
 @using BlazorExample.Client.Shared
 @using System.Security.Claims
 @using Microsoft.AspNetCore.Authorization
-@using Csla.AspNetCore.Razor.TagHelpers


### PR DESCRIPTION
This adds Authentication and Authorisation the blazor sample as suggested in #1370
There is a remaining issue I'll mention at the end.
First the changes:

- Added a item to the menu that displays "Login" or "Logout" based on your authentication status. When you click it, it navigates you to a new /login page.

![image](https://user-images.githubusercontent.com/3176632/66644880-f75e4a00-ec19-11e9-90de-0ec7f1950fa8.png)

- The login page, displays a (functional) Login or Logout button based on your authentication state:

![image](https://user-images.githubusercontent.com/3176632/66644892-0644fc80-ec1a-11e9-9034-2edbf3918532.png)

- The existing "Add Person" menu item - now only displays after you login:

![image](https://user-images.githubusercontent.com/3176632/66645000-40160300-ec1a-11e9-9b2b-d476c4371b54.png)

The corresponding "EditPerson" page is now protetced with an 'Authorize` attribute - meaning if you try to navigate directly to it, and you aren't logged in, it now will display this:

![image](https://user-images.githubusercontent.com/3176632/66645107-7f445400-ec1a-11e9-9e67-bb7add5999c8.png)

## Remaining Issue

Blazor's `AuthenticationStateProvider` works with `ClaimsPrincipal` and `ClaimsIdentity`. Now that the sample uses a ClaimsPrincipal - and sets Csla's ApplicationContext.User to this ClaimsPrincipal - the CSLA pages now error stating that the Principal doesn't work with MobileFormatter as it doesn't derive from a CSLA base class.

@rockfordlhotka given that `ClaimsPrincipal` is so staple in the landscape now, do you think it would be worth extending MobileFormatter to support ClaimsPrincipal directly?





