### PR TITLE
Di changes

### DIFF
--- a/Source/Csla.AspNetCore.Shared/ApplicationContextManager.cs
+++ b/Source/Csla.AspNetCore.Shared/ApplicationContextManager.cs
@@ -25,7 +25,7 @@ namespace Csla.AspNetCore
     private const string _clientContextName = "Csla.ClientContext";
     private const string _globalContextName = "Csla.GlobalContext";
 
-    private readonly IServiceProvider _serviceProvider;
+    private IServiceProvider _serviceProvider;
 
     /// <summary>
     /// Creates an instance of the object, initializing it
@@ -146,7 +146,9 @@ namespace Csla.AspNetCore
     /// </summary>
     public IServiceProvider GetDefaultServiceProvider()
     {
-      return HttpContext?.RequestServices;
+      // on aspnet core we proactively detect request scope, before falling back to root application scope.
+      // this saves users from having to SetServiceProvider() at the start of every request.
+      return HttpContext?.RequestServices ?? _serviceProvider;
     }
 
     /// <summary>
@@ -155,23 +157,24 @@ namespace Csla.AspNetCore
     /// <param name="serviceProvider">IServiceProvider instance</param>
     public void SetDefaultServiceProvider(IServiceProvider serviceProvider)
     {
-      /* ignore value - we get the one from HttpContext */
+      // Service provider to be used as fallback when there is no more specific scoped service provider available.
+      _serviceProvider = serviceProvider;
     }
 
     /// <summary>
-    /// Gets the service provider scope
+    /// Gets the service provider for current scope
     /// </summary>
     /// <returns></returns>
-    public IServiceScope GetServiceProviderScope()
+    public IServiceProvider GetServiceProvider()
     {
-      return (IServiceScope)ApplicationContext.LocalContext["__sps"];
+      return (IServiceProvider)ApplicationContext.LocalContext["__sps"] ?? GetDefaultServiceProvider();
     }
 
     /// <summary>
-    /// Sets the service provider scope
+    /// Sets the service provider for current scope
     /// </summary>
-    /// <param name="scope">IServiceScope instance</param>
-    public void SetServiceProviderScope(IServiceScope scope)
+    /// <param name="scope">IServiceProvider instance</param>
+    public void SetServiceProvider(IServiceProvider scope)
     {
       Csla.ApplicationContext.LocalContext["__sps"] = scope;
     }

--- a/Source/Csla.Shared/ApplicationContext.cs
+++ b/Source/Csla.Shared/ApplicationContext.cs
@@ -14,6 +14,7 @@ using Csla.Core;
 using Csla.Configuration;
 #if !NET40 && !NET45
 using Microsoft.Extensions.DependencyInjection;
+using Csla.Properties;
 #endif
 
 namespace Csla
@@ -849,21 +850,15 @@ namespace Csla
     /// Sets the service provider scope for this application context.
     /// </summary>
 #pragma warning disable CS3003 // Type is not CLS-compliant
-    public static IServiceScope ServiceProviderScope
+    public static IServiceProvider ServiceProviderScope
 #pragma warning restore CS3003 // Type is not CLS-compliant
     {
       internal get
       {
-        var result = _contextManager.GetServiceProviderScope();
-        if (result == null && DefaultServiceProvider != null)
-        {
-          var scopeFactory = DefaultServiceProvider.GetRequiredService<IServiceScopeFactory>();
-          result = scopeFactory.CreateScope();
-          ServiceProviderScope = result;
-        }
-        return result;
+        var result = _contextManager.GetServiceProvider();
+        return result;       
       }
-      set => _contextManager.SetServiceProviderScope(value);
+      set => _contextManager.SetServiceProvider(value);
     }
 
     /// <summary>
@@ -874,7 +869,7 @@ namespace Csla
       get
       {
         if (ServiceProviderScope != null)
-          return ServiceProviderScope.ServiceProvider;
+          return ServiceProviderScope;
         else
           return null;
       }

