### PR TITLE
#37 - Fixes for the blazor sample.

### DIFF
--- a/Samples/BlazorExample/BlazorExample/Client/Pages/EditPerson.razor
+++ b/Samples/BlazorExample/BlazorExample/Client/Pages/EditPerson.razor
@@ -3,7 +3,7 @@
 @using BlazorExample.Shared
 @inject Csla.Blazor.ViewModel<PersonEdit> vm
 @inject NavigationManager NavigationManager
-@attribute [Authorize]
+@attribute [Authorize(Roles="Admin")]
 
 <h1>Edit Person</h1>
 

--- a/Samples/BlazorExample/BlazorExample/Client/Pages/Login.razor
+++ b/Samples/BlazorExample/BlazorExample/Client/Pages/Login.razor
@@ -9,6 +9,14 @@
     <p>You are logged in.</p>
     <span></span>
     <button class="btn btn-primary" @onclick="HandleLogout">Logout</button>
+    <h2>Claims</h2>
+    <ul>
+      @foreach (var claim in AuthState.Result.User.Claims)
+      {
+      <li><p><span>@claim.Type</span>: <span>@claim.Value</span>: <span>@claim.ValueType</span></p></li>
+      }
+    </ul>
+   
   </Authorized>
   <NotAuthorized>
     <button class="btn btn-primary" @onclick="HandleLogin">Login</button>
@@ -17,29 +25,29 @@
 
 @code {
 
-  [CascadingParameter]
-  public Task<AuthenticationState> AuthState { get; set; }
+      [CascadingParameter]
+      public Task<AuthenticationState> AuthState { get; set; }
 
-  public void HandleLogin()
-  {
-    Console.WriteLine("logging in");
-    var claims = new Claim[]
-    {
+      public void HandleLogin()
+      {
+        Console.WriteLine("logging in");
+        var claims = new Claim[]
+        {
         new Claim(ClaimTypes.Name, "Test User"),
         new Claim(ClaimTypes.Role, "Admin"),
-    };
+      };
 
-    var identity = new ClaimsIdentity(claims, "Test", ClaimTypes.Name, ClaimTypes.Role);
+      var identity = new ClaimsIdentity(claims, "Test", ClaimTypes.Name, ClaimTypes.Role);
 
-    CurrentUserService.CurrentUser = new System.Security.Claims.ClaimsPrincipal(identity);
-    StateHasChanged();
-    Console.WriteLine("logged in");
-  }
+      CurrentUserService.CurrentUser = new System.Security.Claims.ClaimsPrincipal(identity);
+      StateHasChanged();
+      Console.WriteLine("logged in");
+    }
 
-  public void HandleLogout()
-  {
-    var identity = new ClaimsIdentity();
-    CurrentUserService.CurrentUser = new System.Security.Claims.ClaimsPrincipal(identity);
-    StateHasChanged();
-  }
+    public void HandleLogout()
+    {
+      var identity = new ClaimsIdentity();
+      CurrentUserService.CurrentUser = new System.Security.Claims.ClaimsPrincipal(identity);
+      StateHasChanged();
+    }
 }

--- a/Samples/BlazorExample/BlazorExample/Client/Startup.cs
+++ b/Samples/BlazorExample/BlazorExample/Client/Startup.cs
@@ -34,8 +34,8 @@ namespace BlazorExample.Client
 
     private void AuthStateProvider_AuthenticationStateChanged(System.Threading.Tasks.Task<AuthenticationState> task)
     {
-      Csla.Security.CslaClaimsPrincipal cslaPrincipal = new Csla.Security.CslaClaimsPrincipal(task.Result.User);
-      Csla.ApplicationContext.User = cslaPrincipal;
+      var cslaPrincipal = new Csla.Security.CslaClaimsPrincipal(task.Result.User);
+      ApplicationContext.User = cslaPrincipal;
     }
   }
 }

