### PR TITLE
#1311 Consolidate base code for data portal proxy types

### DIFF
--- a/Source/Csla.Channels.Grpc/GrpcPortal.cs
+++ b/Source/Csla.Channels.Grpc/GrpcPortal.cs
@@ -15,7 +15,7 @@ using Csla.Core;
 using Csla.Serialization;
 using Csla.Serialization.Mobile;
 using Csla.Server;
-using Csla.Server.Hosts.HttpChannel;
+using Csla.Server.Hosts.DataPortalChannel;
 using Google.Protobuf;
 using Grpc.Core;
 
@@ -49,7 +49,7 @@ namespace Csla.Channels.Grpc
 
     /// <summary>
     /// Gets a dictionary containing the URLs for each
-    /// data portal route, where each key is the 
+    /// data portal route, where each key is the
     /// routing tag identifying the route URL.
     /// </summary>
     protected static Dictionary<string, string> RoutingTagUrls = new Dictionary<string, string>();
@@ -82,8 +82,8 @@ namespace Csla.Channels.Grpc
 
     private async Task<ResponseMessage> InvokePortal(string operation, ByteString requestData)
     {
-      var result = new HttpResponse();
-      HttpErrorInfo errorData = null;
+      var result = new DataPortalResponse();
+      DataPortalErrorInfo errorData = null;
       try
       {
         var request = SerializationFormatterFactory.GetFormatter().Deserialize(requestData.ToByteArray());
@@ -91,30 +91,34 @@ namespace Csla.Channels.Grpc
       }
       catch (Exception ex)
       {
-        errorData = new HttpErrorInfo(ex);
+        errorData = new DataPortalErrorInfo(ex);
       }
-      var portalResult = new HttpResponse { ErrorData = errorData, GlobalContext = result.GlobalContext, ObjectData = result.ObjectData };
+      var portalResult = new DataPortalResponse { ErrorData = errorData, GlobalContext = result.GlobalContext, ObjectData = result.ObjectData };
       var buffer = SerializationFormatterFactory.GetFormatter().Serialize(portalResult);
       return new ResponseMessage { Body = ByteString.CopyFrom(buffer) };
     }
 
