### PR TITLE
Templates init update

### DIFF
--- a/NuGet/Definition/tools/init.ps1
+++ b/NuGet/Definition/tools/init.ps1
@@ -14,7 +14,7 @@ param($installPath, $toolsPath, $package, $project)
 		Copy-Item $files -Destination $destination
 	}
 	
-	$vsVersions = @("2010", "2012", "2013", "2015")
+	$vsVersions = @("2010", "2012", "2013", "2015", "2017", "2019")
 	$cslaFolder = "Csla"
 	$sourceSnippetsCS = "$toolsPath\Snippets\cs\*.snippet"
 	$sourceSnippetsVB = "$toolsPath\Snippets\Vb\*.snippet"

--- a/NuGet/Definition/tools/uninstall.ps1
+++ b/NuGet/Definition/tools/uninstall.ps1
@@ -1,6 +1,6 @@
 param($installPath, $toolsPath, $package, $project)
 
-	$vsVersions = @("2010", "2012", "2013", "2015")
+	$vsVersions = @("2010", "2012", "2013", "2015", "2017", "2019")
 	$cslaFolder = "Csla"
 	$destinationDocumentsRoot = [System.Environment]::GetFolderPath( "MyDocuments" );
 


### PR DESCRIPTION
Issue : #752 
This will fix the nuget installation scripts to allow for the newer versions of visual studio.  I'm not sure that we could do it any differently, unless we began adding version directories for the snippets.  I will look into that, but this will fix the install for now.