--- a/Source/Csla.Shared/Configuration/Fluent/CslaConfiguration.cs
+++ b/Source/Csla.Shared/Configuration/Fluent/CslaConfiguration.cs
@@ -160,7 +160,7 @@ namespace Csla.Configuration
     /// </summary>
     /// <param name="scope">IServiceScope instance</param>
 #pragma warning disable CS3001 // Argument type is not CLS-compliant
-    public CslaConfiguration ServiceProviderScope(IServiceScope scope)
+    public CslaConfiguration ServiceProviderScope(IServiceProvider scope)
 #pragma warning restore CS3001 // Argument type is not CLS-compliant
     {
       ApplicationContext.ServiceProviderScope = scope;

--- a/Source/Csla.Shared/Core/ApplicationContextManager.cs
+++ b/Source/Csla.Shared/Core/ApplicationContextManager.cs
@@ -170,22 +170,22 @@ namespace Csla.Core
 
 #if !NET40 && !NET45
     /// <summary>
-    /// Gets the service provider scope
+    /// Gets the service provider for current scope
     /// </summary>
     /// <returns></returns>
 #pragma warning disable CS3002 // Return type is not CLS-compliant
-    public IServiceScope GetServiceProviderScope()
+    public IServiceProvider GetServiceProvider()
 #pragma warning restore CS3002 // Return type is not CLS-compliant
     {
-      return (IServiceScope)ApplicationContext.LocalContext["__sps"];
+      return (IServiceProvider)ApplicationContext.LocalContext["__sps"] ?? GetDefaultServiceProvider();
     }
 
     /// <summary>
-    /// Sets the service provider scope
+    /// Sets the service provider for current scope
     /// </summary>
-    /// <param name="scope">IServiceScope instance</param>
+    /// <param name="scope">IServiceProvider instance</param>
 #pragma warning disable CS3001 // Argument type is not CLS-compliant
-    public void SetServiceProviderScope(IServiceScope scope)
+    public void SetServiceProvider(IServiceProvider scope)
 #pragma warning restore CS3001 // Argument type is not CLS-compliant
     {
       Csla.ApplicationContext.LocalContext["__sps"] = scope;

--- a/Source/Csla.Shared/Core/ApplicationContextManagerTls.cs
+++ b/Source/Csla.Shared/Core/ApplicationContextManagerTls.cs
@@ -151,22 +151,22 @@ namespace Csla.Core
 
 #if !NET40 && !NET45
     /// <summary>
-    /// Gets the service provider scope
+    /// Gets the service provider for current scope
     /// </summary>
     /// <returns></returns>
 #pragma warning disable CS3002 // Return type is not CLS-compliant
-    public IServiceScope GetServiceProviderScope()
+    public IServiceProvider GetServiceProvider()
 #pragma warning restore CS3002 // Return type is not CLS-compliant
     {
-      return (IServiceScope)ApplicationContext.LocalContext["__sps"];
+      return (IServiceProvider)ApplicationContext.LocalContext["__sps"] ?? GetDefaultServiceProvider();
     }
 
     /// <summary>
-    /// Sets the service provider scope
+    /// Sets the service provider for current scope
     /// </summary>
-    /// <param name="scope">IServiceScope instance</param>
+    /// <param name="scope">IServiceProvider instance</param>
 #pragma warning disable CS3001 // Argument type is not CLS-compliant
-    public void SetServiceProviderScope(IServiceScope scope)
+    public void SetServiceProvider(IServiceProvider scope)
 #pragma warning restore CS3001 // Argument type is not CLS-compliant
     {
       Csla.ApplicationContext.LocalContext["__sps"] = scope;

--- a/Source/Csla.Shared/Core/IContextManager.cs
+++ b/Source/Csla.Shared/Core/IContextManager.cs
@@ -72,17 +72,17 @@ namespace Csla.Core
     void SetDefaultServiceProvider(IServiceProvider serviceProvider);
 #if !NET40 && !NET45
     /// <summary>
-    /// Gets the service provider scope
+    /// Gets the service provider scope for current scope.
     /// </summary>
 #pragma warning disable CS3002 // Return type is not CLS-compliant
-    IServiceScope GetServiceProviderScope();
+    IServiceProvider GetServiceProvider();
 #pragma warning restore CS3002 // Return type is not CLS-compliant
     /// <summary>
-    /// Sets the service provider scope
+    /// Sets the service provider for current scope.
     /// </summary>
-    /// <param name="scope">IServiceScope instance</param>
+    /// <param name="scope">IServiceProvider instance</param>
 #pragma warning disable CS3001 // Argument type is not CLS-compliant
-    void SetServiceProviderScope(IServiceScope scope);
+    void SetServiceProvider(IServiceProvider scope);
 #pragma warning restore CS3001 // Argument type is not CLS-compliant
 #endif
   }

--- a/Source/Csla.Shared/Reflection/ServiceProviderMethodCaller.cs
+++ b/Source/Csla.Shared/Reflection/ServiceProviderMethodCaller.cs
@@ -403,14 +403,17 @@ namespace Csla.Reflection
         int index = 0;
         int criteriaIndex = 0;
 #if !NET40 && !NET45
-        var service = ApplicationContext.ScopedServiceProvider;        
+        var service = ApplicationContext.ScopedServiceProvider;   
+        if(service == null)
+        {
+           throw new InvalidOperationException();
+        }
 #endif
         foreach (var item in method.Parameters)
         {
           if (method.IsInjected[index])
           {
-#if !NET40 && !NET45
-            if (service != null)
+#if !NET40 && !NET45           
               plist[index] = service.GetService(item.ParameterType);
 #endif
           }

--- a/Source/Csla.Shared/Server/DataPortal.cs
+++ b/Source/Csla.Shared/Server/DataPortal.cs
@@ -744,18 +744,6 @@ namespace Csla.Server
 
     private void ClearContext(DataPortalContext context)
     {
-#if !NET40 && !NET45
-      if (_oldLocation == ApplicationContext.LogicalExecutionLocations.Client)
-      {
-        var scope = ApplicationContext.ServiceProviderScope;
-        if (scope != null)
-        {
-          ApplicationContext.ServiceProviderScope = null;
-          scope.Dispose();
-        }
-      }
-#endif
-
       ApplicationContext.SetLogicalExecutionLocation(_oldLocation);
       // if the dataportal is not remote then
       // do nothing

--- a/Source/Csla.Web.Shared/ApplicationContextManager.cs
+++ b/Source/Csla.Web.Shared/ApplicationContextManager.cs
@@ -27,13 +27,15 @@ namespace Csla.Web
     private const string _clientContextName = "Csla.ClientContext";
     private const string _globalContextName = "Csla.GlobalContext";
 
+    private IServiceProvider _defaultServiceProvider = null;
+
     /// <summary>
     /// Gets a value indicating whether this
     /// context manager is valid for use in
     /// the current environment.
     /// </summary>
-    public bool IsValid 
-    { 
+    public bool IsValid
+    {
       get { return HttpContext.Current != null; }
     }
 
@@ -116,11 +118,7 @@ namespace Csla.Web
     /// </summary>
     public IServiceProvider GetDefaultServiceProvider()
     {
-      IServiceProvider result;
-      result = (IServiceProvider)Csla.ApplicationContext.LocalContext["__dsp"];
-      if (result == null)
-        result = GetDefaultServiceProvider();
-      return result;
+      return _defaultServiceProvider;
     }
 
     /// <summary>
@@ -129,24 +127,24 @@ namespace Csla.Web
     /// <param name="serviceProvider">IServiceProvider instance</param>
     public void SetDefaultServiceProvider(IServiceProvider serviceProvider)
     {
-      Csla.ApplicationContext.LocalContext["__dsp"] = serviceProvider;
+      _defaultServiceProvider = serviceProvider;
     }
 
 #if !NET40 && !NET45
     /// <summary>
-    /// Gets the service provider scope
+    /// Gets the service provider for current scope
     /// </summary>
     /// <returns></returns>
-    public IServiceScope GetServiceProviderScope()
+    public IServiceProvider GetServiceProvider()
     {
-      return (IServiceScope)ApplicationContext.LocalContext["__sps"];
+      return (IServiceProvider)ApplicationContext.LocalContext["__sps"] ?? GetDefaultServiceProvider();
     }
 
     /// <summary>
-    /// Sets the service provider scope
+    /// Sets the service provider for current scope
     /// </summary>
-    /// <param name="scope">IServiceScope instance</param>
-    public void SetServiceProviderScope(IServiceScope scope)
+    /// <param name="scope">IServiceProvider instance</param>
+    public void SetServiceProvider(IServiceProvider scope)
     {
       Csla.ApplicationContext.LocalContext["__sps"] = scope;
     }

--- a/Source/Csla.test/AppContext/TestContext.cs
+++ b/Source/Csla.test/AppContext/TestContext.cs
@@ -96,19 +96,19 @@ namespace Csla.Test.AppContext
     }
 
     /// <summary>
-    /// Gets the service provider scope
+    /// Gets the service provider for current scope
     /// </summary>
     /// <returns></returns>
-    public IServiceScope GetServiceProviderScope()
+    public IServiceProvider GetServiceProvider()
     {
-      return (IServiceScope)ApplicationContext.LocalContext["__sps"];
+      return (IServiceProvider)ApplicationContext.LocalContext["__sps"];
     }
 
     /// <summary>
-    /// Sets the service provider scope
+    /// Sets the service provider for current scope
     /// </summary>
-    /// <param name="scope">IServiceScope instance</param>
-    public void SetServiceProviderScope(IServiceScope scope)
+    /// <param name="scope">IServiceProvider instance</param>
+    public void SetServiceProvider(IServiceProvider scope)
     {
       Csla.ApplicationContext.LocalContext["__sps"] = scope;
     }

--- a/Source/csla.netcore.test/DataPortal/ServiceProviderInvocationTests.cs
+++ b/Source/csla.netcore.test/DataPortal/ServiceProviderInvocationTests.cs
@@ -41,8 +41,7 @@ namespace Csla.Test.DataPortal
       var obj = new TestMethods();
       var method = new ServiceProviderMethodInfo { MethodInfo = obj.GetType().GetMethod("Method1") };
       Assert.IsNotNull(method, "needed method");
-      var result = (bool) await ServiceProviderMethodCaller.CallMethodTryAsync(obj, method, new object[] { 123 });
-      Assert.IsTrue(result);
+      await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () => await ServiceProviderMethodCaller.CallMethodTryAsync(obj, method, new object[] { 123 }));      
     }
 
     [TestMethod]
@@ -75,12 +74,12 @@ namespace Csla.Test.DataPortal
 
   public class TestMethods
   {
-    public bool Method1(int id, [Inject]ISpeak speaker)
+    public bool Method1(int id, [Inject] ISpeak speaker)
     {
       return speaker == null;
     }
 
-    public string GetSpeech(int id, [Inject]ISpeak speaker)
+    public string GetSpeech(int id, [Inject] ISpeak speaker)
     {
       return speaker.Speak();
     }


### PR DESCRIPTION
Reminder: Make sure to review CONTRIBUTING.MD and make sure you've sent in your signed contributor agreement.

Issue: https://github.com/MarimerLLC/csla/issues/1874

This PR:

- CSLA is no longer responsible for creating or disposing DI scopes.
- CSLA is given a "default" IServiceProvider - which it will use as a "fallback" if there is not "scope" specific IServiceProvider set in LocalContext. 
- The aspnet core version of ContextManager , has an additional fallback which saves the user having to set the IServiceProvider for the current request, the precedence goes:
    `var currentSp = LocalContext ?? HttpContext.RequestServices ?? _defaultSp;` - same concept for the System.Web version.

- Because CSLA doesn't ever create a scope, it doesn't ever need to dispose a scope either.

NOTE: I have been unable to run the tests on my local VS.. - all sorts therefore may be broken - but this hopefully is enough to discuss whether its worth polishing off.

- I throw an exception on @inject with a null service provider - but I have not added a resx error message.. I am not fluent in many languages..

