### PR TITLE
#2291 Add Missing XML Comments

### DIFF
--- a/Source/Csla.Channels.Grpc/GrpcProxy.cs
+++ b/Source/Csla.Channels.Grpc/GrpcProxy.cs
@@ -93,6 +93,15 @@ namespace Csla.Channels.Grpc
       return _grpcClient ??= new GrpcService.GrpcServiceClient(GetChannel());
     }
 
+    /// <summary>
+    /// Create message and send to Grpc server.
+    /// Return Response from server
+    /// </summary>
+    /// <param name="serialized">Serialised request</param>
+    /// <param name="operation">DataPortal operation</param>
+    /// <param name="routingToken">Routing Tag for server</param>
+    /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
+    /// <returns>Serialised response from server</returns>
     protected override async Task<byte[]> CallDataPortalServer(byte[] serialized, string operation, string routingToken, bool isSync)
     {
       ByteString outbound = ByteString.CopyFrom(serialized);

--- a/Source/Csla.Channels.RabbitMq/RabbitMqProxy.cs
+++ b/Source/Csla.Channels.RabbitMq/RabbitMqProxy.cs
@@ -179,6 +179,15 @@ namespace Csla.Channels.RabbitMq
       return await base.Delete(objectType, criteria, context, isSync);
     }
 
+    /// <summary>
+    /// Create message and send to Rabbit MQ server.
+    /// Return Response from server
+    /// </summary>
+    /// <param name="serialized">Serialised request</param>
+    /// <param name="operation">DataPortal operation</param>
+    /// <param name="routingToken">Routing Tag for server</param>
+    /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
+    /// <returns>Serialised response from server</returns>
     protected override async Task<byte[]> CallDataPortalServer(byte[] serialized, string operation, string routingToken, bool isSync)
     {
       var correlationId = Guid.NewGuid().ToString();

--- a/Source/Csla/DataPortalClient/DataPortalProxy.cs
+++ b/Source/Csla/DataPortalClient/DataPortalProxy.cs
@@ -282,9 +282,18 @@ namespace Csla.DataPortalClient
       return response;
     }
 
+    /// <summary>
+    /// Override this method with implementation of sending and receiving of data to the server
+    /// Returns serialised response from server
+    /// </summary>
+    /// <param name="serialized">Serialised request</param>
+    /// <param name="operation">DataPortal operation</param>
+    /// <param name="routingToken">Routing Tag for server</param>
+    /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
+    /// <returns>Serialised response from server</returns>
     protected abstract Task<byte[]> CallDataPortalServer(byte[] serialized, string operation, string routingToken, bool isSync);
 
-    protected virtual string GetRoutingToken(Type objectType)
+    private string GetRoutingToken(Type objectType)
     {
       string result = null;
       var list = objectType.GetCustomAttributes(typeof(DataPortalServerRoutingTagAttribute), false);

--- a/Source/Csla/DataPortalClient/HttpProxy.cs
+++ b/Source/Csla/DataPortalClient/HttpProxy.cs
@@ -123,13 +123,19 @@ namespace Csla.DataPortalClient
     /// </summary>
     public static bool UseTextSerialization { get; set; } = false;
 
+    /// <summary>
+    /// Select client to make request based on isSync parameter and return response from server
+    /// </summary>
+    /// <param name="serialized">Serialised request</param>
+    /// <param name="operation">DataPortal operation</param>
+    /// <param name="routingToken">Routing Tag for server</param>
+    /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
+    /// <returns>Serialised response from server</returns>
     protected override async Task<byte[]> CallDataPortalServer(byte[] serialized, string operation, string routingToken, bool isSync)
     {
-      if (isSync)
-        serialized = CallViaWebClient(serialized, operation, routingToken);
-      else
-        serialized = await CallViaHttpClient(serialized, operation, routingToken);
-      return serialized;
+      return isSync
+        ? CallViaWebClient(serialized, operation, routingToken)
+        : await CallViaHttpClient(serialized, operation, routingToken);
     }
 
     /// <summary>

--- a/Source/csla.netcore.test/DataPortal/RoutingTagTests.cs
+++ b/Source/csla.netcore.test/DataPortal/RoutingTagTests.cs
@@ -10,15 +10,18 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Csla;
+
 #if !NUNIT
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 #else
 using NUnit.Framework;
 using TestClass = NUnit.Framework.TestFixtureAttribute;
 using TestInitialize = NUnit.Framework.SetUpAttribute;
 using TestCleanup = NUnit.Framework.TearDownAttribute;
 using TestMethod = NUnit.Framework.TestAttribute;
-#endif 
+#endif
 
 namespace csla.netcore.test.DataPortal
 {
@@ -37,9 +40,10 @@ namespace csla.netcore.test.DataPortal
     public void GetRoutingTag()
     {
       var proxy = new Csla.DataPortalClient.HttpProxy();
-      var method = proxy.GetType().GetMethods(System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
-        .Where(r=>r.Name == "GetRoutingToken")
+      var method = proxy.GetType().BaseType.GetMethods(System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+        .Where(r => r.Name == "GetRoutingToken")
         .FirstOrDefault();
+
       string result = (string)method.Invoke(proxy, new object[] { typeof(RoutingTest) });
       Assert.AreEqual("mytag", result);
     }
@@ -93,6 +97,5 @@ namespace csla.netcore.test.DataPortal
   [DataPortalServerRoutingTag("mytag")]
   public class RoutingTest : BusinessBase<RoutingTest>
   {
-
   }
 }


### PR DESCRIPTION
Closes #2291 Add missing comments to CallDataPortalServer methods in DataPortalProxy, GrpcProxy, HttpProxy and RabbitMqProxy

Change routing tag test to use base class and make GetRoutingToken method