-    private async Task<HttpResponse> CallPortal(string operation, object request)
+    private async Task<DataPortalResponse> CallPortal(string operation, object request)
     {
-      HttpResponse result;
+      DataPortalResponse result;
       switch (operation)
       {
         case "create":
           result = await Create((CriteriaRequest)request).ConfigureAwait(false);
           break;
+
         case "fetch":
           result = await Fetch((CriteriaRequest)request).ConfigureAwait(false);
           break;
+
         case "update":
           result = await Update((UpdateRequest)request).ConfigureAwait(false);
           break;
+
         case "delete":
           result = await Delete((CriteriaRequest)request).ConfigureAwait(false);
           break;
+
         default:
           throw new InvalidOperationException(operation);
       }
@@ -125,9 +129,9 @@ namespace Csla.Channels.Grpc
     /// Create and initialize an existing business object.
     /// </summary>
     /// <param name="request">The request parameter object.</param>
-    public async Task<HttpResponse> Create(CriteriaRequest request)
+    public async Task<DataPortalResponse> Create(CriteriaRequest request)
     {
-      var result = new HttpResponse();
+      var result = new DataPortalResponse();
       try
       {
         request = ConvertRequest(request);
@@ -152,13 +156,13 @@ namespace Csla.Channels.Grpc
         var dpr = await prtl.Create(objectType, criteria, context, true);
 
         if (dpr.Error != null)
-          result.ErrorData = new HttpErrorInfo(dpr.Error);
+          result.ErrorData = new DataPortalErrorInfo(dpr.Error);
         result.GlobalContext = SerializationFormatterFactory.GetFormatter().Serialize(dpr.GlobalContext);
         result.ObjectData = SerializationFormatterFactory.GetFormatter().Serialize(dpr.ReturnObject);
       }
       catch (Exception ex)
       {
-        result.ErrorData = new HttpErrorInfo(ex);
+        result.ErrorData = new DataPortalErrorInfo(ex);
         throw;
       }
       finally
@@ -172,9 +176,9 @@ namespace Csla.Channels.Grpc
     /// Get an existing business object.
     /// </summary>
     /// <param name="request">The request parameter object.</param>
-    public async Task<HttpResponse> Fetch(CriteriaRequest request)
+    public async Task<DataPortalResponse> Fetch(CriteriaRequest request)
     {
-      var result = new HttpResponse();
+      var result = new DataPortalResponse();
       try
       {
         request = ConvertRequest(request);
@@ -199,13 +203,13 @@ namespace Csla.Channels.Grpc
         var dpr = await prtl.Fetch(objectType, criteria, context, true);
 
         if (dpr.Error != null)
-          result.ErrorData = new HttpErrorInfo(dpr.Error);
+          result.ErrorData = new DataPortalErrorInfo(dpr.Error);
         result.GlobalContext = SerializationFormatterFactory.GetFormatter().Serialize(dpr.GlobalContext);
         result.ObjectData = SerializationFormatterFactory.GetFormatter().Serialize(dpr.ReturnObject);
       }
       catch (Exception ex)
       {
-        result.ErrorData = new HttpErrorInfo(ex);
+        result.ErrorData = new DataPortalErrorInfo(ex);
         throw;
       }
       finally
@@ -219,9 +223,9 @@ namespace Csla.Channels.Grpc
     /// Update a business object.
     /// </summary>
     /// <param name="request">The request parameter object.</param>
-    public async Task<HttpResponse> Update(UpdateRequest request)
+    public async Task<DataPortalResponse> Update(UpdateRequest request)
     {
-      var result = new HttpResponse();
+      var result = new DataPortalResponse();
       try
       {
         request = ConvertRequest(request);
@@ -240,14 +244,14 @@ namespace Csla.Channels.Grpc
         var dpr = await prtl.Update(obj, context, true);
 
         if (dpr.Error != null)
-          result.ErrorData = new HttpErrorInfo(dpr.Error);
+          result.ErrorData = new DataPortalErrorInfo(dpr.Error);
 
         result.GlobalContext = SerializationFormatterFactory.GetFormatter().Serialize(dpr.GlobalContext);
         result.ObjectData = SerializationFormatterFactory.GetFormatter().Serialize(dpr.ReturnObject);
       }
       catch (Exception ex)
       {
-        result.ErrorData = new HttpErrorInfo(ex);
+        result.ErrorData = new DataPortalErrorInfo(ex);
         throw;
       }
       finally
@@ -261,9 +265,9 @@ namespace Csla.Channels.Grpc
     /// Delete a business object.
     /// </summary>
     /// <param name="request">The request parameter object.</param>
-    public async Task<HttpResponse> Delete(CriteriaRequest request)
+    public async Task<DataPortalResponse> Delete(CriteriaRequest request)
     {
-      var result = new HttpResponse();
+      var result = new DataPortalResponse();
       try
       {
         request = ConvertRequest(request);
@@ -288,13 +292,13 @@ namespace Csla.Channels.Grpc
         var dpr = await prtl.Delete(objectType, criteria, context, true);
 
         if (dpr.Error != null)
-          result.ErrorData = new HttpErrorInfo(dpr.Error);
+          result.ErrorData = new DataPortalErrorInfo(dpr.Error);
         result.GlobalContext = SerializationFormatterFactory.GetFormatter().Serialize(dpr.GlobalContext);
         result.ObjectData = SerializationFormatterFactory.GetFormatter().Serialize(dpr.ReturnObject);
       }
       catch (Exception ex)
       {
-        result.ErrorData = new HttpErrorInfo(ex);
+        result.ErrorData = new DataPortalErrorInfo(ex);
         throw;
       }
       finally
@@ -314,7 +318,7 @@ namespace Csla.Channels.Grpc
       return criteria;
     }
 
-    #endregion
+    #endregion Criteria
 
     #region Extention Method for Requests
 
@@ -343,11 +347,11 @@ namespace Csla.Channels.Grpc
     /// comes back from the network.
     /// </summary>
     /// <param name="response">Response object.</param>
-    protected virtual HttpResponse ConvertResponse(HttpResponse response)
+    protected virtual DataPortalResponse ConvertResponse(DataPortalResponse response)
     {
       return response;
     }
 
-    #endregion
+    #endregion Extention Method for Requests
   }
 }

--- a/Source/Csla.Channels.Grpc/GrpcProxy.cs
+++ b/Source/Csla.Channels.Grpc/GrpcProxy.cs
@@ -24,23 +24,8 @@ namespace Csla.Channels.Grpc
   /// Implements a data portal proxy to relay data portal
   /// calls to a remote application server by using gRPC.
   /// </summary>
-  public class GrpcProxy : IDataPortalProxy
+  public class GrpcProxy : DataPortalProxy
   {
-    /// <summary>
-    /// Gets or sets the HttpClient timeout
-    /// in milliseconds (0 uses default HttpClient timeout).
-    /// </summary>
-    public int Timeout { get; set; }
-
-    /// <summary>
-    /// Creates an instance of the object, initializing
-    /// it to use the DefaultUrl 
-    /// values.
-    /// </summary>
-    public GrpcProxy()
-      : this(null, ApplicationContext.DataPortalUrlString)
-    { }
-
     /// <summary>
     /// Creates an instance of the object, initializing
     /// it to use the supplied URL.
@@ -71,12 +56,6 @@ namespace Csla.Channels.Grpc
       DataPortalUrl = dataPortalUrl;
     }
 
-    /// <summary>
-    /// Gets the URL address for the data portal server
-    /// used by this proxy instance.
-    /// </summary>
-    public string DataPortalUrl { get; protected set; }
-
     private GrpcChannel _channel;
     private static GrpcChannel _defaultChannel;
 
@@ -88,8 +67,7 @@ namespace Csla.Channels.Grpc
     {
       if (_channel == null)
       {
-        if (_defaultChannel == null)
-          _defaultChannel = GrpcChannel.ForAddress(DataPortalUrl);
+        _defaultChannel ??= GrpcChannel.ForAddress(DataPortalUrl);
         _channel = _defaultChannel;
       }
       return _channel;
@@ -112,230 +90,10 @@ namespace Csla.Channels.Grpc
     /// <returns></returns>
     protected virtual GrpcService.GrpcServiceClient GetGrpcClient()
     {
-      if (_grpcClient == null)
-        _grpcClient = new GrpcService.GrpcServiceClient(GetChannel());
-      return _grpcClient;
+      return _grpcClient ??= new GrpcService.GrpcServiceClient(GetChannel());
     }
 
-    /// <summary>
-    /// Gets a value indicating whether the data portal
-    /// is hosted on a remote server.
-    /// </summary>
-    public bool IsServerRemote => true;
-
-    /// <summary>
-    /// Called by <see cref="DataPortal" /> to create a
-    /// new business object.
-    /// </summary>
-    /// <param name="objectType">Type of business object to create.</param>
-    /// <param name="criteria">Criteria object describing business object.</param>
-    /// <param name="context">DataPortalContext object passed to the server.</param>
-    /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public async Task<DataPortalResult> Create(Type objectType, object criteria, DataPortalContext context, bool isSync)
-    {
-      DataPortalResult result;
-      try
-      {
-        var request = GetBaseCriteriaRequest();
-        request.TypeName = AssemblyNameTranslator.GetAssemblyQualifiedName(objectType.AssemblyQualifiedName);
-        if (!(criteria is IMobileObject))
-        {
-          criteria = new PrimitiveCriteria(criteria);
-        }
-        request.CriteriaData = SerializationFormatterFactory.GetFormatter().Serialize(criteria);
-        request = ConvertRequest(request);
-
-        var serialized = SerializationFormatterFactory.GetFormatter().Serialize(request);
-
-        serialized = await CallDataPortalServer(serialized, "create", GetRoutingToken(objectType), isSync);
-
-        var response = (Csla.Server.Hosts.HttpChannel.HttpResponse)SerializationFormatterFactory.GetFormatter().Deserialize(serialized);
-        response = ConvertResponse(response);
-        var globalContext = (ContextDictionary)SerializationFormatterFactory.GetFormatter().Deserialize(response.GlobalContext);
-        if (response != null && response.ErrorData == null)
-        {
-          var obj = SerializationFormatterFactory.GetFormatter().Deserialize(response.ObjectData);
-          result = new DataPortalResult(obj, null, globalContext);
-        }
-        else if (response != null && response.ErrorData != null)
-        {
-          var ex = new DataPortalException(response.ErrorData);
-          result = new DataPortalResult(null, ex, globalContext);
-        }
-        else
-        {
-          throw new DataPortalException("null response", null);
-        }
-      }
-      catch (Exception ex)
-      {
-        result = new DataPortalResult(null, ex, null);
-      }
-      if (result.Error != null)
-        throw result.Error;
-      return result;
-    }
-
-    /// <summary>
-    /// Called by <see cref="DataPortal" /> to load an
-    /// existing business object.
-    /// </summary>
-    /// <param name="objectType">Type of business object to create.</param>
-    /// <param name="criteria">Criteria object describing business object.</param>
-    /// <param name="context">
-    /// <see cref="Server.DataPortalContext" /> object passed to the server.
-    /// </param>
-    /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public async Task<DataPortalResult> Fetch(Type objectType, object criteria, DataPortalContext context, bool isSync)
-    {
-      DataPortalResult result;
-      try
-      {
-        var request = GetBaseCriteriaRequest();
-        request.TypeName = AssemblyNameTranslator.GetAssemblyQualifiedName(objectType.AssemblyQualifiedName);
-        if (!(criteria is IMobileObject))
-        {
-          criteria = new PrimitiveCriteria(criteria);
-        }
-        request.CriteriaData = SerializationFormatterFactory.GetFormatter().Serialize(criteria);
-        request = ConvertRequest(request);
-
-        var serialized = SerializationFormatterFactory.GetFormatter().Serialize(request);
-
-        serialized = await CallDataPortalServer(serialized, "fetch", GetRoutingToken(objectType), isSync);
-
-        var response = (Csla.Server.Hosts.HttpChannel.HttpResponse)SerializationFormatterFactory.GetFormatter().Deserialize(serialized);
-        response = ConvertResponse(response);
-        var globalContext = (ContextDictionary)SerializationFormatterFactory.GetFormatter().Deserialize(response.GlobalContext);
-        if (response != null && response.ErrorData == null)
-        {
-          var obj = SerializationFormatterFactory.GetFormatter().Deserialize(response.ObjectData);
-          result = new DataPortalResult(obj, null, globalContext);
-        }
-        else if (response != null && response.ErrorData != null)
-        {
-          var ex = new DataPortalException(response.ErrorData);
-          result = new DataPortalResult(null, ex, globalContext);
-        }
-        else
-        {
-          throw new DataPortalException("null response", null);
-        }
-      }
-      catch (Exception ex)
-      {
-        result = new DataPortalResult(null, ex, null);
-      }
-      if (result.Error != null)
-        throw result.Error;
-      return result;
-    }
-
-    /// <summary>
-    /// Called by <see cref="DataPortal" /> to update a
-    /// business object.
-    /// </summary>
-    /// <param name="obj">The business object to update.</param>
-    /// <param name="context">
-    /// <see cref="Server.DataPortalContext" /> object passed to the server.
-    /// </param>
-    /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public async Task<DataPortalResult> Update(object obj, DataPortalContext context, bool isSync)
-    {
-      DataPortalResult result;
-      try
-      {
-        var request = GetBaseUpdateCriteriaRequest();
-        request.ObjectData = SerializationFormatterFactory.GetFormatter().Serialize(obj);
-        request = ConvertRequest(request);
-
-        var serialized = SerializationFormatterFactory.GetFormatter().Serialize(request);
-
-        serialized = await CallDataPortalServer(serialized, "update", GetRoutingToken(obj.GetType()), isSync);
-
-        var response = (Csla.Server.Hosts.HttpChannel.HttpResponse)SerializationFormatterFactory.GetFormatter().Deserialize(serialized);
-        response = ConvertResponse(response);
-        var globalContext = (ContextDictionary)SerializationFormatterFactory.GetFormatter().Deserialize(response.GlobalContext);
-        if (response != null && response.ErrorData == null)
-        {
-          var newobj = SerializationFormatterFactory.GetFormatter().Deserialize(response.ObjectData);
-          result = new DataPortalResult(newobj, null, globalContext);
-        }
-        else if (response != null && response.ErrorData != null)
-        {
-          var ex = new DataPortalException(response.ErrorData);
-          result = new DataPortalResult(null, ex, globalContext);
-        }
-        else
-        {
-          throw new DataPortalException("null response", null);
-        }
-      }
-      catch (Exception ex)
-      {
-        result = new DataPortalResult(null, ex, null);
-      }
-      if (result.Error != null)
-        throw result.Error;
-      return result;
-    }
-
-    /// <summary>
-    /// Called by <see cref="DataPortal" /> to delete a
-    /// business object.
-    /// </summary>
-    /// <param name="objectType">Type of business object to create.</param>
-    /// <param name="criteria">Criteria object describing business object.</param>
-    /// <param name="context">
-    /// <see cref="Server.DataPortalContext" /> object passed to the server.
-    /// </param>
-    /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public async Task<DataPortalResult> Delete(Type objectType, object criteria, DataPortalContext context, bool isSync)
-    {
-      DataPortalResult result;
-      try
-      {
-
-        var request = GetBaseCriteriaRequest();
-        request.TypeName = AssemblyNameTranslator.GetAssemblyQualifiedName(objectType.AssemblyQualifiedName);
-        if (!(criteria is IMobileObject))
-        {
-          criteria = new PrimitiveCriteria(criteria);
-        }
-        request.CriteriaData = SerializationFormatterFactory.GetFormatter().Serialize(criteria);
-        request = ConvertRequest(request);
-
-        var serialized = SerializationFormatterFactory.GetFormatter().Serialize(request);
-
-        serialized = await CallDataPortalServer(serialized, "delete", GetRoutingToken(objectType), isSync);
-
-        var response = (Csla.Server.Hosts.HttpChannel.HttpResponse)SerializationFormatterFactory.GetFormatter().Deserialize(serialized);
-        response = ConvertResponse(response);
-        var globalContext = (ContextDictionary)SerializationFormatterFactory.GetFormatter().Deserialize(response.GlobalContext);
-        if (response != null && response.ErrorData == null)
-        {
-          result = new DataPortalResult(null, null, globalContext);
-        }
-        else if (response != null && response.ErrorData != null)
-        {
-          var ex = new DataPortalException(response.ErrorData);
-          result = new DataPortalResult(null, ex, globalContext);
-        }
-        else
-        {
-          throw new DataPortalException("null response", null);
-        }
-      }
-      catch (Exception ex)
-      {
-        result = new DataPortalResult(null, ex, null);
-      }
-      if (result.Error != null)
-        throw result.Error;
-      return result;
-    }
-
-    private async Task<byte[]> CallDataPortalServer(byte[] serialized, string operation, string routingToken, bool isSync)
+    protected override async Task<byte[]> CallDataPortalServer(byte[] serialized, string operation, string routingToken, bool isSync)
     {
       ByteString outbound = ByteString.CopyFrom(serialized);
       var request = new RequestMessage
@@ -360,93 +118,7 @@ namespace Csla.Channels.Grpc
     {
       if (!string.IsNullOrWhiteSpace(versionToken) || !string.IsNullOrWhiteSpace(routingToken))
         return $"{operatation}/{routingToken}-{versionToken}";
-      else
-        return operatation;
+      return operatation;
     }
-
-    private string GetRoutingToken(Type objectType)
-    {
-      string result = null;
-      var list = objectType.GetCustomAttributes(typeof(DataPortalServerRoutingTagAttribute), false);
-      if (list.Count() > 0)
-        result = ((DataPortalServerRoutingTagAttribute)list[0]).RoutingTag;
-      return result;
-    }
-
-    /// <summary>
-    /// Override this method to manipulate the message
-    /// request data sent to the server.
-    /// </summary>
-    /// <param name="request">Update request data.</param>
-    protected virtual Csla.Server.Hosts.HttpChannel.UpdateRequest ConvertRequest(Csla.Server.Hosts.HttpChannel.UpdateRequest request)
-    {
-      return request;
-    }
-
-    /// <summary>
-    /// Override this method to manipulate the message
-    /// request data sent to the server.
-    /// </summary>
-    /// <param name="request">Criteria request data.</param>
-    protected virtual Csla.Server.Hosts.HttpChannel.CriteriaRequest ConvertRequest(Csla.Server.Hosts.HttpChannel.CriteriaRequest request)
-    {
-      return request;
-    }
-
-    /// <summary>
-    /// Override this method to manipulate the message
-    /// request data returned from the server.
-    /// </summary>
-    /// <param name="response">Response data.</param>
-    protected virtual Csla.Server.Hosts.HttpChannel.HttpResponse ConvertResponse(Csla.Server.Hosts.HttpChannel.HttpResponse response)
-    {
-      return response;
-    }
-
-    #region Criteria
-
-    private Csla.Server.Hosts.HttpChannel.CriteriaRequest GetBaseCriteriaRequest()
-    {
-      var request = new Csla.Server.Hosts.HttpChannel.CriteriaRequest();
-      request.CriteriaData = null;
-      request.ClientContext = SerializationFormatterFactory.GetFormatter().Serialize(ApplicationContext.ClientContext);
-#pragma warning disable CS0618 // Type or member is obsolete
-      request.GlobalContext = SerializationFormatterFactory.GetFormatter().Serialize(ApplicationContext.GlobalContext);
-#pragma warning restore CS0618 // Type or member is obsolete
-      if (ApplicationContext.AuthenticationType == "Windows")
-      {
-        request.Principal = SerializationFormatterFactory.GetFormatter().Serialize(null);
-      }
-      else
-      {
-        request.Principal = SerializationFormatterFactory.GetFormatter().Serialize(ApplicationContext.User);
-      }
-      request.ClientCulture = System.Globalization.CultureInfo.CurrentCulture.Name;
-      request.ClientUICulture = System.Globalization.CultureInfo.CurrentUICulture.Name;
-      return request;
-    }
-
-    private Csla.Server.Hosts.HttpChannel.UpdateRequest GetBaseUpdateCriteriaRequest()
-    {
-      var request = new Csla.Server.Hosts.HttpChannel.UpdateRequest();
-      request.ObjectData = null;
-      request.ClientContext = SerializationFormatterFactory.GetFormatter().Serialize(ApplicationContext.ClientContext);
-#pragma warning disable CS0618 // Type or member is obsolete
-      request.GlobalContext = SerializationFormatterFactory.GetFormatter().Serialize(ApplicationContext.GlobalContext);
-#pragma warning restore CS0618 // Type or member is obsolete
-      if (ApplicationContext.AuthenticationType == "Windows")
-      {
-        request.Principal = SerializationFormatterFactory.GetFormatter().Serialize(null);
-      }
-      else
-      {
-        request.Principal = SerializationFormatterFactory.GetFormatter().Serialize(ApplicationContext.User);
-      }
-      request.ClientCulture = Thread.CurrentThread.CurrentCulture.Name;
-      request.ClientUICulture = Thread.CurrentThread.CurrentUICulture.Name;
-      return request;
-    }
-
-    #endregion
   }
 }

--- a/Source/Csla.Channels.RabbitMq/RabbitMqPortal.cs
+++ b/Source/Csla.Channels.RabbitMq/RabbitMqPortal.cs
@@ -12,7 +12,7 @@ using Csla.Core;
 using Csla.Serialization;
 using Csla.Serialization.Mobile;
 using Csla.Server;
-using Csla.Server.Hosts.HttpChannel;
+using Csla.Server.Hosts.DataPortalChannel;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 
@@ -110,7 +110,7 @@ namespace Csla.Channels.RabbitMq
 
     private async void InvokePortal(BasicDeliverEventArgs ea, byte[] requestData)
     {
-      var result = new HttpResponse();
+      var result = new DataPortalResponse();
       try
       {
         var request = SerializationFormatterFactory.GetFormatter().Deserialize(requestData);
@@ -118,7 +118,7 @@ namespace Csla.Channels.RabbitMq
       }
       catch (Exception ex)
       {
-        result.ErrorData = new HttpErrorInfo(ex);
+        result.ErrorData = new DataPortalErrorInfo(ex);
       }
 
       try
@@ -130,7 +130,7 @@ namespace Csla.Channels.RabbitMq
       {
         try
         {
-          result = new HttpResponse { ErrorData = new HttpErrorInfo(ex) };
+          result = new DataPortalResponse { ErrorData = new DataPortalErrorInfo(ex) };
           var response = SerializationFormatterFactory.GetFormatter().Serialize(result);
           SendMessage(ea.BasicProperties.ReplyTo, ea.BasicProperties.CorrelationId, response);
         }
@@ -153,9 +153,9 @@ namespace Csla.Channels.RabbitMq
         body: request);
     }
 
-    private async Task<HttpResponse> CallPortal(string operation, object request)
+    private async Task<DataPortalResponse> CallPortal(string operation, object request)
     {
-      HttpResponse result;
+      DataPortalResponse result;
       switch (operation)
       {
         case "create":
@@ -184,9 +184,9 @@ namespace Csla.Channels.RabbitMq
     /// Create and initialize an existing business object.
     /// </summary>
     /// <param name="request">The request parameter object.</param>
-    public async Task<HttpResponse> Create(CriteriaRequest request)
+    public async Task<DataPortalResponse> Create(CriteriaRequest request)
     {
-      var result = new HttpResponse();
+      var result = new DataPortalResponse();
       try
       {
         request = ConvertRequest(request);
@@ -211,13 +211,13 @@ namespace Csla.Channels.RabbitMq
         var dpr = await prtl.Create(objectType, criteria, context, true);
 
         if (dpr.Error != null)
-          result.ErrorData = new HttpErrorInfo(dpr.Error);
+          result.ErrorData = new DataPortalErrorInfo(dpr.Error);
         result.GlobalContext = SerializationFormatterFactory.GetFormatter().Serialize(dpr.GlobalContext);
         result.ObjectData = SerializationFormatterFactory.GetFormatter().Serialize(dpr.ReturnObject);
       }
       catch (Exception ex)
       {
-        result.ErrorData = new HttpErrorInfo(ex);
+        result.ErrorData = new DataPortalErrorInfo(ex);
         throw;
       }
       finally
@@ -231,9 +231,9 @@ namespace Csla.Channels.RabbitMq
     /// Get an existing business object.
     /// </summary>
     /// <param name="request">The request parameter object.</param>
-    public async Task<HttpResponse> Fetch(CriteriaRequest request)
+    public async Task<DataPortalResponse> Fetch(CriteriaRequest request)
     {
-      var result = new HttpResponse();
+      var result = new DataPortalResponse();
       try
       {
         request = ConvertRequest(request);
@@ -258,13 +258,13 @@ namespace Csla.Channels.RabbitMq
         var dpr = await prtl.Fetch(objectType, criteria, context, true);
 
         if (dpr.Error != null)
-          result.ErrorData = new HttpErrorInfo(dpr.Error);
+          result.ErrorData = new DataPortalErrorInfo(dpr.Error);
         result.GlobalContext = SerializationFormatterFactory.GetFormatter().Serialize(dpr.GlobalContext);
         result.ObjectData = SerializationFormatterFactory.GetFormatter().Serialize(dpr.ReturnObject);
       }
       catch (Exception ex)
       {
-        result.ErrorData = new HttpErrorInfo(ex);
+        result.ErrorData = new DataPortalErrorInfo(ex);
         throw;
       }
       finally
@@ -278,9 +278,9 @@ namespace Csla.Channels.RabbitMq
     /// Update a business object.
     /// </summary>
     /// <param name="request">The request parameter object.</param>
-    public async Task<HttpResponse> Update(UpdateRequest request)
+    public async Task<DataPortalResponse> Update(UpdateRequest request)
     {
-      var result = new HttpResponse();
+      var result = new DataPortalResponse();
       try
       {
         request = ConvertRequest(request);
@@ -299,14 +299,14 @@ namespace Csla.Channels.RabbitMq
         var dpr = await prtl.Update(obj, context, true);
 
         if (dpr.Error != null)
-          result.ErrorData = new HttpErrorInfo(dpr.Error);
+          result.ErrorData = new DataPortalErrorInfo(dpr.Error);
 
         result.GlobalContext = SerializationFormatterFactory.GetFormatter().Serialize(dpr.GlobalContext);
         result.ObjectData = SerializationFormatterFactory.GetFormatter().Serialize(dpr.ReturnObject);
       }
       catch (Exception ex)
       {
-        result.ErrorData = new HttpErrorInfo(ex);
+        result.ErrorData = new DataPortalErrorInfo(ex);
         throw;
       }
       finally
@@ -320,9 +320,9 @@ namespace Csla.Channels.RabbitMq
     /// Delete a business object.
     /// </summary>
     /// <param name="request">The request parameter object.</param>
-    public async Task<HttpResponse> Delete(CriteriaRequest request)
+    public async Task<DataPortalResponse> Delete(CriteriaRequest request)
     {
-      var result = new HttpResponse();
+      var result = new DataPortalResponse();
       try
       {
         request = ConvertRequest(request);
@@ -347,13 +347,13 @@ namespace Csla.Channels.RabbitMq
         var dpr = await prtl.Delete(objectType, criteria, context, true);
 
         if (dpr.Error != null)
-          result.ErrorData = new HttpErrorInfo(dpr.Error);
+          result.ErrorData = new DataPortalErrorInfo(dpr.Error);
         result.GlobalContext = SerializationFormatterFactory.GetFormatter().Serialize(dpr.GlobalContext);
         result.ObjectData = SerializationFormatterFactory.GetFormatter().Serialize(dpr.ReturnObject);
       }
       catch (Exception ex)
       {
-        result.ErrorData = new HttpErrorInfo(ex);
+        result.ErrorData = new DataPortalErrorInfo(ex);
         throw;
       }
       finally
@@ -402,7 +402,7 @@ namespace Csla.Channels.RabbitMq
     /// comes back from the network.
     /// </summary>
     /// <param name="response">Response object.</param>
-    protected virtual HttpResponse ConvertResponse(HttpResponse response)
+    protected virtual DataPortalResponse ConvertResponse(DataPortalResponse response)
     {
       return response;
     }

--- a/Source/Csla.Channels.RabbitMq/RabbitMqProxy.cs
+++ b/Source/Csla.Channels.RabbitMq/RabbitMqProxy.cs
@@ -21,7 +21,7 @@ namespace Csla.Channels.RabbitMq
   /// Implements a data portal proxy to relay data portal
   /// calls to a remote application server by using RabbitMQ.
   /// </summary>
-  public class RabbitMqProxy : IDataPortalProxy, IDisposable
+  public class RabbitMqProxy : DataPortalProxy, IDisposable
   {
     /// <summary>
     /// Creates an instance of the object, initializing
@@ -29,7 +29,6 @@ namespace Csla.Channels.RabbitMq
     /// </summary>
     public RabbitMqProxy()
     {
-      this.DataPortalUrl = ApplicationContext.DataPortalUrlString;
     }
 
     /// <summary>
@@ -39,40 +38,31 @@ namespace Csla.Channels.RabbitMq
     /// <param name="dataPortalUrl">RabbitMQ service URL</param>
     public RabbitMqProxy(string dataPortalUrl)
     {
-      this.DataPortalUrl = dataPortalUrl;
+      DataPortalUrl = dataPortalUrl;
     }
-
-    /// <summary>
-    /// Gets the URL address for the RabbitMQ
-    /// service used by the data portal.
-    /// </summary>
-    public string DataPortalUrl { get; protected set; }
-
-    /// <summary>
-    /// Gets a value indicating whether the data portal
-    /// is hosted on a remote server.
-    /// </summary>
-    public bool IsServerRemote => true;
 
     /// <summary>
     /// Gets or sets the timeout for network
     /// operations in seconds (default is 30 seconds).
     /// </summary>
-    public int Timeout { get; set; } = 30;
+    public override int Timeout { get; set; } = 30;
 
     /// <summary>
     /// Gets or sets the connection to the RabbitMQ service.
     /// </summary>
     protected IConnection Connection { get; set; }
+
     /// <summary>
     /// Gets or sets the channel (model) for RabbitMQ.
     /// </summary>
     protected IModel Channel { get; set; }
+
     /// <summary>
     /// Gets or sets the name of the data portal
     /// service queue.
     /// </summary>
     protected string DataPortalQueueName { get; set; }
+
     /// <summary>
     /// Gets or sets the queue listener that handles
     /// reply messages.
@@ -124,53 +114,13 @@ namespace Csla.Channels.RabbitMq
     /// <param name="criteria">Criteria object describing business object.</param>
     /// <param name="context">DataPortalContext object passed to the server.</param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public async Task<DataPortalResult> Create(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    public override async Task<DataPortalResult> Create(Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       if (isSync)
         throw new NotSupportedException("isSync == true");
 
       InitializeRabbitMQ();
-      DataPortalResult result;
-      try
-      {
-        var request = GetBaseCriteriaRequest();
-        request.TypeName = AssemblyNameTranslator.GetAssemblyQualifiedName(objectType.AssemblyQualifiedName);
-        if (!(criteria is IMobileObject))
-        {
-          criteria = new PrimitiveCriteria(criteria);
-        }
-        request.CriteriaData = SerializationFormatterFactory.GetFormatter().Serialize(criteria);
-        request = ConvertRequest(request);
-
-        var serialized = SerializationFormatterFactory.GetFormatter().Serialize(request);
-
-        serialized = await CallDataPortalServer(serialized, "create");
-
-        var response = (Server.Hosts.HttpChannel.HttpResponse)SerializationFormatterFactory.GetFormatter().Deserialize(serialized);
-        response = ConvertResponse(response);
-        var globalContext = (ContextDictionary)SerializationFormatterFactory.GetFormatter().Deserialize(response.GlobalContext);
-        if (response != null && response.ErrorData == null)
-        {
-          var obj = SerializationFormatterFactory.GetFormatter().Deserialize(response.ObjectData);
-          result = new DataPortalResult(obj, null, globalContext);
-        }
-        else if (response != null && response.ErrorData != null)
-        {
-          var ex = new DataPortalException(response.ErrorData);
-          result = new DataPortalResult(null, ex, globalContext);
-        }
-        else
-        {
-          throw new DataPortalException("null response", null);
-        }
-      }
-      catch (Exception ex)
-      {
-        result = new DataPortalResult(null, ex, null);
-      }
-      if (result.Error != null)
-        throw result.Error;
-      return result;
+      return await base.Create(objectType, criteria, context, isSync);
     }
 
     /// <summary>
@@ -183,53 +133,13 @@ namespace Csla.Channels.RabbitMq
     /// <see cref="Server.DataPortalContext" /> object passed to the server.
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public async Task<DataPortalResult> Fetch(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    public override async Task<DataPortalResult> Fetch(Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       if (isSync)
         throw new NotSupportedException("isSync == true");
 
       InitializeRabbitMQ();
-      DataPortalResult result;
-      try
-      {
-        var request = GetBaseCriteriaRequest();
-        request.TypeName = AssemblyNameTranslator.GetAssemblyQualifiedName(objectType.AssemblyQualifiedName);
-        if (!(criteria is IMobileObject))
-        {
-          criteria = new PrimitiveCriteria(criteria);
-        }
-        request.CriteriaData = SerializationFormatterFactory.GetFormatter().Serialize(criteria);
-        request = ConvertRequest(request);
-
-        var serialized = SerializationFormatterFactory.GetFormatter().Serialize(request);
-
-        serialized = await CallDataPortalServer(serialized, "fetch");
-
-        var response = (Server.Hosts.HttpChannel.HttpResponse)SerializationFormatterFactory.GetFormatter().Deserialize(serialized);
-        response = ConvertResponse(response);
-        var globalContext = (ContextDictionary)SerializationFormatterFactory.GetFormatter().Deserialize(response.GlobalContext);
-        if (response != null && response.ErrorData == null)
-        {
-          var obj = SerializationFormatterFactory.GetFormatter().Deserialize(response.ObjectData);
-          result = new DataPortalResult(obj, null, globalContext);
-        }
-        else if (response != null && response.ErrorData != null)
-        {
-          var ex = new DataPortalException(response.ErrorData);
-          result = new DataPortalResult(null, ex, globalContext);
-        }
-        else
-        {
-          throw new DataPortalException("null response", null);
-        }
-      }
-      catch (Exception ex)
-      {
-        result = new DataPortalResult(null, ex, null);
-      }
-      if (result.Error != null)
-        throw result.Error;
-      return result;
+      return await base.Fetch(objectType, criteria, context, isSync);
     }
 
     /// <summary>
@@ -241,48 +151,13 @@ namespace Csla.Channels.RabbitMq
     /// <see cref="Server.DataPortalContext" /> object passed to the server.
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public async Task<DataPortalResult> Update(object obj, DataPortalContext context, bool isSync)
+    public override async Task<DataPortalResult> Update(object obj, DataPortalContext context, bool isSync)
     {
       if (isSync)
         throw new NotSupportedException("isSync == true");
 
       InitializeRabbitMQ();
-      DataPortalResult result;
-      try
-      {
-        var request = GetBaseUpdateCriteriaRequest();
-        request.ObjectData = SerializationFormatterFactory.GetFormatter().Serialize(obj);
-        request = ConvertRequest(request);
-
-        var serialized = SerializationFormatterFactory.GetFormatter().Serialize(request);
-
-        serialized = await CallDataPortalServer(serialized, "update");
-
-        var response = (Csla.Server.Hosts.HttpChannel.HttpResponse)SerializationFormatterFactory.GetFormatter().Deserialize(serialized);
-        response = ConvertResponse(response);
-        var globalContext = (ContextDictionary)SerializationFormatterFactory.GetFormatter().Deserialize(response.GlobalContext);
-        if (response != null && response.ErrorData == null)
-        {
-          var newobj = SerializationFormatterFactory.GetFormatter().Deserialize(response.ObjectData);
-          result = new DataPortalResult(newobj, null, globalContext);
-        }
-        else if (response != null && response.ErrorData != null)
-        {
-          var ex = new DataPortalException(response.ErrorData);
-          result = new DataPortalResult(null, ex, globalContext);
-        }
-        else
-        {
-          throw new DataPortalException("null response", null);
-        }
-      }
-      catch (Exception ex)
-      {
-        result = new DataPortalResult(null, ex, null);
-      }
-      if (result.Error != null)
-        throw result.Error;
-      return result;
+      return await base.Update(obj, context, isSync);
     }
 
     /// <summary>
@@ -295,56 +170,16 @@ namespace Csla.Channels.RabbitMq
     /// <see cref="Server.DataPortalContext" /> object passed to the server.
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public async Task<DataPortalResult> Delete(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    public override async Task<DataPortalResult> Delete(Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       if (isSync)
         throw new NotSupportedException("isSync == true");
 
       InitializeRabbitMQ();
-      DataPortalResult result;
-      try
-      {
-        var request = GetBaseCriteriaRequest();
-        request.TypeName = AssemblyNameTranslator.GetAssemblyQualifiedName(objectType.AssemblyQualifiedName);
-        if (!(criteria is IMobileObject))
-        {
-          criteria = new PrimitiveCriteria(criteria);
-        }
-        request.CriteriaData = SerializationFormatterFactory.GetFormatter().Serialize(criteria);
-        request = ConvertRequest(request);
-
-        var serialized = SerializationFormatterFactory.GetFormatter().Serialize(request);
-
-        serialized = await CallDataPortalServer(serialized, "delete");
-
-        var response = (Server.Hosts.HttpChannel.HttpResponse)SerializationFormatterFactory.GetFormatter().Deserialize(serialized);
-        response = ConvertResponse(response);
-        var globalContext = (ContextDictionary)SerializationFormatterFactory.GetFormatter().Deserialize(response.GlobalContext);
-        if (response != null && response.ErrorData == null)
-        {
-          var obj = SerializationFormatterFactory.GetFormatter().Deserialize(response.ObjectData);
-          result = new DataPortalResult(obj, null, globalContext);
-        }
-        else if (response != null && response.ErrorData != null)
-        {
-          var ex = new DataPortalException(response.ErrorData);
-          result = new DataPortalResult(null, ex, globalContext);
-        }
-        else
-        {
-          throw new DataPortalException("null response", null);
-        }
-      }
-      catch (Exception ex)
-      {
-        result = new DataPortalResult(null, ex, null);
-      }
-      if (result.Error != null)
-        throw result.Error;
-      return result;
+      return await base.Delete(objectType, criteria, context, isSync);
     }
 
-    private async Task<byte[]> CallDataPortalServer(byte[] serialized, string operation)
+    protected override async Task<byte[]> CallDataPortalServer(byte[] serialized, string operation, string routingToken, bool isSync)
     {
       var correlationId = Guid.NewGuid().ToString();
       var resetEvent = new Csla.Threading.AsyncManualResetEvent();
@@ -385,89 +220,5 @@ namespace Csla.Channels.RabbitMq
       Channel = null;
       Connection = null;
     }
-
-    #region Conversions
-
-    /// <summary>
-    /// Override this method to manipulate the message
-    /// request data sent to the server.
-    /// </summary>
-    /// <param name="request">Update request data.</param>
-    protected virtual Csla.Server.Hosts.HttpChannel.UpdateRequest ConvertRequest(Csla.Server.Hosts.HttpChannel.UpdateRequest request)
-    {
-      return request;
-    }
-
-    /// <summary>
-    /// Override this method to manipulate the message
-    /// request data sent to the server.
-    /// </summary>
-    /// <param name="request">Criteria request data.</param>
-    protected virtual Csla.Server.Hosts.HttpChannel.CriteriaRequest ConvertRequest(Csla.Server.Hosts.HttpChannel.CriteriaRequest request)
-    {
-      return request;
-    }
-
-    /// <summary>
-    /// Override this method to manipulate the message
-    /// request data returned from the server.
-    /// </summary>
-    /// <param name="response">Response data.</param>
-    protected virtual Csla.Server.Hosts.HttpChannel.HttpResponse ConvertResponse(Csla.Server.Hosts.HttpChannel.HttpResponse response)
-    {
-      return response;
-    }
-
-    #endregion
-
-    #region Criteria
-
-    private Csla.Server.Hosts.HttpChannel.CriteriaRequest GetBaseCriteriaRequest()
-    {
-      var request = new Csla.Server.Hosts.HttpChannel.CriteriaRequest
-      {
-        CriteriaData = null,
-        ClientContext = SerializationFormatterFactory.GetFormatter().Serialize(ApplicationContext.ClientContext),
-#pragma warning disable CS0618 // Type or member is obsolete
-        GlobalContext = SerializationFormatterFactory.GetFormatter().Serialize(ApplicationContext.GlobalContext)
-#pragma warning restore CS0618 // Type or member is obsolete
-      };
-      if (ApplicationContext.AuthenticationType == "Windows")
-      {
-        request.Principal = SerializationFormatterFactory.GetFormatter().Serialize(null);
-      }
-      else
-      {
-        request.Principal = SerializationFormatterFactory.GetFormatter().Serialize(ApplicationContext.User);
-      }
-      request.ClientCulture = System.Globalization.CultureInfo.CurrentCulture.Name;
-      request.ClientUICulture = System.Globalization.CultureInfo.CurrentUICulture.Name;
-      return request;
-    }
-
-    private Csla.Server.Hosts.HttpChannel.UpdateRequest GetBaseUpdateCriteriaRequest()
-    {
-      var request = new Csla.Server.Hosts.HttpChannel.UpdateRequest
-      {
-        ObjectData = null,
-        ClientContext = SerializationFormatterFactory.GetFormatter().Serialize(ApplicationContext.ClientContext),
-#pragma warning disable CS0618 // Type or member is obsolete
-        GlobalContext = SerializationFormatterFactory.GetFormatter().Serialize(ApplicationContext.GlobalContext)
-#pragma warning restore CS0618 // Type or member is obsolete
-      };
-      if (ApplicationContext.AuthenticationType == "Windows")
-      {
-        request.Principal = SerializationFormatterFactory.GetFormatter().Serialize(null);
-      }
-      else
-      {
-        request.Principal = SerializationFormatterFactory.GetFormatter().Serialize(ApplicationContext.User);
-      }
-      request.ClientCulture = Thread.CurrentThread.CurrentCulture.Name;
-      request.ClientUICulture = Thread.CurrentThread.CurrentUICulture.Name;
-      return request;
-    }
-
-    #endregion
   }
 }

--- a/Source/Csla.Web.Mvc.Shared/Server/Hosts/HttpPortal.cs
+++ b/Source/Csla.Web.Mvc.Shared/Server/Hosts/HttpPortal.cs
@@ -13,10 +13,10 @@ using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-using Csla.Server.Hosts.HttpChannel;
 using Csla.Core;
 using System.Security.Principal;
 using Csla.Serialization;
+using Csla.Server.Hosts.DataPortalChannel;
 
 namespace Csla.Server.Hosts
 {
@@ -31,10 +31,10 @@ namespace Csla.Server.Hosts
     /// </summary>
     /// <param name="request">The request parameter object.</param>
 #pragma warning disable 1998
-    public async Task<HttpResponse> Create(CriteriaRequest request)
+    public async Task<DataPortalResponse> Create(CriteriaRequest request)
 #pragma warning restore 1998
     {
-      var result = new HttpResponse();
+      var result = new DataPortalResponse();
       try
       {
         request = ConvertRequest(request);
@@ -59,13 +59,13 @@ namespace Csla.Server.Hosts
         var dpr = await prtl.Create(objectType, criteria, context, true);
 
         if (dpr.Error != null)
-          result.ErrorData = new HttpErrorInfo(dpr.Error);
+          result.ErrorData = new DataPortalErrorInfo(dpr.Error);
         result.GlobalContext = SerializationFormatterFactory.GetFormatter().Serialize(dpr.GlobalContext);
         result.ObjectData = SerializationFormatterFactory.GetFormatter().Serialize(dpr.ReturnObject);
       }
       catch (Exception ex)
       {
-        result.ErrorData = new HttpErrorInfo(ex);
+        result.ErrorData = new DataPortalErrorInfo(ex);
         throw;
       }
       finally
@@ -80,10 +80,10 @@ namespace Csla.Server.Hosts
     /// </summary>
     /// <param name="request">The request parameter object.</param>
 #pragma warning disable 1998
-    public async Task<HttpResponse> Fetch(CriteriaRequest request)
+    public async Task<DataPortalResponse> Fetch(CriteriaRequest request)
 #pragma warning restore 1998
     {
-      var result = new HttpResponse();
+      var result = new DataPortalResponse();
       try
       {
         request = ConvertRequest(request);
@@ -108,13 +108,13 @@ namespace Csla.Server.Hosts
         var dpr = await prtl.Fetch(objectType, criteria, context, true);
 
         if (dpr.Error != null)
-          result.ErrorData = new HttpErrorInfo(dpr.Error);
+          result.ErrorData = new DataPortalErrorInfo(dpr.Error);
         result.GlobalContext = SerializationFormatterFactory.GetFormatter().Serialize(dpr.GlobalContext);
         result.ObjectData = SerializationFormatterFactory.GetFormatter().Serialize(dpr.ReturnObject);
       }
       catch (Exception ex)
       {
-        result.ErrorData = new HttpErrorInfo(ex);
+        result.ErrorData = new DataPortalErrorInfo(ex);
         throw;
       }
       finally
@@ -129,10 +129,10 @@ namespace Csla.Server.Hosts
     /// </summary>
     /// <param name="request">The request parameter object.</param>
 #pragma warning disable 1998
-    public async Task<HttpResponse> Update(UpdateRequest request)
+    public async Task<DataPortalResponse> Update(UpdateRequest request)
 #pragma warning restore 1998
     {
-      var result = new HttpResponse();
+      var result = new DataPortalResponse();
       try
       {
         request = ConvertRequest(request);
@@ -151,14 +151,14 @@ namespace Csla.Server.Hosts
         var dpr = await prtl.Update(obj, context, true);
 
         if (dpr.Error != null)
-          result.ErrorData = new HttpErrorInfo(dpr.Error);
+          result.ErrorData = new DataPortalErrorInfo(dpr.Error);
 
         result.GlobalContext = SerializationFormatterFactory.GetFormatter().Serialize(dpr.GlobalContext);
         result.ObjectData = SerializationFormatterFactory.GetFormatter().Serialize(dpr.ReturnObject);
       }
       catch (Exception ex)
       {
-        result.ErrorData = new HttpErrorInfo(ex);
+        result.ErrorData = new DataPortalErrorInfo(ex);
         throw;
       }
       finally
@@ -173,10 +173,10 @@ namespace Csla.Server.Hosts
     /// </summary>
     /// <param name="request">The request parameter object.</param>
 #pragma warning disable 1998
-    public async Task<HttpResponse> Delete(CriteriaRequest request)
+    public async Task<DataPortalResponse> Delete(CriteriaRequest request)
 #pragma warning restore 1998
     {
-      var result = new HttpResponse();
+      var result = new DataPortalResponse();
       try
       {
         request = ConvertRequest(request);
@@ -201,13 +201,13 @@ namespace Csla.Server.Hosts
         var dpr = await prtl.Delete(objectType, criteria, context, true);
 
         if (dpr.Error != null)
-          result.ErrorData = new HttpErrorInfo(dpr.Error);
+          result.ErrorData = new DataPortalErrorInfo(dpr.Error);
         result.GlobalContext = SerializationFormatterFactory.GetFormatter().Serialize(dpr.GlobalContext);
         result.ObjectData = SerializationFormatterFactory.GetFormatter().Serialize(dpr.ReturnObject);
       }
       catch (Exception ex)
       {
-        result.ErrorData = new HttpErrorInfo(ex);
+        result.ErrorData = new DataPortalErrorInfo(ex);
         throw;
       }
       finally
@@ -227,7 +227,7 @@ namespace Csla.Server.Hosts
       return criteria;
     }
 
-    #endregion
+    #endregion Criteria
 
     #region Extention Method for Requests
 
@@ -256,11 +256,11 @@ namespace Csla.Server.Hosts
     /// comes back from the network.
     /// </summary>
     /// <param name="response">Response object.</param>
-    protected virtual HttpResponse ConvertResponse(HttpResponse response)
+    protected virtual DataPortalResponse ConvertResponse(DataPortalResponse response)
     {
       return response;
     }
 
-    #endregion
+    #endregion Extention Method for Requests
   }
 }

--- a/Source/Csla/DataPortalClient/DataPortalProxy.cs
+++ b/Source/Csla/DataPortalClient/DataPortalProxy.cs
@@ -1,0 +1,332 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="DataPortalProxy.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>Abstract data portal proxy with common data portal proxy behaviour. Implements IDataPortalProxy</summary>
+//-----------------------------------------------------------------------
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Csla.Core;
+using Csla.Serialization.Mobile;
+using Csla.Serialization;
+using Csla.Server;
+using Csla.Server.Hosts.DataPortalChannel;
+
+namespace Csla.DataPortalClient
+{
+  /// <summary>
+  /// Implements a data portal proxy to relay data portal
+  /// calls to a remote application server.
+  /// </summary>
+  public abstract class DataPortalProxy : IDataPortalProxy
+  {
+    /// <summary>
+    /// Gets a value indicating whether the data portal
+    /// is hosted on a remote server.
+    /// </summary>
+    public virtual bool IsServerRemote => true;
+
+    /// <summary>
+    /// Gets or sets the Client timeout
+    /// in milliseconds (0 uses default timeout).
+    /// </summary>
+    public virtual int Timeout { get; set; }
+
+    /// <summary>
+    /// Gets the URL address for the data portal server
+    /// used by this proxy instance.
+    /// </summary>
+    public string DataPortalUrl { get; protected set; } = ApplicationContext.DataPortalUrlString;
+
+    /// <summary>
+    /// Called by <see cref="DataPortal" /> to create a
+    /// new business object.
+    /// </summary>
+    /// <param name="objectType">Type of business object to create.</param>
+    /// <param name="criteria">Criteria object describing business object.</param>
+    /// <param name="context">
+    /// <see cref="Server.DataPortalContext" /> object passed to the server.
+    /// </param>
+    /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
+    public async virtual Task<DataPortalResult> Create(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    {
+      DataPortalResult result;
+      try
+      {
+        var request = GetBaseCriteriaRequest();
+        request.TypeName = AssemblyNameTranslator.GetAssemblyQualifiedName(objectType.AssemblyQualifiedName);
+        if (!(criteria is IMobileObject))
+        {
+          criteria = new PrimitiveCriteria(criteria);
+        }
+        request.CriteriaData = SerializationFormatterFactory.GetFormatter().Serialize(criteria);
+        request = ConvertRequest(request);
+        var serialized = SerializationFormatterFactory.GetFormatter().Serialize(request);
+        serialized = await CallDataPortalServer(serialized, "create", GetRoutingToken(objectType), isSync);
+        var response = (DataPortalResponse)SerializationFormatterFactory.GetFormatter().Deserialize(serialized);
+        response = ConvertResponse(response);
+
+        var globalContext = (ContextDictionary)SerializationFormatterFactory.GetFormatter().Deserialize(response.GlobalContext);
+        if (response.ErrorData == null)
+        {
+          var obj = SerializationFormatterFactory.GetFormatter().Deserialize(response.ObjectData);
+          result = new DataPortalResult(obj, null, globalContext);
+        }
+        else if (response.ErrorData != null)
+        {
+          var ex = new DataPortalException(response.ErrorData);
+          result = new DataPortalResult(null, ex, globalContext);
+        }
+        else
+        {
+          throw new DataPortalException("null response", null);
+        }
+      }
+      catch (Exception ex)
+      {
+        result = new DataPortalResult(null, ex, null);
+      }
+      if (result.Error != null)
+        throw result.Error;
+      return result;
+    }
+
+    /// <summary>
+    /// Called by <see cref="DataPortal" /> to load an
+    /// existing business object.
+    /// </summary>
+    /// <param name="objectType">Type of business object to create.</param>
+    /// <param name="criteria">Criteria object describing business object.</param>
+    /// <param name="context">
+    /// <see cref="Server.DataPortalContext" /> object passed to the server.
+    /// </param>
+    /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
+    public async virtual Task<DataPortalResult> Fetch(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    {
+      DataPortalResult result;
+      try
+      {
+        var request = GetBaseCriteriaRequest();
+        request.TypeName = AssemblyNameTranslator.GetAssemblyQualifiedName(objectType.AssemblyQualifiedName);
+        if (!(criteria is IMobileObject))
+        {
+          criteria = new PrimitiveCriteria(criteria);
+        }
+        request.CriteriaData = SerializationFormatterFactory.GetFormatter().Serialize(criteria);
+        request = ConvertRequest(request);
+
+        var serialized = SerializationFormatterFactory.GetFormatter().Serialize(request);
+
+        serialized = await CallDataPortalServer(serialized, "fetch", GetRoutingToken(objectType), isSync);
+
+        var response = (DataPortalResponse)SerializationFormatterFactory.GetFormatter().Deserialize(serialized);
+        response = ConvertResponse(response);
+        var globalContext = (ContextDictionary)SerializationFormatterFactory.GetFormatter().Deserialize(response.GlobalContext);
+        if (response.ErrorData == null)
+        {
+          var obj = SerializationFormatterFactory.GetFormatter().Deserialize(response.ObjectData);
+          result = new DataPortalResult(obj, null, globalContext);
+        }
+        else if (response.ErrorData != null)
+        {
+          var ex = new DataPortalException(response.ErrorData);
+          result = new DataPortalResult(null, ex, globalContext);
+        }
+        else
+        {
+          throw new DataPortalException("null response", null);
+        }
+      }
+      catch (Exception ex)
+      {
+        result = new DataPortalResult(null, ex, null);
+      }
+      if (result.Error != null)
+        throw result.Error;
+      return result;
+    }
+
+    /// <summary>
+    /// Called by <see cref="DataPortal" /> to update a
+    /// business object.
+    /// </summary>
+    /// <param name="obj">The business object to update.</param>
+    /// <param name="context">
+    /// <see cref="Server.DataPortalContext" /> object passed to the server.
+    /// </param>
+    /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
+    public async virtual Task<DataPortalResult> Update(object obj, DataPortalContext context, bool isSync)
+    {
+      DataPortalResult result;
+      try
+      {
+        var request = GetBaseUpdateCriteriaRequest();
+        request.ObjectData = SerializationFormatterFactory.GetFormatter().Serialize(obj);
+        request = ConvertRequest(request);
+
+        var serialized = SerializationFormatterFactory.GetFormatter().Serialize(request);
+
+        serialized = await CallDataPortalServer(serialized, "update", GetRoutingToken(obj.GetType()), isSync);
+
+        var response = (DataPortalResponse)SerializationFormatterFactory.GetFormatter().Deserialize(serialized);
+        response = ConvertResponse(response);
+        var globalContext = (ContextDictionary)SerializationFormatterFactory.GetFormatter().Deserialize(response.GlobalContext);
+        if (response.ErrorData == null)
+        {
+          var newobj = SerializationFormatterFactory.GetFormatter().Deserialize(response.ObjectData);
+          result = new DataPortalResult(newobj, null, globalContext);
+        }
+        else if (response.ErrorData != null)
+        {
+          var ex = new DataPortalException(response.ErrorData);
+          result = new DataPortalResult(null, ex, globalContext);
+        }
+        else
+        {
+          throw new DataPortalException("null response", null);
+        }
+      }
+      catch (Exception ex)
+      {
+        result = new DataPortalResult(null, ex, null);
+      }
+      if (result.Error != null)
+        throw result.Error;
+      return result;
+    }
+
+    /// <summary>
+    /// Called by <see cref="DataPortal" /> to delete a
+    /// business object.
+    /// </summary>
+    /// <param name="objectType">Type of business object to create.</param>
+    /// <param name="criteria">Criteria object describing business object.</param>
+    /// <param name="context">
+    /// <see cref="Server.DataPortalContext" /> object passed to the server.
+    /// </param>
+    /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
+    public async virtual Task<DataPortalResult> Delete(Type objectType, object criteria, DataPortalContext context,
+      bool isSync)
+    {
+      DataPortalResult result;
+      try
+      {
+        var request = GetBaseCriteriaRequest();
+        request.TypeName = AssemblyNameTranslator.GetAssemblyQualifiedName(objectType.AssemblyQualifiedName);
+        if (!(criteria is IMobileObject))
+        {
+          criteria = new PrimitiveCriteria(criteria);
+        }
+        request.CriteriaData = SerializationFormatterFactory.GetFormatter().Serialize(criteria);
+        request = ConvertRequest(request);
+
+        var serialized = SerializationFormatterFactory.GetFormatter().Serialize(request);
+
+        serialized = await CallDataPortalServer(serialized, "delete", GetRoutingToken(objectType), isSync);
+
+        var response = (DataPortalResponse)SerializationFormatterFactory.GetFormatter().Deserialize(serialized);
+        response = ConvertResponse(response);
+        var globalContext = (ContextDictionary)SerializationFormatterFactory.GetFormatter().Deserialize(response.GlobalContext);
+        if (response.ErrorData == null)
+        {
+          result = new DataPortalResult(null, null, globalContext);
+        }
+        else if (response.ErrorData != null)
+        {
+          var ex = new DataPortalException(response.ErrorData);
+          result = new DataPortalResult(null, ex, globalContext);
+        }
+        else
+        {
+          throw new DataPortalException("null response", null);
+        }
+      }
+      catch (Exception ex)
+      {
+        result = new DataPortalResult(null, ex, null);
+      }
+      if (result.Error != null)
+        throw result.Error;
+      return result;
+    }
+
+    /// <summary>
+    /// Override this method to manipulate the message
+    /// request data sent to the server.
+    /// </summary>
+    /// <param name="request">Criteria request data.</param>
+    protected virtual CriteriaRequest ConvertRequest(CriteriaRequest request)
+    {
+      return request;
+    }
+
+    /// <summary>
+    /// Override this method to manipulate the message
+    /// request data sent to the server.
+    /// </summary>
+    /// <param name="request">Update request data.</param>
+    protected virtual UpdateRequest ConvertRequest(UpdateRequest request)
+    {
+      return request;
+    }
+
+    /// <summary>
+    /// Override this method to manipulate the message
+    /// request data returned from the server.
+    /// </summary>
+    /// <param name="response">Response data.</param>
+    protected virtual DataPortalResponse ConvertResponse(DataPortalResponse response)
+    {
+      return response;
+    }
+
+    protected abstract Task<byte[]> CallDataPortalServer(byte[] serialized, string operation, string routingToken, bool isSync);
+
+    protected virtual string GetRoutingToken(Type objectType)
+    {
+      string result = null;
+      var list = objectType.GetCustomAttributes(typeof(DataPortalServerRoutingTagAttribute), false);
+      if (list.Length > 0)
+        result = ((DataPortalServerRoutingTagAttribute)list[0]).RoutingTag;
+      return result;
+    }
+
+    #region Criteria
+
+    private static CriteriaRequest GetBaseCriteriaRequest()
+    {
+      return new CriteriaRequest
+      {
+        CriteriaData = null,
+        ClientContext = SerializationFormatterFactory.GetFormatter().Serialize(ApplicationContext.ClientContext),
+#pragma warning disable CS0618 // Type or member is obsolete
+        GlobalContext = SerializationFormatterFactory.GetFormatter().Serialize(ApplicationContext.GlobalContext),
+#pragma warning restore CS0618 // Type or member is obsolete
+        Principal = SerializationFormatterFactory.GetFormatter()
+          .Serialize(ApplicationContext.AuthenticationType == "Windows" ? null : ApplicationContext.User),
+        ClientCulture = System.Globalization.CultureInfo.CurrentCulture.Name,
+        ClientUICulture = System.Globalization.CultureInfo.CurrentUICulture.Name
+      };
+    }
+
+    private static UpdateRequest GetBaseUpdateCriteriaRequest()
+    {
+      return new UpdateRequest
+      {
+        ObjectData = null,
+        ClientContext = SerializationFormatterFactory.GetFormatter().Serialize(ApplicationContext.ClientContext),
+#pragma warning disable CS0618 // Type or member is obsolete
+        GlobalContext = SerializationFormatterFactory.GetFormatter().Serialize(ApplicationContext.GlobalContext),
+#pragma warning restore CS0618 // Type or member is obsolete
+        Principal = SerializationFormatterFactory.GetFormatter()
+          .Serialize(ApplicationContext.AuthenticationType == "Windows" ? null : ApplicationContext.User),
+        ClientCulture = Thread.CurrentThread.CurrentCulture.Name,
+        ClientUICulture = Thread.CurrentThread.CurrentUICulture.Name
+      };
+    }
+
+    #endregion Criteria
+  }
+}

--- a/Source/Csla/DataPortalClient/HttpProxy.cs
+++ b/Source/Csla/DataPortalClient/HttpProxy.cs
@@ -23,35 +23,15 @@ namespace Csla.DataPortalClient
   /// Implements a data portal proxy to relay data portal
   /// calls to a remote application server by using http.
   /// </summary>
-  public class HttpProxy : IDataPortalProxy
+  public class HttpProxy : DataPortalProxy
   {
     /// <summary>
-    /// Gets or sets the HttpClient timeout
-    /// in milliseconds (0 uses default HttpClient/WebClient timeout).
-    /// </summary>
-    public int Timeout { get; set; }
-
-    /// <summary>
-    /// Gets or sets the default URL address
-    /// for the data portal server.
-    /// </summary>
-    /// <remarks>
-    /// Deprecated: use ApplicationContext.DataPortalUrlString
-    /// </remarks>
-    public static string DefaultUrl
-    {
-      get { return ApplicationContext.DataPortalUrlString; }
-      set { ApplicationContext.DataPortalUrlString = value; }
-    }
-
-    /// <summary>
     /// Creates an instance of the object, initializing
-    /// it to use the DefaultUrl 
+    /// it to use the DefaultUrl
     /// values.
     /// </summary>
     public HttpProxy()
     {
-      this.DataPortalUrl = HttpProxy.DefaultUrl;
     }
 
     /// <summary>
@@ -61,7 +41,7 @@ namespace Csla.DataPortalClient
     /// <param name="dataPortalUrl">Server endpoint URL</param>
     public HttpProxy(string dataPortalUrl)
     {
-      this.DataPortalUrl = dataPortalUrl;
+      DataPortalUrl = dataPortalUrl;
     }
 
     /// <summary>
@@ -71,7 +51,6 @@ namespace Csla.DataPortalClient
     /// <param name="httpClient">HttpClient instance</param>
     public HttpProxy(HttpClient httpClient)
     {
-      this.DataPortalUrl = HttpProxy.DefaultUrl;
       _httpClient = httpClient;
     }
 
@@ -86,21 +65,6 @@ namespace Csla.DataPortalClient
       _httpClient = httpClient;
       DataPortalUrl = dataPortalUrl;
     }
-
-    /// <summary>
-    /// Gets a value indicating whether the data portal
-    /// is hosted on a remote server.
-    /// </summary>
-    public bool IsServerRemote
-    {
-      get { return true; }
-    }
-
-    /// <summary>
-    /// Gets the URL address for the data portal server
-    /// used by this proxy instance.
-    /// </summary>
-    public string DataPortalUrl { get; protected set; }
 
     private static HttpClient _httpClient;
 
@@ -119,7 +83,7 @@ namespace Csla.DataPortalClient
     /// </summary>
     protected virtual HttpClient GetHttpClient()
     {
-      if (_httpClient == null) 
+      if (_httpClient == null)
       {
         var handler = GetHttpClientHandler();
         if (UseTextSerialization)
@@ -134,7 +98,8 @@ namespace Csla.DataPortalClient
           };
         }
         _httpClient = new HttpClient(handler);
-        if (Timeout > 0) {
+        if (Timeout > 0)
+        {
           _httpClient.Timeout = TimeSpan.FromMilliseconds(this.Timeout);
         }
       }
@@ -158,273 +123,7 @@ namespace Csla.DataPortalClient
     /// </summary>
     public static bool UseTextSerialization { get; set; } = false;
 
-    #region Criteria
-
-    private Csla.Server.Hosts.HttpChannel.CriteriaRequest GetBaseCriteriaRequest()
-    {
-      var request = new Csla.Server.Hosts.HttpChannel.CriteriaRequest();
-      request.CriteriaData = null;
-      request.ClientContext = SerializationFormatterFactory.GetFormatter().Serialize(ApplicationContext.ClientContext);
-#pragma warning disable CS0618 // Type or member is obsolete
-      request.GlobalContext = SerializationFormatterFactory.GetFormatter().Serialize(ApplicationContext.GlobalContext);
-#pragma warning restore CS0618 // Type or member is obsolete
-      if (ApplicationContext.AuthenticationType == "Windows")
-      {
-        request.Principal = SerializationFormatterFactory.GetFormatter().Serialize(null);
-      }
-      else
-      {
-        request.Principal = SerializationFormatterFactory.GetFormatter().Serialize(ApplicationContext.User);
-      }
-      request.ClientCulture = System.Globalization.CultureInfo.CurrentCulture.Name;
-      request.ClientUICulture = System.Globalization.CultureInfo.CurrentUICulture.Name;
-      return request;
-    }
-
-    private Csla.Server.Hosts.HttpChannel.UpdateRequest GetBaseUpdateCriteriaRequest()
-    {
-      var request = new Csla.Server.Hosts.HttpChannel.UpdateRequest();
-      request.ObjectData = null;
-      request.ClientContext = SerializationFormatterFactory.GetFormatter().Serialize(ApplicationContext.ClientContext);
-#pragma warning disable CS0618 // Type or member is obsolete
-      request.GlobalContext = SerializationFormatterFactory.GetFormatter().Serialize(ApplicationContext.GlobalContext);
-#pragma warning restore CS0618 // Type or member is obsolete
-      if (ApplicationContext.AuthenticationType == "Windows")
-      {
-        request.Principal = SerializationFormatterFactory.GetFormatter().Serialize(null);
-      }
-      else
-      {
-        request.Principal = SerializationFormatterFactory.GetFormatter().Serialize(ApplicationContext.User);
-      }
-      request.ClientCulture = Thread.CurrentThread.CurrentCulture.Name;
-      request.ClientUICulture = Thread.CurrentThread.CurrentUICulture.Name;
-      return request;
-    }
-
-#endregion
-
-    /// <summary>
-    /// Called by <see cref="DataPortal" /> to create a
-    /// new business object.
-    /// </summary>
-    /// <param name="objectType">Type of business object to create.</param>
-    /// <param name="criteria">Criteria object describing business object.</param>
-    /// <param name="context">
-    /// <see cref="Server.DataPortalContext" /> object passed to the server.
-    /// </param>
-    /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public async Task<DataPortalResult> Create(Type objectType, object criteria, DataPortalContext context, bool isSync)
-    {
-      DataPortalResult result;
-      try
-      {
-        var request = GetBaseCriteriaRequest();
-        request.TypeName = AssemblyNameTranslator.GetAssemblyQualifiedName(objectType.AssemblyQualifiedName);
-        if (!(criteria is IMobileObject))
-        {
-          criteria = new PrimitiveCriteria(criteria);
-        }
-        request.CriteriaData = SerializationFormatterFactory.GetFormatter().Serialize(criteria);
-        request = ConvertRequest(request);
-
-        var serialized = SerializationFormatterFactory.GetFormatter().Serialize(request);
-
-        serialized = await CallDataPortalServer(serialized, "create", GetRoutingToken(objectType), isSync);
-
-        var response = (Csla.Server.Hosts.HttpChannel.HttpResponse)SerializationFormatterFactory.GetFormatter().Deserialize(serialized);
-        response = ConvertResponse(response);
-        var globalContext = (ContextDictionary)SerializationFormatterFactory.GetFormatter().Deserialize(response.GlobalContext);
-        if (response != null && response.ErrorData == null)
-        {
-          var obj = SerializationFormatterFactory.GetFormatter().Deserialize(response.ObjectData);
-          result = new DataPortalResult(obj, null, globalContext);
-        }
-        else if (response != null && response.ErrorData != null)
-        {
-          var ex = new DataPortalException(response.ErrorData);
-          result = new DataPortalResult(null, ex, globalContext);
-        }
-        else
-        {
-          throw new DataPortalException("null response", null);
-        }
-      }
-      catch (Exception ex)
-      {
-        result = new DataPortalResult(null, ex, null);
-      }
-      if (result.Error != null)
-        throw result.Error;
-      return result;
-    }
-
-    /// <summary>
-    /// Called by <see cref="DataPortal" /> to load an
-    /// existing business object.
-    /// </summary>
-    /// <param name="objectType">Type of business object to create.</param>
-    /// <param name="criteria">Criteria object describing business object.</param>
-    /// <param name="context">
-    /// <see cref="Server.DataPortalContext" /> object passed to the server.
-    /// </param>
-    /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-#pragma warning disable 1998
-    public async Task<DataPortalResult> Fetch(Type objectType, object criteria, DataPortalContext context, bool isSync)
-#pragma warning restore 1998
-    {
-      DataPortalResult result;
-      try
-      {
-        var request = GetBaseCriteriaRequest();
-        request.TypeName = AssemblyNameTranslator.GetAssemblyQualifiedName(objectType.AssemblyQualifiedName);
-        if (!(criteria is IMobileObject))
-        {
-          criteria = new PrimitiveCriteria(criteria);
-        }
-        request.CriteriaData = SerializationFormatterFactory.GetFormatter().Serialize(criteria);
-        request = ConvertRequest(request);
-
-        var serialized = SerializationFormatterFactory.GetFormatter().Serialize(request);
-
-        serialized = await CallDataPortalServer(serialized, "fetch", GetRoutingToken(objectType), isSync);
-
-        var response = (Csla.Server.Hosts.HttpChannel.HttpResponse)SerializationFormatterFactory.GetFormatter().Deserialize(serialized);
-        response = ConvertResponse(response);
-        var globalContext = (ContextDictionary)SerializationFormatterFactory.GetFormatter().Deserialize(response.GlobalContext);
-        if (response != null && response.ErrorData == null)
-        {
-          var obj = SerializationFormatterFactory.GetFormatter().Deserialize(response.ObjectData);
-          result = new DataPortalResult(obj, null, globalContext);
-        }
-        else if (response != null && response.ErrorData != null)
-        {
-          var ex = new DataPortalException(response.ErrorData);
-          result = new DataPortalResult(null, ex, globalContext);
-        }
-        else
-        {
-          throw new DataPortalException("null response", null);
-        }
-      }
-      catch (Exception ex)
-      {
-        result = new DataPortalResult(null, ex, null);
-      }
-      if (result.Error != null)
-        throw result.Error;
-      return result;
-    }
-
-    /// <summary>
-    /// Called by <see cref="DataPortal" /> to update a
-    /// business object.
-    /// </summary>
-    /// <param name="obj">The business object to update.</param>
-    /// <param name="context">
-    /// <see cref="Server.DataPortalContext" /> object passed to the server.
-    /// </param>
-    /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-#pragma warning disable 1998
-    public async Task<DataPortalResult> Update(object obj, DataPortalContext context, bool isSync)
-#pragma warning restore 1998
-    {
-      DataPortalResult result;
-      try
-      {
-        var request = GetBaseUpdateCriteriaRequest();
-        request.ObjectData = SerializationFormatterFactory.GetFormatter().Serialize(obj);
-        request = ConvertRequest(request);
-
-        var serialized = SerializationFormatterFactory.GetFormatter().Serialize(request);
-
-        serialized = await CallDataPortalServer(serialized, "update", GetRoutingToken(obj.GetType()), isSync);
-
-        var response = (Csla.Server.Hosts.HttpChannel.HttpResponse)SerializationFormatterFactory.GetFormatter().Deserialize(serialized);
-        response = ConvertResponse(response);
-        var globalContext = (ContextDictionary)SerializationFormatterFactory.GetFormatter().Deserialize(response.GlobalContext);
-        if (response != null && response.ErrorData == null)
-        {
-          var newobj = SerializationFormatterFactory.GetFormatter().Deserialize(response.ObjectData);
-          result = new DataPortalResult(newobj, null, globalContext);
-        }
-        else if (response != null && response.ErrorData != null)
-        {
-          var ex = new DataPortalException(response.ErrorData);
-          result = new DataPortalResult(null, ex, globalContext);
-        }
-        else
-        {
-          throw new DataPortalException("null response", null);
-        }
-      }
-      catch (Exception ex)
-      {
-        result = new DataPortalResult(null, ex, null);
-      }
-      if (result.Error != null)
-        throw result.Error;
-      return result;
-    }
-
-    /// <summary>
-    /// Called by <see cref="DataPortal" /> to delete a
-    /// business object.
-    /// </summary>
-    /// <param name="objectType">Type of business object to create.</param>
-    /// <param name="criteria">Criteria object describing business object.</param>
-    /// <param name="context">
-    /// <see cref="Server.DataPortalContext" /> object passed to the server.
-    /// </param>
-    /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-#pragma warning disable 1998
-    public async Task<DataPortalResult> Delete(Type objectType, object criteria, DataPortalContext context, bool isSync)
-#pragma warning restore 1998
-    {
-      DataPortalResult result;
-      try
-      {
-
-        var request = GetBaseCriteriaRequest();
-        request.TypeName = AssemblyNameTranslator.GetAssemblyQualifiedName(objectType.AssemblyQualifiedName);
-        if (!(criteria is IMobileObject))
-        {
-          criteria = new PrimitiveCriteria(criteria);
-        }
-        request.CriteriaData = SerializationFormatterFactory.GetFormatter().Serialize(criteria);
-        request = ConvertRequest(request);
-
-        var serialized = SerializationFormatterFactory.GetFormatter().Serialize(request);
-
-        serialized = await CallDataPortalServer(serialized, "delete", GetRoutingToken(objectType), isSync);
-
-        var response = (Csla.Server.Hosts.HttpChannel.HttpResponse)SerializationFormatterFactory.GetFormatter().Deserialize(serialized);
-        response = ConvertResponse(response);
-        var globalContext = (ContextDictionary)SerializationFormatterFactory.GetFormatter().Deserialize(response.GlobalContext);
-        if (response != null && response.ErrorData == null)
-        {
-          result = new DataPortalResult(null, null, globalContext);
-        }
-        else if (response != null && response.ErrorData != null)
-        {
-          var ex = new DataPortalException(response.ErrorData);
-          result = new DataPortalResult(null, ex, globalContext);
-        }
-        else
-        {
-          throw new DataPortalException("null response", null);
-        }
-      }
-      catch (Exception ex)
-      {
-        result = new DataPortalResult(null, ex, null);
-      }
-      if (result.Error != null)
-        throw result.Error;
-      return result;
-    }
-
-    private async Task<byte[]> CallDataPortalServer(byte[] serialized, string operation, string routingToken, bool isSync)
+    protected override async Task<byte[]> CallDataPortalServer(byte[] serialized, string operation, string routingToken, bool isSync)
     {
       if (isSync)
         serialized = CallViaWebClient(serialized, operation, routingToken);
@@ -446,7 +145,7 @@ namespace Csla.DataPortalClient
       HttpClient client = GetHttpClient();
       HttpRequestMessage httpRequest;
       httpRequest = new HttpRequestMessage(
-        HttpMethod.Post, 
+        HttpMethod.Post,
         $"{DataPortalUrl}?operation={CreateOperationTag(operation, ApplicationContext.VersionRoutingTag, routingToken)}");
       SetHttpRequestHeaders(httpRequest);
       if (UseTextSerialization)
@@ -501,47 +200,7 @@ namespace Csla.DataPortalClient
     {
       if (!string.IsNullOrWhiteSpace(versionToken) || !string.IsNullOrWhiteSpace(routingToken))
         return $"{operatation}/{routingToken}-{versionToken}";
-      else
-        return operatation;
-    }
-
-    private string GetRoutingToken(Type objectType)
-    {
-      string result = null;
-      var list = objectType.GetCustomAttributes(typeof(DataPortalServerRoutingTagAttribute), false);
-      if (list.Count() > 0)
-        result = ((DataPortalServerRoutingTagAttribute)list[0]).RoutingTag;
-      return result;
-    }
-
-    /// <summary>
-    /// Override this method to manipulate the message
-    /// request data sent to the server.
-    /// </summary>
-    /// <param name="request">Update request data.</param>
-    protected virtual Csla.Server.Hosts.HttpChannel.UpdateRequest ConvertRequest(Csla.Server.Hosts.HttpChannel.UpdateRequest request)
-    {
-      return request;
-    }
-
-    /// <summary>
-    /// Override this method to manipulate the message
-    /// request data sent to the server.
-    /// </summary>
-    /// <param name="request">Criteria request data.</param>
-    protected virtual Csla.Server.Hosts.HttpChannel.CriteriaRequest ConvertRequest(Csla.Server.Hosts.HttpChannel.CriteriaRequest request)
-    {
-      return request;
-    }
-
-    /// <summary>
-    /// Override this method to manipulate the message
-    /// request data returned from the server.
-    /// </summary>
-    /// <param name="response">Response data.</param>
-    protected virtual Csla.Server.Hosts.HttpChannel.HttpResponse ConvertResponse(Csla.Server.Hosts.HttpChannel.HttpResponse response)
-    {
-      return response;
+      return operatation;
     }
 
     private class DefaultWebClient : WebClient

--- a/Source/Csla/DataPortalException.cs
+++ b/Source/Csla/DataPortalException.cs
@@ -7,10 +7,10 @@
 //-----------------------------------------------------------------------
 using System;
 using System.Security.Permissions;
+using Csla.Server.Hosts.DataPortalChannel;
 
 namespace Csla
 {
-
   /// <summary>
   /// This exception is returned for any errors occurring
   /// during the server-side DataPortal invocation.
@@ -69,7 +69,7 @@ namespace Csla
     public DataPortalException(WcfPortal.WcfErrorInfo info)
       : base(info.Message)
     {
-      this.ErrorInfo = new Csla.Server.Hosts.HttpChannel.HttpErrorInfo(info);
+      this.ErrorInfo = new Csla.Server.Hosts.DataPortalChannel.DataPortalErrorInfo(info);
     }
 #endif
 
@@ -77,7 +77,7 @@ namespace Csla
     /// Creates an instance of the object.
     /// </summary>
     /// <param name="info">Info about the exception.</param>
-    public DataPortalException(Csla.Server.Hosts.HttpChannel.HttpErrorInfo info)
+    public DataPortalException(DataPortalErrorInfo info)
       : base(info.Message)
     {
       this.ErrorInfo = info;
@@ -114,13 +114,13 @@ namespace Csla
     /// but this property returns information
     /// about the exception.
     /// </summary>
-    public Csla.Server.Hosts.HttpChannel.HttpErrorInfo ErrorInfo { get; private set; }
+    public DataPortalErrorInfo ErrorInfo { get; private set; }
 
     /// <summary>
     /// Gets the original exception error info
     /// that caused this exception.
     /// </summary>
-    public Server.Hosts.HttpChannel.HttpErrorInfo BusinessErrorInfo
+    public DataPortalErrorInfo BusinessErrorInfo
     {
       get
       {

--- a/Source/Csla/Server/Hosts/DataPortalChannel/CriteriaRequest.cs
+++ b/Source/Csla/Server/Hosts/DataPortalChannel/CriteriaRequest.cs
@@ -1,43 +1,56 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="UpdateRequest.cs" company="Marimer LLC">
+// <copyright file="CriteriaRequest.cs" company="Marimer LLC">
 //     Copyright (c) Marimer LLC. All rights reserved.
 //     Website: https://cslanet.com
 // </copyright>
-// <summary>Request message for updating</summary>
+// <summary>Message sent to the server</summary>
 //-----------------------------------------------------------------------
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Csla;
 
-namespace Csla.Server.Hosts.HttpChannel
+using System;
+
+namespace Csla.Server.Hosts.DataPortalChannel
 {
   /// <summary>
-  /// Request message for updating
-  /// a business object.
+  /// Message sent to the WCF data portal.
   /// </summary>
   [Serializable]
-  public class UpdateRequest : ReadOnlyBase<UpdateRequest>
+  public class CriteriaRequest : ReadOnlyBase<CriteriaRequest>
   {
     /// <summary>
-    /// Serialized object data.
+    /// Assembly qualified name of the
+    /// business object type to create.
     /// </summary>
-    public static readonly PropertyInfo<byte[]> ObjectDataProperty = RegisterProperty<byte[]>(c => c.ObjectData);
+    public static readonly PropertyInfo<string> TypeNameProperty = RegisterProperty<string>(c => c.TypeName);
+
     /// <summary>
-    /// Serialized object data.
+    /// Assembly qualified name of the
+    /// business object type to create.
     /// </summary>
-    public byte[] ObjectData
+    public string TypeName
     {
-      get { return GetProperty(ObjectDataProperty); }
-      set { LoadProperty(ObjectDataProperty, value); }
+      get { return GetProperty(TypeNameProperty); }
+      set { LoadProperty(TypeNameProperty, value); }
+    }
+
+    /// <summary>
+    /// Serialized data for the criteria object.
+    /// </summary>
+    public static readonly PropertyInfo<byte[]> CriteriaDataProperty = RegisterProperty<byte[]>(c => c.CriteriaData);
+
+    /// <summary>
+    /// Serialized data for the criteria object.
+    /// </summary>
+    public byte[] CriteriaData
+    {
+      get { return GetProperty(CriteriaDataProperty); }
+      set { LoadProperty(CriteriaDataProperty, value); }
     }
 
     /// <summary>
     /// Serialized data for the principal object.
     /// </summary>
     public static readonly PropertyInfo<byte[]> PrincipalProperty = RegisterProperty<byte[]>(c => c.Principal);
+
     /// <summary>
     /// Serialized data for the principal object.
     /// </summary>
@@ -51,6 +64,7 @@ namespace Csla.Server.Hosts.HttpChannel
     /// Serialized data for the global context object.
     /// </summary>
     public static readonly PropertyInfo<byte[]> GlobalContextProperty = RegisterProperty<byte[]>(c => c.GlobalContext);
+
     /// <summary>
     /// Serialized data for the global context object.
     /// </summary>
@@ -64,6 +78,7 @@ namespace Csla.Server.Hosts.HttpChannel
     /// Serialized data for the client context object.
     /// </summary>
     public static readonly PropertyInfo<byte[]> ClientContextProperty = RegisterProperty<byte[]>(c => c.ClientContext);
+
     /// <summary>
     /// Serialized data for the client context object.
     /// </summary>
@@ -78,6 +93,7 @@ namespace Csla.Server.Hosts.HttpChannel
     /// </summary>
     /// <value>The client culture.</value>
     public static readonly PropertyInfo<string> ClientCultureProperty = RegisterProperty<string>(c => c.ClientCulture);
+
     /// <summary>
     /// Serialized client culture.
     /// </summary>
@@ -93,6 +109,7 @@ namespace Csla.Server.Hosts.HttpChannel
     /// </summary>
     /// <value>The client UI culture.</value>
     public static readonly PropertyInfo<string> ClientUICultureProperty = RegisterProperty<string>(c => c.ClientUICulture);
+
     /// <summary>
     /// Serialized client UI culture.
     /// </summary>

--- a/Source/Csla/Server/Hosts/DataPortalChannel/DataPortalErrorInfo.cs
+++ b/Source/Csla/Server/Hosts/DataPortalChannel/DataPortalErrorInfo.cs
@@ -5,20 +5,17 @@
 // </copyright>
 // <summary>Message containing details about any</summary>
 //-----------------------------------------------------------------------
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Csla.Server.Hosts.HttpChannel
+using System;
+
+namespace Csla.Server.Hosts.DataPortalChannel
 {
   /// <summary>
   /// Message containing details about any
   /// server-side exception.
   /// </summary>
   [Serializable]
-  public class HttpErrorInfo : ReadOnlyBase<HttpErrorInfo>
+  public class DataPortalErrorInfo : ReadOnlyBase<DataPortalErrorInfo>
   {
     /// <summary>
     /// Type name of the exception object.
@@ -75,12 +72,12 @@ namespace Csla.Server.Hosts.HttpChannel
       get { return GetProperty(SourceProperty); }
       private set { LoadProperty(SourceProperty, value); }
     }
-    
+
     /// <summary>
     /// TargetSiteName of the exception object.
     /// </summary>
     public static readonly PropertyInfo<string> TargetSiteNameProperty = RegisterProperty<string>(c => c.TargetSiteName);
-    
+
     /// <summary>
     /// TargetSiteName of the exception object.
     /// </summary>
@@ -89,20 +86,20 @@ namespace Csla.Server.Hosts.HttpChannel
       get { return GetProperty(TargetSiteNameProperty); }
       private set { LoadProperty(TargetSiteNameProperty, value); }
     }
-    
-    /// <summary>
-    /// HttpErrorInfo object containing information
-    /// about any inner exception of the original
-    /// exception.
-    /// </summary>
-    public static readonly PropertyInfo<HttpErrorInfo> InnerErrorProperty = RegisterProperty<HttpErrorInfo>(c => c.InnerError);
 
     /// <summary>
     /// HttpErrorInfo object containing information
     /// about any inner exception of the original
     /// exception.
     /// </summary>
-    public HttpErrorInfo InnerError
+    public static readonly PropertyInfo<DataPortalErrorInfo> InnerErrorProperty = RegisterProperty<DataPortalErrorInfo>(c => c.InnerError);
+
+    /// <summary>
+    /// HttpErrorInfo object containing information
+    /// about any inner exception of the original
+    /// exception.
+    /// </summary>
+    public DataPortalErrorInfo InnerError
     {
       get { return GetProperty(InnerErrorProperty); }
       private set { LoadProperty(InnerErrorProperty, value); }
@@ -114,7 +111,7 @@ namespace Csla.Server.Hosts.HttpChannel
     /// <param name="ex">
     /// The Exception to encapusulate.
     /// </param>
-    public HttpErrorInfo(Exception ex)
+    public DataPortalErrorInfo(Exception ex)
     {
       this.ExceptionTypeName = ex.GetType().FullName;
       this.Message = ex.Message;
@@ -123,13 +120,13 @@ namespace Csla.Server.Hosts.HttpChannel
       this.Source = ex.Source;
 #endif
       if (ex.InnerException != null)
-        this.InnerError = new HttpErrorInfo(ex.InnerException);
+        this.InnerError = new DataPortalErrorInfo(ex.InnerException);
     }
 
     /// <summary>
     /// Creates an empty instance of the type.
     /// </summary>
-    public HttpErrorInfo()
+    public DataPortalErrorInfo()
     { }
 
 #if !NETSTANDARD2_0 && !NET5_0
@@ -138,7 +135,7 @@ namespace Csla.Server.Hosts.HttpChannel
     /// the WcfErrorInfo data.
     /// </summary>
     /// <param name="info">WcfErrorInfo object.</param>
-    public HttpErrorInfo(Csla.WcfPortal.WcfErrorInfo info)
+    public DataPortalErrorInfo(Csla.WcfPortal.WcfErrorInfo info)
     {
       var errorInfo = this;
       var source = info;
@@ -152,7 +149,7 @@ namespace Csla.Server.Hosts.HttpChannel
         source = source.InnerError;
         if (source != null)
         {
-          errorInfo.InnerError = new HttpErrorInfo();
+          errorInfo.InnerError = new DataPortalErrorInfo();
           errorInfo = errorInfo.InnerError;
         }
       }

--- a/Source/Csla/Server/Hosts/DataPortalChannel/DataPortalResponse.cs
+++ b/Source/Csla/Server/Hosts/DataPortalChannel/DataPortalResponse.cs
@@ -5,37 +5,37 @@
 // </copyright>
 // <summary>Response message for returning</summary>
 //-----------------------------------------------------------------------
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Csla.Server.Hosts.HttpChannel
+using System;
+
+namespace Csla.Server.Hosts.DataPortalChannel
 {
   /// <summary>
   /// Response message for returning
   /// the results of a data portal call.
   /// </summary>
   [Serializable]
-  public class HttpResponse : ReadOnlyBase<HttpResponse>
+  public class DataPortalResponse : ReadOnlyBase<DataPortalResponse>
   {
     /// <summary>
     /// Server-side exception data if an exception occurred on the server.
     /// </summary>
-    public static readonly PropertyInfo<HttpErrorInfo> ErrorDataProperty = RegisterProperty<HttpErrorInfo>(c => c.ErrorData);
+    public static readonly PropertyInfo<DataPortalErrorInfo> ErrorDataProperty = RegisterProperty<DataPortalErrorInfo>(c => c.ErrorData);
+
     /// <summary>
     /// Server-side exception data if an exception occurred on the server.
     /// </summary>
-    public HttpErrorInfo ErrorData
+    public DataPortalErrorInfo ErrorData
     {
       get { return GetProperty(ErrorDataProperty); }
       set { LoadProperty(ErrorDataProperty, value); }
     }
+
     /// <summary>
     /// Serialized GlobalContext data returned from the server (deserialize with MobileFormatter).
     /// </summary>
     public static readonly PropertyInfo<byte[]> GlobalContextProperty = RegisterProperty<byte[]>(c => c.GlobalContext);
+
     /// <summary>
     /// Serialized GlobalContext data returned from the server (deserialize with MobileFormatter).
     /// </summary>
@@ -44,10 +44,12 @@ namespace Csla.Server.Hosts.HttpChannel
       get { return GetProperty(GlobalContextProperty); }
       set { LoadProperty(GlobalContextProperty, value); }
     }
+
     /// <summary>
     /// Serialized business object data returned from the server (deserialize with MobileFormatter).
     /// </summary>
     public static readonly PropertyInfo<byte[]> ObjectDataProperty = RegisterProperty<byte[]>(c => c.ObjectData);
+
     /// <summary>
     /// Serialized business object data returned from the server (deserialize with MobileFormatter).
     /// </summary>

--- a/Source/Csla/Server/Hosts/DataPortalChannel/UpdateRequest.cs
+++ b/Source/Csla/Server/Hosts/DataPortalChannel/UpdateRequest.cs
@@ -1,57 +1,41 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="CriteriaRequest.cs" company="Marimer LLC">
+// <copyright file="UpdateRequest.cs" company="Marimer LLC">
 //     Copyright (c) Marimer LLC. All rights reserved.
 //     Website: https://cslanet.com
 // </copyright>
-// <summary>Message sent to the server</summary>
+// <summary>Request message for updating</summary>
 //-----------------------------------------------------------------------
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Csla;
 
-namespace Csla.Server.Hosts.HttpChannel
+using System;
+
+namespace Csla.Server.Hosts.DataPortalChannel
 {
   /// <summary>
-  /// Message sent to the WCF data portal.
+  /// Request message for updating
+  /// a business object.
   /// </summary>
   [Serializable]
-  public class CriteriaRequest : ReadOnlyBase<CriteriaRequest>
+  public class UpdateRequest : ReadOnlyBase<UpdateRequest>
   {
     /// <summary>
-    /// Assembly qualified name of the 
-    /// business object type to create.
+    /// Serialized object data.
     /// </summary>
-    public static readonly PropertyInfo<string> TypeNameProperty = RegisterProperty<string>(c => c.TypeName);
-    /// <summary>
-    /// Assembly qualified name of the 
-    /// business object type to create.
-    /// </summary>
-    public string TypeName
-    {
-      get { return GetProperty(TypeNameProperty); }
-      set { LoadProperty(TypeNameProperty, value); }
-    }
+    public static readonly PropertyInfo<byte[]> ObjectDataProperty = RegisterProperty<byte[]>(c => c.ObjectData);
 
     /// <summary>
-    /// Serialized data for the criteria object.
+    /// Serialized object data.
     /// </summary>
-    public static readonly PropertyInfo<byte[]> CriteriaDataProperty = RegisterProperty<byte[]>(c => c.CriteriaData);
-    /// <summary>
-    /// Serialized data for the criteria object.
-    /// </summary>
-    public byte[] CriteriaData
+    public byte[] ObjectData
     {
-      get { return GetProperty(CriteriaDataProperty); }
-      set { LoadProperty(CriteriaDataProperty, value); }
+      get { return GetProperty(ObjectDataProperty); }
+      set { LoadProperty(ObjectDataProperty, value); }
     }
 
     /// <summary>
     /// Serialized data for the principal object.
     /// </summary>
     public static readonly PropertyInfo<byte[]> PrincipalProperty = RegisterProperty<byte[]>(c => c.Principal);
+
     /// <summary>
     /// Serialized data for the principal object.
     /// </summary>
@@ -65,6 +49,7 @@ namespace Csla.Server.Hosts.HttpChannel
     /// Serialized data for the global context object.
     /// </summary>
     public static readonly PropertyInfo<byte[]> GlobalContextProperty = RegisterProperty<byte[]>(c => c.GlobalContext);
+
     /// <summary>
     /// Serialized data for the global context object.
     /// </summary>
@@ -78,6 +63,7 @@ namespace Csla.Server.Hosts.HttpChannel
     /// Serialized data for the client context object.
     /// </summary>
     public static readonly PropertyInfo<byte[]> ClientContextProperty = RegisterProperty<byte[]>(c => c.ClientContext);
+
     /// <summary>
     /// Serialized data for the client context object.
     /// </summary>
@@ -92,6 +78,7 @@ namespace Csla.Server.Hosts.HttpChannel
     /// </summary>
     /// <value>The client culture.</value>
     public static readonly PropertyInfo<string> ClientCultureProperty = RegisterProperty<string>(c => c.ClientCulture);
+
     /// <summary>
     /// Serialized client culture.
     /// </summary>
@@ -107,6 +94,7 @@ namespace Csla.Server.Hosts.HttpChannel
     /// </summary>
     /// <value>The client UI culture.</value>
     public static readonly PropertyInfo<string> ClientUICultureProperty = RegisterProperty<string>(c => c.ClientUICulture);
+
     /// <summary>
     /// Serialized client UI culture.
     /// </summary>


### PR DESCRIPTION
#1311 

Moved all common code to new abstract DataPortalProxy class and updated Http Proxy, RabbitMqProxy and GrpcProxy.

The HttpChannel types have been moved to DataPortalChannel and types prefixed with Http now prefixed with DataPortal. Not sure if that is what you meant by 'Some type names should change (the various message/exception/etc. types prefixed with Http) - this should be relatively transparent to most people, but could still break some code'. 