### PR TITLE
Fixes to broken Analyzer tests after DataPortal changes for CSLA 6

### DIFF
--- a/Source/Csla.Analyzers/Csla.Analyzers.Tests/FindSaveAssignmentIssueAnalyzerAddAssignmentCodeFixTests.cs
+++ b/Source/Csla.Analyzers/Csla.Analyzers.Tests/FindSaveAssignmentIssueAnalyzerAddAssignmentCodeFixTests.cs
@@ -36,9 +36,16 @@ public class A : BusinessBase<A> { }
 
 public class VerifyGetFixes
 {
+  private IDataPortal<A> _dataPortal;
+
+  public VerifyGetFixes(IDataPortal<A> dataPortal)
+  {
+    _dataPortal = dataPortal;
+  }
+
   public void Use()
   {
-    var x = DataPortal.Fetch<A>();
+    var x = _dataPortal.Fetch<A>();
     x.Save();
   }
 }";

--- a/Source/Csla.Analyzers/Csla.Analyzers.Tests/FindSaveAssignmentIssueAnalyzerAddAsyncAssignmentCodeFixTests.cs
+++ b/Source/Csla.Analyzers/Csla.Analyzers.Tests/FindSaveAssignmentIssueAnalyzerAddAsyncAssignmentCodeFixTests.cs
@@ -37,9 +37,16 @@ public class A : BusinessBase<A> { }
 
 public class VerifyGetFixes
 {
+  private IDataPortal<A> _dataPortal;
+
+  public VerifyGetFixes(IDataPortal<A> dataPortal)
+  {
+    _dataPortal = dataPortal;
+  }
+
   public async Task Use()
   {
-    var x = DataPortal.Fetch<A>();
+    var x = _dataPortal.Fetch<A>();
     await x.SaveAsync();
   }
 }";


### PR DESCRIPTION
Fixes to broken Csla.Analyzers.Tests after DataPortal changes for Csla 6

Fixes form part of #2544 
