### PR TITLE
Lock to avoid concurrency issue when initializing static fields on a type

### DIFF
--- a/Source/Csla.Shared/Core/FieldManager/FieldDataManager.cs
+++ b/Source/Csla.Shared/Core/FieldManager/FieldDataManager.cs
@@ -764,18 +764,21 @@ namespace Csla.Core.FieldManager
     /// <param name="type">Type of object to initialize.</param>
     public static void ForceStaticFieldInit(Type type)
     {
-      var attr =
+      const BindingFlags attr =
         BindingFlags.Static |
         BindingFlags.Public |
         BindingFlags.DeclaredOnly |
         BindingFlags.NonPublic;
-      var t = type;
-      while (t != null)
+      lock (type)
       {
-        var fields = t.GetFields(attr);
-        if (fields.Length > 0)
-          fields[0].GetValue(null);
-        t = t.BaseType;
+        var t = type;
+        while (t != null)
+        {
+          var fields = t.GetFields(attr);
+          if (fields.Length > 0)
+            fields[0].GetValue(null);
+          t = t.BaseType;
+        }
       }
     }
   }


### PR DESCRIPTION
Closes #2022 Lock to avoid concurrency issue when initializing static fields on a type
