### PR TITLE
Check for whether synchronous WebClient calls are supported, Issue #2392

### DIFF
--- a/Source/Csla/DataPortalClient/HttpProxy.cs
+++ b/Source/Csla/DataPortalClient/HttpProxy.cs
@@ -6,6 +6,7 @@
 // <summary>Implements a data portal proxy to relay data portal</summary>
 //-----------------------------------------------------------------------
 using Csla.Core;
+using Csla.Properties;
 using Csla.Serialization;
 using Csla.Serialization.Mobile;
 using Csla.Server;
@@ -169,6 +170,10 @@ namespace Csla.DataPortalClient
 
     private byte[] CallViaWebClient(byte[] serialized, string operation, string routingToken)
     {
+      if (!WebCallCapabilities.AreSyncWebClientMethodsSupported())
+      {
+        throw new InvalidOperationException(Resources.SyncDataAccessNotSupportedException);
+      }
       WebClient client = GetWebClient();
       var url = $"{DataPortalUrl}?operation={CreateOperationTag(operation, ApplicationContext.VersionRoutingTag, routingToken)}";
       if (UseTextSerialization)

--- a/Source/Csla/DataPortalClient/HttpProxy.cs
+++ b/Source/Csla/DataPortalClient/HttpProxy.cs
@@ -172,7 +172,7 @@ namespace Csla.DataPortalClient
     {
       if (!WebCallCapabilities.AreSyncWebClientMethodsSupported())
       {
-        throw new InvalidOperationException(Resources.SyncDataAccessNotSupportedException);
+        throw new NotSupportedException(Resources.SyncDataAccessNotSupportedException);
       }
       WebClient client = GetWebClient();
       var url = $"{DataPortalUrl}?operation={CreateOperationTag(operation, ApplicationContext.VersionRoutingTag, routingToken)}";

--- a/Source/Csla/DataPortalClient/WebCallCapabilities.cs
+++ b/Source/Csla/DataPortalClient/WebCallCapabilities.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Csla.DataPortalClient
+{
+
+  /// <summary>
+  /// Determines capabilities of web calls in the current runtime environment
+  /// </summary>
+  internal static class WebCallCapabilities
+  {
+
+    /// <summary>
+    /// Method to determine if the runtime supports synchronous WebClient usage
+    /// WebAssembly specifically disallows use of this synchronous class
+    /// </summary>
+    /// <returns>Boolean true if synchronous data access is enabled, otherwise false</returns>
+    public static bool AreSyncWebClientMethodsSupported()
+    {
+      bool isWebAssembly;
+
+#if NETFRAMEWORK
+      isWebAssembly = false;
+#elif NETSTANDARD
+      // Use textual OSDescription to identify WebAssembly on .NET Standard
+      string osDescription = RuntimeInformation.OSDescription;
+      isWebAssembly = osDescription.Equals("web", StringComparison.InvariantCultureIgnoreCase);
+#else
+      isWebAssembly = RuntimeInformation.OSArchitecture == Architecture.Wasm;
+#endif
+
+      return !isWebAssembly;
+    }
+
+  }
+}

--- a/Source/Csla/DataPortalClient/WebCallCapabilities.cs
+++ b/Source/Csla/DataPortalClient/WebCallCapabilities.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿//-----------------------------------------------------------------------
+// <copyright file="HttpProxy.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>Exposes platform-specific web call capabilities</summary>
+//-----------------------------------------------------------------------
+using System;
 using System.Runtime.InteropServices;
 
 namespace Csla.DataPortalClient

--- a/Source/Csla/Properties/Resources.Designer.cs
+++ b/Source/Csla/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Csla.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -1029,6 +1029,15 @@ namespace Csla.Properties {
         public static string StringToDateException {
             get {
                 return ResourceManager.GetString("StringToDateException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Synchronous data access is not supported on this runtime! Please use async data access methods.
+        /// </summary>
+        public static string SyncDataAccessNotSupportedException {
+            get {
+                return ResourceManager.GetString("SyncDataAccessNotSupportedException", resourceCulture);
             }
         }
         

--- a/Source/Csla/Properties/Resources.Designer.cs
+++ b/Source/Csla/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Csla.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -1033,7 +1033,7 @@ namespace Csla.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Synchronous data access is not supported on this runtime! Please use async data access methods.
+        ///   Looks up a localized string similar to Synchronous data access is not supported on this runtime. Please use async data access methods.
         /// </summary>
         public static string SyncDataAccessNotSupportedException {
             get {

--- a/Source/Csla/Properties/Resources.resx
+++ b/Source/Csla/Properties/Resources.resx
@@ -476,6 +476,6 @@
     <value>{0} requires a value for either the {1} or the {2} parameter.</value>
   </data>
   <data name="SyncDataAccessNotSupportedException" xml:space="preserve">
-    <value>Synchronous data access is not supported on this runtime! Please use async data access methods</value>
+    <value>Synchronous data access is not supported on this runtime. Please use async data access methods</value>
   </data>
 </root>

--- a/Source/Csla/Properties/Resources.resx
+++ b/Source/Csla/Properties/Resources.resx
@@ -475,4 +475,7 @@
   <data name="OneOfTwoParametersRequiredException" xml:space="preserve">
     <value>{0} requires a value for either the {1} or the {2} parameter.</value>
   </data>
+  <data name="SyncDataAccessNotSupportedException" xml:space="preserve">
+    <value>Synchronous data access is not supported on this runtime! Please use async data access methods</value>
+  </data>
 </root>


### PR DESCRIPTION
Added a check for whether synchronous WebClient calls are supported, to throw a more helpful exception when running on WebAssembly, Issue #2392

I chose not to complicate things with dependency injection, as this class is not testable anyway due to the level of implementation detail it already contains.