### PR TITLE
Addition of code that enables authorization rules to work in BlazorExample

### DIFF
--- a/Samples/BlazorExample/BlazorExample/Client/CurrentUserService.cs
+++ b/Samples/BlazorExample/BlazorExample/Client/CurrentUserService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Security.Claims;
+using Csla;
 
 namespace BlazorExample.Client
 {
@@ -9,24 +10,25 @@ namespace BlazorExample.Client
   /// </summary>
   public class CurrentUserService
   {
-    private ClaimsPrincipal _currentUser;
+    private ApplicationContext ApplicationContext;
 
     public event EventHandler<CurrentUserChangedEventArgs> CurrentUserChanged;
 
-    public CurrentUserService()
+    public CurrentUserService(ApplicationContext applicationContext)
     {
-      CurrentUser = new ClaimsPrincipal(new ClaimsIdentity());
+      ApplicationContext = applicationContext;
+      applicationContext.Principal = new ClaimsPrincipal(new ClaimsIdentity());
     }
 
     public ClaimsPrincipal CurrentUser
     {
       get
       {
-        return _currentUser;
+        return ApplicationContext.Principal;
       }
       set
       {
-        _currentUser = value;
+        ApplicationContext.Principal = value;
         CurrentUserChanged?.Invoke(this, new CurrentUserChangedEventArgs() { NewUser = value });
       }
     }

--- a/Samples/BlazorExample/BlazorExample/Client/Program.cs
+++ b/Samples/BlazorExample/BlazorExample/Client/Program.cs
@@ -13,8 +13,8 @@ builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.
 
 builder.Services.AddAuthorizationCore();
 builder.Services.AddOptions();
-builder.Services.AddSingleton<AuthenticationStateProvider, CurrentUserAuthenticationStateProvider>();
-builder.Services.AddSingleton<CurrentUserService>();
+builder.Services.AddScoped<AuthenticationStateProvider, CurrentUserAuthenticationStateProvider>();
+builder.Services.AddScoped<CurrentUserService>();
 
 builder.Services.AddCsla(o=>o
   .WithBlazorWebAssembly()

--- a/Samples/BlazorExample/BlazorExample/Shared/PersonEdit.cs
+++ b/Samples/BlazorExample/BlazorExample/Shared/PersonEdit.cs
@@ -32,6 +32,22 @@ namespace BlazorExample.Shared
       set => SetProperty(NameLengthProperty, value);
     }
 
+    #region Authorisation
+
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    [ObjectAuthorizationRules]
+    public static void AddObjectAuthorizationRules()
+    {
+      Csla.Rules.BusinessRules.AddRule(typeof(PersonEdit),
+        new Csla.Rules.CommonRules.IsInRole(Csla.Rules.AuthorizationActions.CreateObject, "Admin"));
+      Csla.Rules.BusinessRules.AddRule(typeof(PersonEdit),
+        new Csla.Rules.CommonRules.IsInRole(Csla.Rules.AuthorizationActions.EditObject, "Admin"));
+      Csla.Rules.BusinessRules.AddRule(typeof(PersonEdit),
+        new Csla.Rules.CommonRules.IsInRole(Csla.Rules.AuthorizationActions.DeleteObject, "Admin"));
+    }
+
+    #endregion
+
     protected override void AddBusinessRules()
     {
       base.AddBusinessRules();

--- a/Source/Csla/Rules/AuthorizationRules.cs
+++ b/Source/Csla/Rules/AuthorizationRules.cs
@@ -15,12 +15,9 @@ namespace Csla.Rules.CommonRules
   /// <summary>
   /// IsInRole authorization rule.
   /// </summary>
-  public class IsInRole : AuthorizationRule, Core.IUseApplicationContext
+  public class IsInRole : AuthorizationRule
   {
     private List<string> _roles;
-
-    ApplicationContext Core.IUseApplicationContext.ApplicationContext { get => ApplicationContext; set => ApplicationContext = value; }
-    private ApplicationContext ApplicationContext { get; set; }
 
     /// <summary>
     /// Creates an instance of the rule.
@@ -74,12 +71,12 @@ namespace Csla.Rules.CommonRules
     /// <param name="context">Rule context.</param>
     protected override void Execute(IAuthorizationContext context)
     {
-      if (ApplicationContext.User != null)
+      if (context.User != null)
       {
         if (_roles.Count > 0)
         {
           foreach (var item in _roles)
-            if (ApplicationContext.User.IsInRole(item))
+            if (context.User.IsInRole(item))
             {
               context.HasPermission = true;
               break;
@@ -96,12 +93,9 @@ namespace Csla.Rules.CommonRules
   /// <summary>
   /// IsNotInRole authorization rule.
   /// </summary>
-  public class IsNotInRole : AuthorizationRule, Core.IUseApplicationContext
+  public class IsNotInRole : AuthorizationRule
   {
     private List<string> _roles;
-
-    ApplicationContext Core.IUseApplicationContext.ApplicationContext { get => ApplicationContext; set => ApplicationContext = value; }
-    private ApplicationContext ApplicationContext { get; set; }
 
     /// <summary>
     /// Creates an instance of the rule.
@@ -156,10 +150,10 @@ namespace Csla.Rules.CommonRules
     protected override void Execute(IAuthorizationContext context)
     {
       context.HasPermission = true;
-      if (ApplicationContext.User != null)
+      if (context.User != null)
       {
         foreach (var item in _roles)
-          if (ApplicationContext.User.IsInRole(item))
+          if (context.User.IsInRole(item))
           {
             context.HasPermission = false;
             break;


### PR DESCRIPTION
This change includes the addition of authorization rules to the sample, plus the resolution of two bugs that prevent authorization from working in it. One of these bugs - a failure to impact ApplicationContext when logging in, affects just this sample application. However, the other - use of the wrong ApplicationContext instance on authorization rules (the instance captured [or not, as it happens] at the time of creation of the shared rule object instance, instead of the one provided during execution) - has wider impact than just this sample code, and is worthy of much more significant scrutiny.

Resolution for new issue #2644