### PR TITLE
Initial fixes to get Csla.Blazor.Tests to pass after rewrite to use DI

### DIFF
--- a/Source/Csla.Analyzers/Csla.Analyzers/Csla.Analyzers.csproj
+++ b/Source/Csla.Analyzers/Csla.Analyzers/Csla.Analyzers.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.10.0" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />

--- a/Source/Csla.Blazor.Test/Csla.Blazor.Test.csproj
+++ b/Source/Csla.Blazor.Test/Csla.Blazor.Test.csproj
@@ -2,14 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-
     <IsPackable>false</IsPackable>
-
     <ApplicationIcon />
-
     <OutputType>Library</OutputType>
-
-    <StartupObject />
+    <BaseOutputPath>..\..\Bin</BaseOutputPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,8 +13,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/Csla.Blazor.Test/EditContextCslaExtensionsTests.cs
+++ b/Source/Csla.Blazor.Test/EditContextCslaExtensionsTests.cs
@@ -3,16 +3,18 @@ using Csla.Blazor.Test.Fakes;
 using Microsoft.AspNetCore.Components.Forms;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using System;
 
 namespace Csla.Blazor.Test
 {
-	[TestClass]
-	public class EditContextCslaExtensionsTests
-	{
+  [TestClass]
+  public class EditContextCslaExtensionsTests
+  {
 
-		[TestMethod]
-		public void ValidateModel_EmptyLastName_OneValidationMessage()
-		{
+    [TestMethod]
+    public void ValidateModel_EmptyLastName_OneValidationMessage()
+    {
       // Arrange
       FakePerson person = GetValidFakePerson();
       EditContext editContext = new EditContext(person);
@@ -28,7 +30,7 @@ namespace Csla.Blazor.Test
       // Assert
       Assert.AreEqual(1, messages.Count(), "Incorrect number of validation messages returned! " + ConcatenateMessages(messages));
 
-		}
+    }
 
     [TestMethod]
     public void ValidateModel_ShortFirstName_NoValidationMessages()
@@ -260,7 +262,11 @@ namespace Csla.Blazor.Test
 
     FakePerson GetValidFakePerson()
     {
-      FakePerson person = FakePerson.NewFakePerson();
+      DataPortal<FakePerson> dataPortal;
+      FakePerson person;
+
+      dataPortal = new DataPortal<FakePerson>(Startup.ApplicationContext);
+      person = dataPortal.Create();
 
       person.FirstName = "John";
       person.LastName = "Smith";

--- a/Source/Csla.Blazor.Test/Fakes/FakePerson.cs
+++ b/Source/Csla.Blazor.Test/Fakes/FakePerson.cs
@@ -51,15 +51,6 @@ namespace Csla.Blazor.Test.Fakes
 
     #endregion
 
-    #region Factory Methods
-
-    public static FakePerson NewFakePerson()
-    {
-      return DataPortal.Create<FakePerson>();
-    }
-
-    #endregion
-
     #region Business Rules
 
     protected override void AddBusinessRules()
@@ -97,8 +88,11 @@ namespace Csla.Blazor.Test.Fakes
     [Create]
     private void Create()
     {
+      DataPortal<FakePersonEmailAddresses> dataPortal;
+
       // Create an empty list for holding email addresses
-      LoadProperty(EmailAddressesProperty, DataPortal.CreateChild<FakePersonEmailAddresses>());
+      dataPortal = new DataPortal<FakePersonEmailAddresses>(ApplicationContext);
+      LoadProperty(EmailAddressesProperty, dataPortal.CreateChild());
 
       // Trigger object checks
       BusinessRules.CheckRules();

--- a/Source/Csla.Blazor.Test/Fakes/FakePersonEmailAddresses.cs
+++ b/Source/Csla.Blazor.Test/Fakes/FakePersonEmailAddresses.cs
@@ -10,7 +10,12 @@ namespace Csla.Blazor.Test.Fakes
 
     public FakePersonEmailAddress NewEmailAddress()
     {
-      var emailAddress = DataPortal.CreateChild<FakePersonEmailAddress>();
+      DataPortal<FakePersonEmailAddress> dataPortal;
+
+      // Create an empty list for holding email addresses
+      dataPortal = new DataPortal<FakePersonEmailAddress>(ApplicationContext);
+
+      var emailAddress = dataPortal.CreateChild();
       this.Add(emailAddress);
       return emailAddress;
     }

--- a/Source/Csla.Blazor.Test/Startup.cs
+++ b/Source/Csla.Blazor.Test/Startup.cs
@@ -1,0 +1,54 @@
+﻿using Csla.Configuration;
+using Csla.Server;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Security.Principal;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Csla.Blazor.Test
+{
+
+  [TestClass]
+  public class Startup
+  {
+
+    private static ApplicationContext _applicationContext;
+
+    [AssemblyInitialize]
+    public static void Initialize(TestContext testContext)
+    {
+      IPrincipal genericPrincipal;
+      ServiceProvider serviceProvider;
+      Core.ApplicationContextManagerStatic contextManager;
+
+      // Initialise DI
+      var services = new ServiceCollection();
+
+      // Add Csla
+      services.AddCsla();
+      services.AddTransient<IDataPortalServer, SimpleDataPortal>();
+
+      serviceProvider = services.BuildServiceProvider();
+
+      // Make the service provider available to CSLA
+      // CslaConfiguration.Configure().ServiceProviderScope(serviceProvider);
+      // CslaConfiguration.Configure().DataPortal().DefaultProxy(typeof(DataPortalClient.LocalProxy), "");
+
+      // Initialise CSLA security
+      contextManager = new Core.ApplicationContextManagerStatic();
+      contextManager.SetDefaultServiceProvider(serviceProvider);
+      genericPrincipal = new GenericPrincipal(new GenericIdentity("Fred"), new string[] { "Users" });
+      contextManager.SetUser(genericPrincipal);
+      _applicationContext = new ApplicationContext(contextManager, serviceProvider);
+
+    }
+
+    public static ApplicationContext ApplicationContext => _applicationContext;
+
+  }
+}

--- a/Source/Csla.Generators/cs/Csla.Generators.CSharp.TestObjects/Csla.Generators.CSharp.TestObjects.csproj
+++ b/Source/Csla.Generators/cs/Csla.Generators.CSharp.TestObjects/Csla.Generators.CSharp.TestObjects.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <BaseOutputPath>..\..\..\..\Bin</BaseOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Csla.Generators/cs/Csla.Generators.CSharp.Tests/Csla.Generators.CSharp.Tests.csproj
+++ b/Source/Csla.Generators/cs/Csla.Generators.CSharp.Tests/Csla.Generators.CSharp.Tests.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-
     <IsPackable>false</IsPackable>
+    <BaseOutputPath>..\..\..\..\Bin</BaseOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Csla/DataPortalT.cs
+++ b/Source/Csla/DataPortalT.cs
@@ -158,21 +158,21 @@ namespace Csla
       return (T)Create(typeof(T), Server.DataPortal.GetCriteriaFromArray(criteria));
     }
 
-    //internal static object Create(Type objectType, object criteria)
-    //{
-    //  var dp = new DataPortal<object>();
-    //  try
-    //  {
-    //    return dp.DoCreateAsync(objectType, criteria, true).Result;
-    //  }
-    //  catch (AggregateException ex)
-    //  {
-    //    if (ex.InnerExceptions.Count > 0)
-    //      throw ex.InnerExceptions[0];
-    //    else
-    //      throw;
-    //  }
-    //}
+    private object Create(Type objectType, object criteria)
+    {
+      var dp = new DataPortal<object>(ApplicationContext);
+      try
+      {
+        return dp.DoCreateAsync(objectType, criteria, true).Result;
+      }
+      catch (AggregateException ex)
+      {
+        if (ex.InnerExceptions.Count > 0)
+          throw ex.InnerExceptions[0];
+        else
+          throw;
+      }
+    }
 
     /// <summary>
     /// Called by a factory method in a business class or

--- a/Source/Csla/Server/DataPortalContext.cs
+++ b/Source/Csla/Server/DataPortalContext.cs
@@ -23,6 +23,7 @@ namespace Csla.Server
     private bool _remotePortal;
     private string _clientCulture;
     private string _clientUICulture;
+    private ApplicationContext _applicationContext;
     private ContextDictionary _clientContext;
     [NonSerialized]
     private TransactionalTypes _transactionalType;
@@ -32,7 +33,14 @@ namespace Csla.Server
     /// <summary>
     /// Gets or sets the current ApplicationContext object.
     /// </summary>
-    public ApplicationContext ApplicationContext { get; set; }
+    public ApplicationContext ApplicationContext { 
+      get { return _applicationContext; }
+      set 
+      {
+        _applicationContext = value;
+        _clientContext = value.ContextManager.GetClientContext(value.ExecutionLocation);
+      } 
+    }
 
     /// <summary>
     /// The current principal object
@@ -109,7 +117,6 @@ namespace Csla.Server
       _remotePortal = isRemotePortal;
       _clientCulture = System.Threading.Thread.CurrentThread.CurrentCulture.Name;
       _clientUICulture = System.Threading.Thread.CurrentThread.CurrentUICulture.Name;
-      _clientContext = ApplicationContext.ContextManager.GetClientContext(ApplicationContext.ExecutionLocation);
     }
 
     /// <summary>

--- a/Source/csla.test.sln
+++ b/Source/csla.test.sln
@@ -57,6 +57,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Csla.AspNetCore", "Csla.Asp
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Csla.Web.Mvc5-Net4.6", "Csla.Web.Mvc5.Net4.6\Csla.Web.Mvc5-Net4.6.csproj", "{9D8A32E2-E82E-425C-A8EA-AC2BC17CCA0D}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Csla.Blazor.Test", "Csla.Blazor.Test\Csla.Blazor.Test.csproj", "{A83CE9B0-F972-426E-9611-B3EFD8EE922E}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Csla.Xaml.Shared\Csla.Xaml.Shared.projitems*{182ac936-b5af-4b1e-a9d5-5dacad90ec1f}*SharedItemsImports = 5
@@ -809,6 +811,46 @@ Global
 		{9D8A32E2-E82E-425C-A8EA-AC2BC17CCA0D}.Testing|x64.Build.0 = Debug|Any CPU
 		{9D8A32E2-E82E-425C-A8EA-AC2BC17CCA0D}.Testing|x86.ActiveCfg = Debug|Any CPU
 		{9D8A32E2-E82E-425C-A8EA-AC2BC17CCA0D}.Testing|x86.Build.0 = Debug|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Debug|ARM.Build.0 = Debug|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Debug|x64.Build.0 = Debug|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Debug|x86.Build.0 = Debug|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Mono Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Mono Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Mono Debug|ARM.ActiveCfg = Debug|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Mono Debug|ARM.Build.0 = Debug|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Mono Debug|x64.ActiveCfg = Debug|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Mono Debug|x64.Build.0 = Debug|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Mono Debug|x86.ActiveCfg = Debug|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Mono Debug|x86.Build.0 = Debug|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Mono Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Mono Release|Any CPU.Build.0 = Release|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Mono Release|ARM.ActiveCfg = Release|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Mono Release|ARM.Build.0 = Release|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Mono Release|x64.ActiveCfg = Release|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Mono Release|x64.Build.0 = Release|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Mono Release|x86.ActiveCfg = Release|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Mono Release|x86.Build.0 = Release|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Release|ARM.ActiveCfg = Release|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Release|ARM.Build.0 = Release|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Release|x64.ActiveCfg = Release|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Release|x64.Build.0 = Release|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Release|x86.ActiveCfg = Release|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Release|x86.Build.0 = Release|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Testing|Any CPU.ActiveCfg = Debug|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Testing|Any CPU.Build.0 = Debug|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Testing|ARM.ActiveCfg = Debug|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Testing|ARM.Build.0 = Debug|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Testing|x64.ActiveCfg = Debug|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Testing|x64.Build.0 = Debug|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Testing|x86.ActiveCfg = Debug|Any CPU
+		{A83CE9B0-F972-426E-9611-B3EFD8EE922E}.Testing|x86.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Submission as part of #2544; this gets Csla.Blazor.Tests to run and pass.

Includes changes to DataPortal<T> and DataPortalContext classes in order to get closer to a working version of CSLA after the significant changes to use DI for ApplicationContext. However, these changes are really only to get a happy path up and running; I don't feel at all precious about these being considered authoritative solutions to the problems I encountered!