### PR TITLE
Throw exception when service provider is null on inject

### DIFF
--- a/Source/Csla.Shared/Reflection/ServiceProviderMethodCaller.cs
+++ b/Source/Csla.Shared/Reflection/ServiceProviderMethodCaller.cs
@@ -410,9 +410,11 @@ namespace Csla.Reflection
           if (method.IsInjected[index])
           {
 #if !NET40 && !NET45
-            if (service != null)
-              plist[index] = service.GetService(item.ParameterType);
-            //throw new InjectException(obj.GetType().Name + "." + info.Name + " " + Resources.MethodInjectFailed);
+            if (service == null)
+            {
+              throw new NullReferenceException(nameof(service));
+            }
+            plist[index] = service.GetService(item.ParameterType);
 
 #endif
           }

--- a/Source/csla.netcore.test/DataPortal/ServiceProviderInvocationTests.cs
+++ b/Source/csla.netcore.test/DataPortal/ServiceProviderInvocationTests.cs
@@ -41,10 +41,7 @@ namespace Csla.Test.DataPortal
       var obj = new TestMethods();
       var method = new ServiceProviderMethodInfo { MethodInfo = obj.GetType().GetMethod("Method1") };
       Assert.IsNotNull(method, "needed method");
-      var result = (bool)await ServiceProviderMethodCaller.CallMethodTryAsync(obj, method, new object[] { 123 });
-      Assert.IsTrue(result);
-
-     // await Assert.ThrowsExceptionAsync<InjectException>(async () => await ServiceProviderMethodCaller.CallMethodTryAsync(obj, method, new object[] { 123 }));      
+      await Assert.ThrowsExceptionAsync<NullReferenceException>(async () => await ServiceProviderMethodCaller.CallMethodTryAsync(obj, method, new object[] { 123 }));
     }
 
     [TestMethod]


### PR DESCRIPTION
Closes #1874 

Throw an exception if inject attribute is used and no service provider is available on injection.
