### PR TITLE
Add pdb files to nuspec

### DIFF
--- a/NuGet/Definition/Core.NuSpec
+++ b/NuGet/Definition/Core.NuSpec
@@ -70,12 +70,16 @@ Supports the creation of Class Library projects containing business domain class
   <files>
     <!-- NetStandard 2.0 Assembly -->
     <file src="..\..\bin\Release\netstandard\netstandard2.0\**\Csla.dll*" target="lib\netstandard2.0" />
-    <file src="..\..\bin\Release\netstandard\netstandard2.0\**\Csla.xml*" target="lib\netstandard2.0" />
+    <file src="..\..\bin\Release\netstandard\netstandard2.0\**\Csla.pdb*" target="lib\netstandard2.0" />
     <file src="..\..\bin\Release\netstandard\netstandard2.0\**\Csla.resources.dll*" target="lib\netstandard2.0" />
+    <file src="..\..\bin\Release\netstandard\netstandard2.0\**\Csla.resources.pdb*" target="lib\netstandard2.0" />
+    <file src="..\..\bin\Release\netstandard\netstandard2.0\**\Csla.xml*" target="lib\netstandard2.0" />
     <!-- Net 5.0 Assembly -->
     <file src="..\..\bin\Release\netstandard\net5.0\**\Csla.dll*" target="lib\net5.0" />
-    <file src="..\..\bin\Release\netstandard\net5.0\**\Csla.xml*" target="lib\net5.0" />
+    <file src="..\..\bin\Release\netstandard\net5.0\**\Csla.pdb*" target="lib\net5.0" />
     <file src="..\..\bin\Release\netstandard\net5.0\**\Csla.resources.dll*" target="lib\net5.0" />
+    <file src="..\..\bin\Release\netstandard\net5.0\**\Csla.resources.pdb*" target="lib\net5.0" />
+    <file src="..\..\bin\Release\netstandard\net5.0\**\Csla.xml*" target="lib\net5.0" />
     <!-- .NET 4.0 Client -->
     <file src="..\..\Bin\Release\NET4\**\Csla.dll*" target="lib\net40" />
     <file src="..\..\Bin\Release\NET4\**\Csla.pdb*" target="lib\net40" />

--- a/NuGet/Definition/MonoAndroid.NuSpec
+++ b/NuGet/Definition/MonoAndroid.NuSpec
@@ -26,7 +26,7 @@ Supports the creation of Xamarin Android applications.
   </metadata>
   <files>
     <!-- Xamarin Android Client -->
-    <file src="..\..\Bin\Release\Android\**\Csla.Axml." target="lib\MonoAndroid10" />
+    <file src="..\..\Bin\Release\Android\**\Csla.Axml.*" target="lib\MonoAndroid10" />
     <!-- icon -->
     <file src="..\..\Support\Logos\csla.png" target="images\" />
   </files>

--- a/NuGet/Push All.ps1
+++ b/NuGet/Push All.ps1
@@ -31,15 +31,15 @@ try
     Write-Host "Publish all CLSA .NET NuGet packages" -ForegroundColor White
     Write-Host "====================================" -ForegroundColor White
     
-    ## Get list of packages (without ".symbols.") from Packages folder
+    ## Get list of packages (without ".snupkg") from Packages folder
     ## ---------------------------------------------------------------
     Write-Host "Get list of packages..." -ForegroundColor Yellow
-    $packages = Get-ChildItem $pathToNuGetPackageOutput -Exclude "*.symbols.*"
+    $packages = Get-ChildItem $pathToNuGetPackageOutput -Exclude "*.snupkg"
     
     ## Spawn off individual publish processes...
     ## -----------------------------------------
     Write-Host "Publishing packages..." -ForegroundColor Yellow