--- a/Samples/BlazorExample/BlazorExample/Client/Startup.cs
+++ b/Samples/BlazorExample/BlazorExample/Client/Startup.cs
@@ -34,7 +34,8 @@ namespace BlazorExample.Client
 
     private void AuthStateProvider_AuthenticationStateChanged(System.Threading.Tasks.Task<AuthenticationState> task)
     {
-      Csla.ApplicationContext.User = task.Result.User;
+      Csla.Security.CslaClaimsPrincipal cslaPrincipal = new Csla.Security.CslaClaimsPrincipal(task.Result.User);
+      Csla.ApplicationContext.User = cslaPrincipal;
     }
   }
 }

--- a/Samples/BlazorExample/BlazorExample/Server/BlazorExample.Server.csproj
+++ b/Samples/BlazorExample/BlazorExample/Server/BlazorExample.Server.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Csla.AspNetCore" Version="5.1.0-R19100901" />
+    <PackageReference Include="Csla.AspNetCore" Version="5.1.0-R19101002" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="3.0.0-preview9.19424.4" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.0" />

--- a/Samples/BlazorExample/BlazorExample/Server/Program.cs
+++ b/Samples/BlazorExample/BlazorExample/Server/Program.cs
@@ -13,6 +13,10 @@ namespace BlazorExample.Server
 
     public static IWebHost BuildWebHost(string[] args) =>
         WebHost.CreateDefaultBuilder(args)
+            .ConfigureKestrel(o =>
+            {
+              o.AllowSynchronousIO = false;
+            })
             .UseConfiguration(new ConfigurationBuilder()
                 .AddCommandLine(args)
                 .Build())

--- a/Samples/BlazorExample/BlazorExample/Server/Program.cs
+++ b/Samples/BlazorExample/BlazorExample/Server/Program.cs
@@ -15,7 +15,7 @@ namespace BlazorExample.Server
         WebHost.CreateDefaultBuilder(args)
             .ConfigureKestrel(o =>
             {
-              o.AllowSynchronousIO = false;
+              o.AllowSynchronousIO = true;
             })
             .UseConfiguration(new ConfigurationBuilder()
                 .AddCommandLine(args)

--- a/Samples/BlazorExample/BlazorExample/Server/Startup.cs
+++ b/Samples/BlazorExample/BlazorExample/Server/Startup.cs
@@ -2,6 +2,7 @@ using Csla.Configuration;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.ResponseCompression;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json.Serialization;
@@ -15,6 +16,12 @@ namespace BlazorExample.Server
     // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
     public void ConfigureServices(IServiceCollection services)
     {
+      // If using Kestrel:
+      services.Configure<KestrelServerOptions>(options =>
+      {
+        options.AllowSynchronousIO = true;
+      });
+
       services.AddMvc().AddNewtonsoftJson();
       services.AddResponseCompression(opts =>
       {

--- a/Samples/BlazorExample/BlazorExample/Server/Startup.cs
+++ b/Samples/BlazorExample/BlazorExample/Server/Startup.cs
@@ -16,12 +16,6 @@ namespace BlazorExample.Server
     // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
     public void ConfigureServices(IServiceCollection services)
     {
-      // If using Kestrel:
-      services.Configure<KestrelServerOptions>(options =>
-      {
-        options.AllowSynchronousIO = true;
-      });
-
       services.AddMvc().AddNewtonsoftJson();
       services.AddResponseCompression(opts =>
       {


### PR DESCRIPTION
Fixes for #1373 

This PR addresses 2 issues with the blazor sample.

1. When setting `ApplicationContext.User` is now uses `CslaClaimsPrincipal`. This allows the pages in the sample to work and not throw errors bubbling up from MobileFormatter.

2. It seems `HttpDataPortalController` must do some stuff (perhaps serialization) that writes to the io stream synchronously. Because when I run the blazor sample and visit a page that does a DP operation, I get the error reported here: https://github.com/aspnet/AspNetCore/issues/7644
To address this, rather than fix the underlying issue with the sychronous io in the code, I have simply configured Kestrel in Program.Main() to turn that setting to allow synchronous IO back on.

With these two changes, the sample seems fully functional again.

I also made a slight tweak to the /login page - when logged in it will now list your claims.