-    $packages | ForEach-Object { & $pathToNuGetPackager Push "$_" -Source https://www.nuget.org/api/v2/package }
+    $packages | ForEach-Object { & $pathToNuGetPackager Push "$_" -Source https://api.nuget.org/v3/index.json }
     Write-Host "Publish all done." -ForegroundColor Green
 }
 catch 

--- a/Source/Csla.Analyzers/Csla.Analyzers/Csla.Analyzers.csproj
+++ b/Source/Csla.Analyzers/Csla.Analyzers/Csla.Analyzers.csproj
@@ -17,6 +17,8 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <OutputPath>..\..\..\Bin\Release\netstandard\</OutputPath>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Csla.AspNetCore.Mvc2.NetStandard2.0/Csla.AspNetCore.Mvc2.NetStandard2.0.csproj
+++ b/Source/Csla.AspNetCore.Mvc2.NetStandard2.0/Csla.AspNetCore.Mvc2.NetStandard2.0.csproj
@@ -24,6 +24,8 @@
     <OutputPath>..\..\Bin\Release\netstandard\</OutputPath>
     <DocumentationFile>..\..\Bin\Release\netstandard\netstandard2.0\Csla.AspNetCore.Mvc.xml</DocumentationFile>
     <DefineConstants>TRACE;NETSTANDARD2_0</DefineConstants>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Source/Csla.AspNetCore.NetCore3.1/Csla.AspNetCore.NetCore3.1.csproj
+++ b/Source/Csla.AspNetCore.NetCore3.1/Csla.AspNetCore.NetCore3.1.csproj
@@ -24,6 +24,8 @@
     <OutputPath>..\..\Bin\Release\netstandard\</OutputPath>
     <DocumentationFile>..\..\Bin\Release\netstandard\netcoreapp3.1\Csla.AspNetCore.xml</DocumentationFile>
     <DefineConstants>TRACE;NETCORE3_1</DefineConstants>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU' and '$(TargetFramework)' == 'netcoreapp3.1'">
@@ -34,6 +36,8 @@
     <OutputPath>..\..\Bin\Release\netstandard\</OutputPath>
     <DocumentationFile>..\..\Bin\Release\netstandard\net5.0\Csla.AspNetCore.xml</DocumentationFile>
     <DefineConstants>TRACE</DefineConstants>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <Import Project="..\Csla.Web.Mvc.Shared\Csla.Web.Mvc.Shared.projitems" Label="Shared" />

--- a/Source/Csla.Axml.Android/Csla.Axml.Android.csproj
+++ b/Source/Csla.Axml.Android/Csla.Axml.Android.csproj
@@ -36,13 +36,14 @@
     <DocumentationFile>..\..\Bin\Debug\Android\Csla.Axml.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\Android\</OutputPath>
     <DefineConstants>TRACE;ANDROID</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\Android\Csla.Axml.XML</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/Source/Csla.Blazor.WebAssembly/Csla.Blazor.WebAssembly.csproj
+++ b/Source/Csla.Blazor.WebAssembly/Csla.Blazor.WebAssembly.csproj
@@ -24,6 +24,8 @@
     <OutputPath>..\..\Bin\Release\netstandard\</OutputPath>
     <DocumentationFile>..\..\Bin\Release\netstandard\netstandard2.1\Csla.Blazor.WebAssembly.xml</DocumentationFile>
     <DefineConstants>TRACE;BLAZOR</DefineConstants>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Source/Csla.Blazor/Csla.Blazor.csproj
+++ b/Source/Csla.Blazor/Csla.Blazor.csproj
@@ -24,6 +24,8 @@
     <OutputPath>..\..\Bin\Release\netstandard\</OutputPath>
     <DocumentationFile>..\..\Bin\Release\netstandard\netstandard2.1\Csla.Blazor.xml</DocumentationFile>
     <DefineConstants>TRACE;BLAZOR</DefineConstants>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Source/Csla.Channels.Grpc/Csla.Channels.Grpc.csproj
+++ b/Source/Csla.Channels.Grpc/Csla.Channels.Grpc.csproj
@@ -24,6 +24,8 @@
     <DefineConstants>TRACE;NETSTANDARD2_0</DefineConstants>
     <OutputPath>..\..\Bin\Release\netstandard\</OutputPath>
     <DocumentationFile>..\..\Bin\Release\netstandard\netstandard2.1\Csla.Channels.Grpc.xml</DocumentationFile>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Source/Csla.Channels.RabbitMq/Csla.Channels.RabbitMq.csproj
+++ b/Source/Csla.Channels.RabbitMq/Csla.Channels.RabbitMq.csproj
@@ -22,6 +22,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <OutputPath>..\..\Bin\Release\netstandard\</OutputPath>
     <DocumentationFile>..\..\Bin\Release\netstandard\netstandard2.0\Csla.Channels.RabbitMq.xml</DocumentationFile>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Csla.Data.EF4.Net4.5/Csla.Data.EF4.Net4.5.csproj
+++ b/Source/Csla.Data.EF4.Net4.5/Csla.Data.EF4.Net4.5.csproj
@@ -31,13 +31,14 @@
     <DocumentationFile>..\..\Bin\Debug\NET45\Csla.Data.EF4.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET45\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\NET45\Csla.Data.EF4.XML</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/Source/Csla.Data.EF4.Net4.6/Csla.Data.EF4.Net4.6.csproj
+++ b/Source/Csla.Data.EF4.Net4.6/Csla.Data.EF4.Net4.6.csproj
@@ -29,13 +29,14 @@
     <DocumentationFile>..\..\Bin\Debug\NET46\Csla.Data.EF4.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET46\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\NET46\Csla.Data.EF4.xml</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/Source/Csla.Data.EF4.Net4/Csla.Data.EF4.Net4.csproj
+++ b/Source/Csla.Data.EF4.Net4/Csla.Data.EF4.Net4.csproj
@@ -31,13 +31,14 @@
     <DocumentationFile>..\..\Bin\Debug\NET4\Csla.Data.EF4.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET4\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\NET4\Csla.Data.EF4.XML</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/Source/Csla.Data.EF5.Net4.5/Csla.Data.EF5.Net4.5.csproj
+++ b/Source/Csla.Data.EF5.Net4.5/Csla.Data.EF5.Net4.5.csproj
@@ -31,13 +31,14 @@
     <DocumentationFile>..\..\Bin\Debug\NET45\Csla.Data.EF5.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET45\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\NET45\Csla.Data.EF5.XML</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/Source/Csla.Data.EF5.Net4.6/Csla.Data.EF5.Net4.6.csproj
+++ b/Source/Csla.Data.EF5.Net4.6/Csla.Data.EF5.Net4.6.csproj
@@ -29,13 +29,14 @@
     <DocumentationFile>..\..\Bin\Debug\NET46\Csla.Data.EF5.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET46\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\NET46\Csla.Data.EF5.XML</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/Source/Csla.Data.EF5.Net4/Csla.Data.EF5.Net4.csproj
+++ b/Source/Csla.Data.EF5.Net4/Csla.Data.EF5.Net4.csproj
@@ -31,13 +31,14 @@
     <DocumentationFile>..\..\Bin\Debug\NET4\Csla.Data.EF5.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET4\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\NET4\Csla.Data.EF5.xml</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/Source/Csla.Data.EF6.Net4.5/Csla.Data.EF6.Net4.5.csproj
+++ b/Source/Csla.Data.EF6.Net4.5/Csla.Data.EF6.Net4.5.csproj
@@ -31,13 +31,14 @@
     <DocumentationFile>..\..\Bin\Debug\NET45\Csla.Data.EF6.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET45\</OutputPath>
     <DefineConstants>TRACE;EF6</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\NET45\Csla.Data.EF6.xml</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/Source/Csla.Data.EF6.Net4.6/Csla.Data.EF6.Net4.6.csproj
+++ b/Source/Csla.Data.EF6.Net4.6/Csla.Data.EF6.Net4.6.csproj
@@ -30,13 +30,14 @@
     <DocumentationFile>..\..\Bin\Debug\NET46\Csla.Data.EF6.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET46\</OutputPath>
     <DefineConstants>TRACE;EF6</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\NET46\Csla.Data.EF6.XML</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/Source/Csla.Data.EF6.Net4/Csla.Data.EF6.Net4.csproj
+++ b/Source/Csla.Data.EF6.Net4/Csla.Data.EF6.Net4.csproj
@@ -31,13 +31,14 @@
     <DocumentationFile>..\..\Bin\Debug\NET4\Csla.Data.EF6.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET4\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\NET4\Csla.Data.EF6.xml</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/Source/Csla.Data.EFCore.2.0/Csla.Data.EFCore.2.0.csproj
+++ b/Source/Csla.Data.EFCore.2.0/Csla.Data.EFCore.2.0.csproj
@@ -26,6 +26,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <OutputPath>..\..\Bin\Release\netstandard\</OutputPath>
     <DocumentationFile>..\..\Bin\Release\netstandard\netstandard2.0\Csla.Data.EntityFrameworkCore.xml</DocumentationFile>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Csla.Data.EFCore.3.0/Csla.Data.EFCore.3.0.csproj
+++ b/Source/Csla.Data.EFCore.3.0/Csla.Data.EFCore.3.0.csproj
@@ -26,6 +26,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <OutputPath>..\..\Bin\Release\netstandard\</OutputPath>
     <DocumentationFile>..\..\Bin\Release\netstandard\netstandard2.1\Csla.Data.EntityFrameworkCore.xml</DocumentationFile>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Csla.Data.SqlClient.Fx/Csla.Data.SqlClient.Fx.csproj
+++ b/Source/Csla.Data.SqlClient.Fx/Csla.Data.SqlClient.Fx.csproj
@@ -29,6 +29,8 @@
     <DefineConstants>TRACE;NETSTANDARD2_0;NETFX</DefineConstants>
     <OutputPath>..\..\Bin\Release\netstandard\</OutputPath>
     <DocumentationFile>..\..\Bin\Release\netstandard\netstandard2.0\Csla.Data.SqlClient.Fx.xml</DocumentationFile>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Csla.Data.SqlClient/Csla.Data.SqlClient.csproj
+++ b/Source/Csla.Data.SqlClient/Csla.Data.SqlClient.csproj
@@ -23,6 +23,8 @@
     <DefineConstants>TRACE;NETSTANDARD2_0</DefineConstants>
     <OutputPath>..\..\Bin\Release\netstandard\</OutputPath>
     <DocumentationFile>..\..\Bin\Release\netstandard\netstandard2.0\Csla.Data.SqlClient.xml</DocumentationFile>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Source/Csla.Iosui.Ios/Csla.Iosui.Ios.csproj
+++ b/Source/Csla.Iosui.Ios/Csla.Iosui.Ios.csproj
@@ -33,7 +33,7 @@
     <DocumentationFile>..\..\Bin\Debug\iOS\Csla.Iosui.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>none</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\iOS\</OutputPath>
     <ErrorReport>prompt</ErrorReport>
@@ -42,6 +42,7 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <DocumentationFile>..\..\Bin\Release\iOS\Csla.Iosui.XML</DocumentationFile>
     <DefineConstants>IOS</DefineConstants>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Csla.Xaml.Shared\ExecuteEventArgs.cs">

--- a/Source/Csla.Net4.5/Csla.Net4.5.csproj
+++ b/Source/Csla.Net4.5/Csla.Net4.5.csproj
@@ -54,7 +54,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET45\</OutputPath>
     <DefineConstants>NET45</DefineConstants>

--- a/Source/Csla.Net4.6/Csla.Net4.6.csproj
+++ b/Source/Csla.Net4.6/Csla.Net4.6.csproj
@@ -54,7 +54,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET46\</OutputPath>
     <DefineConstants>NET46</DefineConstants>

--- a/Source/Csla.Net4/Csla.Net4.csproj
+++ b/Source/Csla.Net4/Csla.Net4.csproj
@@ -54,7 +54,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET4\</OutputPath>
     <DefineConstants>NET40</DefineConstants>

--- a/Source/Csla.Net5.0/Csla.Net5.0.csproj
+++ b/Source/Csla.Net5.0/Csla.Net5.0.csproj
@@ -27,6 +27,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <OutputPath>..\..\Bin\Release\netstandard\</OutputPath>
     <DocumentationFile>..\..\Bin\Release\netstandard\net5.0\Csla.xml</DocumentationFile>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <Target Name="PrecompileScript" BeforeTargets="BeforeBuild">

--- a/Source/Csla.NetStandard2.0/Csla.NetStandard2.0.csproj
+++ b/Source/Csla.NetStandard2.0/Csla.NetStandard2.0.csproj
@@ -27,6 +27,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <OutputPath>..\..\Bin\Release\netstandard\</OutputPath>
     <DocumentationFile>..\..\Bin\Release\netstandard\netstandard2.0\Csla.xml</DocumentationFile>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <Target Name="PrecompileScript" BeforeTargets="BeforeBuild">

--- a/Source/Csla.Validation.Android/Csla.Validation.Android.csproj
+++ b/Source/Csla.Validation.Android/Csla.Validation.Android.csproj
@@ -35,13 +35,14 @@
     <DocumentationFile>..\..\Bin\Debug\Android\Csla.Validation.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\Android\</OutputPath>
     <DefineConstants>TRACE;__ANDROID__,SILVERLIGHT,WINDOWS_PHONE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\Android\Csla.Validation.xml</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Android" />

--- a/Source/Csla.Validation.Ios/Csla.Validation.Ios.csproj
+++ b/Source/Csla.Validation.Ios/Csla.Validation.Ios.csproj
@@ -33,7 +33,7 @@
     <DocumentationFile>..\..\bin\Debug\ios\Csla.Validation.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>none</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\iOS\</OutputPath>
     <ErrorReport>prompt</ErrorReport>
@@ -42,6 +42,7 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <DefineConstants>__UNIFIED__;__MOBILE__;__IOS__;SILVERLIGHT;WINDOWS_PHONE;__IOS__</DefineConstants>
     <DocumentationFile>..\..\Bin\Release\iOS\Csla.Validation.XML</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Source/Csla.Validation.Net4.5/Csla.Validation.Net4.5.csproj
+++ b/Source/Csla.Validation.Net4.5/Csla.Validation.Net4.5.csproj
@@ -29,13 +29,14 @@
     <DocumentationFile>..\..\Bin\Debug\NET45\Csla.Validation.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET45\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\NET45\Csla.Validation.XML</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/Source/Csla.Validation.Net4.6/Csla.Validation.Net4.6.csproj
+++ b/Source/Csla.Validation.Net4.6/Csla.Validation.Net4.6.csproj
@@ -29,13 +29,14 @@
     <DocumentationFile>..\..\Bin\Debug\NET46\Csla.Validation.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET46\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\NET46\Csla.Validation.XML</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/Source/Csla.Validation.Net4/Csla.Validation.Net4.csproj
+++ b/Source/Csla.Validation.Net4/Csla.Validation.Net4.csproj
@@ -31,13 +31,14 @@
     <DocumentationFile>..\..\Bin\Debug\NET4\Csla.Validation.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET4\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\NET4\Csla.Validation.XML</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/Source/Csla.Validation.Uwp/Csla.Validation.Uwp.csproj
+++ b/Source/Csla.Validation.Uwp/Csla.Validation.Uwp.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\UWP\</OutputPath>
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
@@ -39,6 +39,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\UWP\Csla.Validation.XML</DocumentationFile>
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <PlatformTarget>ARM</PlatformTarget>

--- a/Source/Csla.Web.Mvc4.Net4.5/Csla.Web.Mvc4.Net4.5.csproj
+++ b/Source/Csla.Web.Mvc4.Net4.5/Csla.Web.Mvc4.Net4.5.csproj
@@ -36,7 +36,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET45\</OutputPath>
     <DefineConstants>TRACE;MVC4</DefineConstants>

--- a/Source/Csla.Web.Mvc4.Net4.6/Csla.Web.Mvc4.Net4.6.csproj
+++ b/Source/Csla.Web.Mvc4.Net4.6/Csla.Web.Mvc4.Net4.6.csproj
@@ -29,13 +29,14 @@
     <DocumentationFile>..\..\Bin\Debug\NET46\Csla.Web.Mvc4.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET46\</OutputPath>
     <DefineConstants>TRACE;MVC4</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\NET46\Csla.Web.Mvc4.XML</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/Source/Csla.Web.Mvc4.Net4/Csla.Web.Mvc4.Net4.csproj
+++ b/Source/Csla.Web.Mvc4.Net4/Csla.Web.Mvc4.Net4.csproj
@@ -28,13 +28,14 @@
     <DocumentationFile>..\..\Bin\Debug\NET4\Csla.Web.Mvc4.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET4\</OutputPath>
     <DefineConstants>TRACE;MVC4</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\NET4\Csla.Web.Mvc4.XML</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/Source/Csla.Web.Mvc5.Net4.5/Csla.Web.Mvc5.Net4.5.csproj
+++ b/Source/Csla.Web.Mvc5.Net4.5/Csla.Web.Mvc5.Net4.5.csproj
@@ -31,13 +31,14 @@
     <DocumentationFile>..\..\Bin\Debug\NET45\Csla.Web.Mvc5.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET45\</OutputPath>
     <DefineConstants>TRACE;MVC5</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\NET45\Csla.Web.Mvc5.XML</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Source/Csla.Web.Mvc5.Net4.6/Csla.Web.Mvc5.Net4.6.csproj
+++ b/Source/Csla.Web.Mvc5.Net4.6/Csla.Web.Mvc5.Net4.6.csproj
@@ -29,13 +29,14 @@
     <DocumentationFile>..\..\Bin\Debug\NET46\Csla.Web.Mvc5.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET46\</OutputPath>
     <DefineConstants>TRACE;MVC5</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\NET46\Csla.Web.Mvc5.XML</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/Source/Csla.Web.Net4.5/Csla.Web.Net4.5.csproj
+++ b/Source/Csla.Web.Net4.5/Csla.Web.Net4.5.csproj
@@ -34,7 +34,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET45\</OutputPath>
     <DefineConstants>TRACE;NET45</DefineConstants>

--- a/Source/Csla.Web.Net4.6/Csla.Web.Net4.6.csproj
+++ b/Source/Csla.Web.Net4.6/Csla.Web.Net4.6.csproj
@@ -29,13 +29,14 @@
     <DocumentationFile>..\..\Bin\Debug\NET46\Csla.Web.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET46\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\NET46\Csla.Web.xml</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/Source/Csla.Web.Net4/Csla.Web.Net4.csproj
+++ b/Source/Csla.Web.Net4/Csla.Web.Net4.csproj
@@ -28,13 +28,14 @@
     <DocumentationFile>..\..\Bin\Debug\NET4\Csla.Web.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET4\</OutputPath>
     <DefineConstants>TRACE;NET40</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\NET4\Csla.Web.XML</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/Source/Csla.Windows.Net4.5/Csla.Windows.Net4.5.csproj
+++ b/Source/Csla.Windows.Net4.5/Csla.Windows.Net4.5.csproj
@@ -35,7 +35,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET45\</OutputPath>
     <DefineConstants>TRACE;NET45</DefineConstants>

--- a/Source/Csla.Windows.Net4.6/Csla.Windows.Net4.6.csproj
+++ b/Source/Csla.Windows.Net4.6/Csla.Windows.Net4.6.csproj
@@ -30,13 +30,14 @@
     <DocumentationFile>..\..\Bin\Debug\NET46\Csla.Windows.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET46\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\NET46\Csla.Windows.XML</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/Source/Csla.Windows.Net4/Csla.Windows.Net4.csproj
+++ b/Source/Csla.Windows.Net4/Csla.Windows.Net4.csproj
@@ -36,7 +36,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET4\</OutputPath>
     <DefineConstants>TRACE;NET40</DefineConstants>

--- a/Source/Csla.Windows.NetCoreApp3.0/Csla.Windows.NetCoreApp3.0.csproj
+++ b/Source/Csla.Windows.NetCoreApp3.0/Csla.Windows.NetCoreApp3.0.csproj
@@ -24,11 +24,15 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU' and '$(TargetFramework)' == 'netcoreapp3.1'">
     <OutputPath>..\..\Bin\Release\netstandard\</OutputPath>
     <DocumentationFile>..\..\Bin\Release\netstandard\netcoreapp3.1\Csla.Windows.xml</DocumentationFile>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU' and '$(TargetFramework)' == 'net5.0-windows10.0.19041.0'">
     <OutputPath>..\..\Bin\Release\netstandard\</OutputPath>
     <DocumentationFile>..\..\Bin\Release\netstandard\net5.0-windows10.0.19041.0\Csla.Windows.xml</DocumentationFile>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <Import Project="..\Csla.Windows.Shared\Csla.Windows.Shared.projitems" Label="Shared" />

--- a/Source/Csla.Xaml.Net4.5/Csla.Xaml.Net4.5.csproj
+++ b/Source/Csla.Xaml.Net4.5/Csla.Xaml.Net4.5.csproj
@@ -35,7 +35,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET45\</OutputPath>
     <DefineConstants>TRACE;NET45</DefineConstants>

--- a/Source/Csla.Xaml.Net4.6/Csla.Xaml.Net4.6.csproj
+++ b/Source/Csla.Xaml.Net4.6/Csla.Xaml.Net4.6.csproj
@@ -29,13 +29,14 @@
     <DocumentationFile>..\..\Bin\Debug\NET46\Csla.Xaml.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET46\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\NET46\Csla.Xaml.XML</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/Source/Csla.Xaml.Net4/Csla.Xaml.Net4.csproj
+++ b/Source/Csla.Xaml.Net4/Csla.Xaml.Net4.csproj
@@ -36,7 +36,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\NET4\</OutputPath>
     <DefineConstants>TRACE;NET40</DefineConstants>

--- a/Source/Csla.Xaml.NetCoreApp3.0/Csla.Xaml.NetCoreApp3.0.csproj
+++ b/Source/Csla.Xaml.NetCoreApp3.0/Csla.Xaml.NetCoreApp3.0.csproj
@@ -16,11 +16,15 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU' and '$(TargetFramework)' == 'netcoreapp3.1'">
     <OutputPath>..\..\Bin\Release\netstandard\</OutputPath>
     <DocumentationFile>..\..\Bin\Release\netstandard\netcoreapp3.1\Csla.Xaml.xml</DocumentationFile>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU' and '$(TargetFramework)' == 'net5.0-windows10.0.19041.0'">
     <OutputPath>..\..\Bin\Release\netstandard\</OutputPath>
     <DocumentationFile>..\..\Bin\Release\netstandard\net5.0-windows10.0.19041.0\Csla.Xaml.xml</DocumentationFile>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <Import Project="..\Csla.Xaml.Shared\Csla.Xaml.Shared.projitems" Label="Shared" />

--- a/Source/Csla.Xaml.Uwp/Csla.Xaml.Uwp.csproj
+++ b/Source/Csla.Xaml.Uwp/Csla.Xaml.Uwp.csproj
@@ -30,13 +30,14 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\Bin\Release\UWP\</OutputPath>
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Bin\Release\UWP\Csla.Xaml.xml</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <PlatformTarget>x86</PlatformTarget>

--- a/Source/Csla.Xaml.Xamarin/Csla.Xaml.Xamarin.csproj
+++ b/Source/Csla.Xaml.Xamarin/Csla.Xaml.Xamarin.csproj
@@ -25,6 +25,8 @@
     <DefineConstants>TRACE;XAMARIN</DefineConstants>
     <OutputPath>..\..\Bin\Release\Xamarin\</OutputPath>
     <DocumentationFile>..\..\Bin\Release\Xamarin\netstandard2.0\Csla.Xaml.xml</DocumentationFile>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #1997

I believe the `netstandard2.0` and `net5.0` were missing entries in the `.nuspec` file that will include the *.pdb files.

Updated `Core.NuSpec`.

N.B. I need to sign the contributor agreement.