### PR TITLE
Data portal exception sanitization inspector, implementing IDataPortalExceptionInspector

### DIFF
--- a/Source/Csla.Blazor.Test/Csla.Blazor.Test.csproj
+++ b/Source/Csla.Blazor.Test/Csla.Blazor.Test.csproj
@@ -5,10 +5,10 @@
     <IsPackable>false</IsPackable>
     <ApplicationIcon />
     <OutputType>Library</OutputType>
-    <BaseOutputPath>..\..\Bin</BaseOutputPath>
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />

--- a/Source/Csla.Blazor.Test/Startup.cs
+++ b/Source/Csla.Blazor.Test/Startup.cs
@@ -26,9 +26,9 @@ namespace Csla.Blazor.Test
 
       // Initialise DI
       var services = new ServiceCollection();
+      services.AddCslaTesting();
 
       // Add Csla
-      services.AddCsla();
       serviceProvider = services.BuildServiceProvider();
 
       // Initialise CSLA security

--- a/Source/Csla.Generators/cs/Csla.Generators.CSharp.TestObjects/Csla.Generators.CSharp.TestObjects.csproj
+++ b/Source/Csla.Generators/cs/Csla.Generators.CSharp.TestObjects/Csla.Generators.CSharp.TestObjects.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <BaseOutputPath>..\..\..\..\Bin</BaseOutputPath>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Csla.Generators/cs/Csla.Generators.CSharp.Tests/Csla.Generators.CSharp.Tests.csproj
+++ b/Source/Csla.Generators/cs/Csla.Generators.CSharp.Tests/Csla.Generators.CSharp.Tests.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
-    <BaseOutputPath>..\..\..\..\Bin</BaseOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Csla.TestHelpers/Csla.TestHelpers.csproj
+++ b/Source/Csla.TestHelpers/Csla.TestHelpers.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Csla.TestHelpers/ServiceCollectionExtensions.cs
+++ b/Source/Csla.TestHelpers/ServiceCollectionExtensions.cs
@@ -1,0 +1,41 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ServiceCollectionExtensions.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>Wiring up of DI for Csla, for enabling test projects</summary>
+//-----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Csla.Configuration;
+using Csla.TestHelpers;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+
+  /// <summary>
+  /// Extensions to IServiceCollection to support testability of Csla
+  /// </summary>
+  public static class ServiceCollectionExtensions
+  {
+
+    /// <summary>
+    /// Add the most basic of DI configurations to support testing
+    /// </summary>
+    /// <param name="services">The service collection into which dependencies are registered</param>
+    /// <returns>The instance of IServiceCollection being extended, to support method chaining</returns>
+    public static IServiceCollection AddCslaTesting(this IServiceCollection services)
+    {
+      services.AddTransient<IHostEnvironment, TestHostEnvironment>();
+      services.AddLogging();
+      services.AddCsla();
+      services.AddSingleton<Csla.Core.IContextManager, Csla.Core.ApplicationContextManagerStatic>();
+      services.AddSingleton<Csla.Server.Dashboard.IDashboard, Csla.Server.Dashboard.Dashboard>();
+
+      return services;
+    }
+
+  }
+}

--- a/Source/Csla.TestHelpers/TestHostEnvironment.cs
+++ b/Source/Csla.TestHelpers/TestHostEnvironment.cs
@@ -1,0 +1,45 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TestHostEnvironment.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>Helper class to support testing of behaviour under different hosting configurations</summary>
+//-----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+
+namespace Csla.TestHelpers
+{
+
+  /// <summary>
+  /// Basic implementation of IHostEnvironment, to support testing of anything 
+  /// that is dependent upon there being an implementation available
+  /// </summary>
+  public class TestHostEnvironment : IHostEnvironment
+  {
+
+    /// <summary>
+    /// The name of the environment in which the application is being run
+    /// </summary>
+    public string EnvironmentName { get; set; } = "Production";
+
+    /// <summary>
+    /// The name of the application
+    /// </summary>
+    public string ApplicationName { get; set; } = "ApplicationName";
+
+    /// <summary>
+    /// The path to the content root
+    /// </summary>
+    public string ContentRootPath { get; set; } = @"C:\Windows\Temp";
+
+    /// <summary>
+    /// The file provider to the content root; null by default
+    /// </summary>
+    public IFileProvider ContentRootFileProvider { get; set; }
+
+  }
+}

--- a/Source/Csla.Windows/Csla.Windows.csproj
+++ b/Source/Csla.Windows/Csla.Windows.csproj
@@ -21,8 +21,4 @@
     <ProjectReference Include="..\Csla\Csla.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
-  </ItemGroup>
 </Project>

--- a/Source/Csla.Xaml.Wpf/Csla.Xaml.Wpf.csproj
+++ b/Source/Csla.Xaml.Wpf/Csla.Xaml.Wpf.csproj
@@ -53,8 +53,4 @@
     <ProjectReference Include="..\Csla\Csla.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
-  </ItemGroup>
 </Project>

--- a/Source/Csla.Xaml.Xamarin/Csla.Xaml.Xamarin.csproj
+++ b/Source/Csla.Xaml.Xamarin/Csla.Xaml.Xamarin.csproj
@@ -24,8 +24,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.9" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/Csla/Configuration/Fluent/DataPortalServerOptions.cs
+++ b/Source/Csla/Configuration/Fluent/DataPortalServerOptions.cs
@@ -39,7 +39,7 @@ namespace Csla.Configuration
     /// that should be executed by the server-side data portal.
     /// injection.
     /// </summary>
-    internal List<Type> InterceptorProviders { get; } = new List<Type>() { typeof(Server.Interceptors.ServerSide.RevalidatingInterceptor) };
+    internal List<Type> InterceptorProviders { get; } = new List<Type>() { typeof(DefaultExceptionInspector) };
 
     /// <summary>
     /// Adds the type of an IInterceptDataPortal that will

--- a/Source/Csla/Configuration/Fluent/DataPortalServerOptions.cs
+++ b/Source/Csla/Configuration/Fluent/DataPortalServerOptions.cs
@@ -39,7 +39,7 @@ namespace Csla.Configuration
     /// that should be executed by the server-side data portal.
     /// injection.
     /// </summary>
-    internal List<Type> InterceptorProviders { get; } = new List<Type>() { typeof(DefaultExceptionInspector) };
+    internal List<Type> InterceptorProviders { get; } = new List<Type>() { typeof(Csla.Server.Interceptors.ServerSide.RevalidatingInterceptor) };
 
     /// <summary>
     /// Adds the type of an IInterceptDataPortal that will
@@ -72,7 +72,7 @@ namespace Csla.Configuration
     /// <summary>
     /// Gets or sets the type of the ExceptionInspector.
     /// </summary>
-    internal Type ExceptionInspectorType { get; set; } = typeof(SanitizingExceptionInspector);
+    internal Type ExceptionInspectorType { get; set; } = typeof(DefaultExceptionInspector);
 
     /// <summary>
     /// Sets the type of the ExceptionInspector.

--- a/Source/Csla/Configuration/Fluent/DataPortalServerOptions.cs
+++ b/Source/Csla/Configuration/Fluent/DataPortalServerOptions.cs
@@ -72,7 +72,7 @@ namespace Csla.Configuration
     /// <summary>
     /// Gets or sets the type of the ExceptionInspector.
     /// </summary>
-    internal Type ExceptionInspectorType { get; set; } = typeof(DefaultExceptionInspector);
+    internal Type ExceptionInspectorType { get; set; } = typeof(SanitizingExceptionInspector);
 
     /// <summary>
     /// Sets the type of the ExceptionInspector.

--- a/Source/Csla/Csla.csproj
+++ b/Source/Csla/Csla.csproj
@@ -36,6 +36,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />
@@ -54,6 +56,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
@@ -61,6 +65,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
@@ -68,6 +74,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
@@ -76,11 +84,14 @@
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">
       <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="Properties\Resources.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
 

--- a/Source/Csla/Properties/Resources.Designer.cs
+++ b/Source/Csla/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Csla.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -921,6 +921,24 @@ namespace Csla.Properties {
         public static string RuleMessageRequired {
             get {
                 return ResourceManager.GetString("RuleMessageRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A dataportal exception occurred on the server. See server logs for details. Request Id: {identifier}.
+        /// </summary>
+        public static string SanitizedServerSideDataPortalException {
+            get {
+                return ResourceManager.GetString("SanitizedServerSideDataPortalException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to An exception has occured during a server-side dataportal operation. Request Id: {identifier}\r\n{ex}.
+        /// </summary>
+        public static string ServerSideDataPortalException {
+            get {
+                return ResourceManager.GetString("ServerSideDataPortalException", resourceCulture);
             }
         }
         

--- a/Source/Csla/Properties/Resources.Designer.cs
+++ b/Source/Csla/Properties/Resources.Designer.cs
@@ -925,7 +925,16 @@ namespace Csla.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A dataportal exception occurred on the server. See server logs for details. Request Id: {identifier}.
+        ///   Looks up a localized string similar to An exception has occured during a server-side dataportal operation. Request Id: {0}.
+        /// </summary>
+        public static string SanitizedServerSideDataPortalDetailedException {
+            get {
+                return ResourceManager.GetString("SanitizedServerSideDataPortalDetailedException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A dataportal exception occurred on the server. Details are available from the server logs.
         /// </summary>
         public static string SanitizedServerSideDataPortalException {
             get {
@@ -934,7 +943,7 @@ namespace Csla.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An exception has occured during a server-side dataportal operation. Request Id: {identifier}\r\n{ex}.
+        ///   Looks up a localized string similar to An exception has occured during a server-side dataportal operation. Request Id: {identifier}.
         /// </summary>
         public static string ServerSideDataPortalException {
             get {

--- a/Source/Csla/Properties/Resources.resx
+++ b/Source/Csla/Properties/Resources.resx
@@ -479,9 +479,12 @@
     <value>Synchronous data access is not supported on this runtime. Please use async data access methods</value>
   </data>
   <data name="SanitizedServerSideDataPortalException" xml:space="preserve">
-    <value>A dataportal exception occurred on the server. See server logs for details. Request Id: {identifier}</value>
+    <value>A dataportal exception occurred on the server. Details are available from the server logs</value>
   </data>
   <data name="ServerSideDataPortalException" xml:space="preserve">
-    <value>An exception has occured during a server-side dataportal operation. Request Id: {identifier}\r\n{ex}</value>
+    <value>An exception has occured during a server-side dataportal operation. Request Id: {identifier}</value>
+  </data>
+  <data name="SanitizedServerSideDataPortalDetailedException" xml:space="preserve">
+    <value>An exception has occured during a server-side dataportal operation. Request Id: {0}</value>
   </data>
 </root>

--- a/Source/Csla/Properties/Resources.resx
+++ b/Source/Csla/Properties/Resources.resx
@@ -478,4 +478,10 @@
   <data name="SyncDataAccessNotSupportedException" xml:space="preserve">
     <value>Synchronous data access is not supported on this runtime. Please use async data access methods</value>
   </data>
+  <data name="SanitizedServerSideDataPortalException" xml:space="preserve">
+    <value>A dataportal exception occurred on the server. See server logs for details. Request Id: {identifier}</value>
+  </data>
+  <data name="ServerSideDataPortalException" xml:space="preserve">
+    <value>An exception has occured during a server-side dataportal operation. Request Id: {identifier}\r\n{ex}</value>
+  </data>
 </root>

--- a/Source/Csla/Server/SanitizedServerSideDataPortalException.cs
+++ b/Source/Csla/Server/SanitizedServerSideDataPortalException.cs
@@ -16,8 +16,10 @@ namespace Csla.Server
   /// avoid the transmission of sensitive server-side information
   /// to the client in remote data portal operations
   /// </summary>
-  public class SanitizedServerSideDataPortalException : ApplicationException
+  public class SanitizedServerSideDataPortalException : Exception
   {
+
+    private const string IdentifierKey = "identifier";
 
     /// <summary>
     /// Constructor.
@@ -25,7 +27,27 @@ namespace Csla.Server
     /// <param name="identifier">The unique identifier for this exception</param>
     public SanitizedServerSideDataPortalException(string identifier) : base(Properties.Resources.SanitizedServerSideDataPortalException)
     {
-      this.Data.Add("identifier", identifier);
+      Data.Add(IdentifierKey, identifier);
+    }
+
+    /// <summary>
+    /// The unique identifier for the request that failed
+    /// Use this identifier to look for the exception details in server logs
+    /// </summary>
+    public string RequestIdentifier 
+    { get 
+      {
+        return Data[IdentifierKey].ToString();
+      }
+    }
+
+    /// <summary>
+    /// Override of the ToString method to insert the unique identifier
+    /// </summary>
+    /// <returns>String representation of the custom exception, including the custom tokens</returns>
+    public override string ToString() 
+    {
+      return string.Format(Properties.Resources.SanitizedServerSideDataPortalDetailedException, RequestIdentifier);
     }
   }
 }

--- a/Source/Csla/Server/SanitizedServerSideDataPortalException.cs
+++ b/Source/Csla/Server/SanitizedServerSideDataPortalException.cs
@@ -1,0 +1,31 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SanitizedServerSideDataPortalException.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>Sanitized exception for server-side data portal operations.</summary>
+//-----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Csla.Server
+{
+  /// <summary>
+  /// Sanitized server-side data portal exception; used to 
+  /// avoid the transmission of sensitive server-side information
+  /// to the client in remote data portal operations
+  /// </summary>
+  public class SanitizedServerSideDataPortalException : ApplicationException
+  {
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    /// <param name="identifier">The unique identifier for this exception</param>
+    public SanitizedServerSideDataPortalException(string identifier) : base(Properties.Resources.SanitizedServerSideDataPortalException)
+    {
+      this.Data.Add("identifier", identifier);
+    }
+  }
+}

--- a/Source/Csla/Server/SanitizingExceptionInspector.cs
+++ b/Source/Csla/Server/SanitizingExceptionInspector.cs
@@ -1,0 +1,65 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SanitizingExceptionInspector.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>Server-side sanitizing exception inspector.</summary>
+//-----------------------------------------------------------------------
+using System;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Csla.Server
+{
+  /// <summary>
+  /// Sanitizing implementation of exception inspector, for hiding 
+  /// sensitive information in exception details.
+  /// </summary>
+  /// <remarks>Only sanitizes exceptions from remote dataportals</remarks>
+  public class SanitizingExceptionInspector : IDataPortalExceptionInspector
+  {
+
+    private readonly IHostEnvironment _hostEnvironment;
+    private readonly ApplicationContext _applicationContext;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    /// <param name="environment">The host environment in which we are operating</param>
+    /// <param name="applicationContext">The context of the current request</param>
+    /// <param name="logger">The logger to which to log exceptions</param>
+    public SanitizingExceptionInspector(IHostEnvironment environment, ApplicationContext applicationContext, ILogger<SanitizingExceptionInspector> logger)
+    {
+      _hostEnvironment = environment;
+      _applicationContext = applicationContext;
+      _logger = logger;
+    }
+
+    /// <summary>
+    /// Logs the exception that occurred during DataPortal call, then
+    /// throws a generic, less detailed exception for return to the client
+    /// </summary>
+    /// <param name="objectType">Type of the object.</param>
+    /// <param name="businessObject">The business object , if available.</param>
+    /// <param name="criteria">The criteria.</param>
+    /// <param name="methodName">Name of the method.</param>
+    /// <param name="ex">The exception.</param>
+    public void InspectException(Type objectType, object businessObject, object criteria, string methodName, Exception ex)
+    {
+      // Shortcut if we are not running on the server-side of a remote data portal operation
+      if (_applicationContext.ExecutionLocation != ApplicationContext.ExecutionLocations.Server ||
+        _applicationContext.LogicalExecutionLocation != ApplicationContext.LogicalExecutionLocations.Server)
+        return;
+
+      // Shortcut if we are running in development (max. developer productivity)
+      //if (_hostEnvironment.IsDevelopment())
+      //  return;
+
+      // Sanitize in all remaining scenarios
+      string identifier = Guid.NewGuid().ToString();
+      _logger.LogError(Properties.Resources.ServerSideDataPortalException, identifier, ex.ToString());
+      throw new SanitizedServerSideDataPortalException(identifier);
+    }
+  }
+}

--- a/Source/Csla/Server/SanitizingExceptionInspector.cs
+++ b/Source/Csla/Server/SanitizingExceptionInspector.cs
@@ -60,7 +60,7 @@ namespace Csla.Server
       string identifier = Guid.NewGuid().ToString();
       string message = Properties.Resources.ServerSideDataPortalException + Environment.NewLine + ex.ToString();
       _logger.LogError(message, identifier);
-      throw new SanitizedServerSideDataPortalException(identifier);
+      throw new ServerException(identifier);
     }
   }
 }

--- a/Source/Csla/Server/SanitizingExceptionInspector.cs
+++ b/Source/Csla/Server/SanitizingExceptionInspector.cs
@@ -41,7 +41,7 @@ namespace Csla.Server
     /// throws a generic, less detailed exception for return to the client
     /// </summary>
     /// <param name="objectType">Type of the object.</param>
-    /// <param name="businessObject">The business object , if available.</param>
+    /// <param name="businessObject">The business object, if available.</param>
     /// <param name="criteria">The criteria.</param>
     /// <param name="methodName">Name of the method.</param>
     /// <param name="ex">The exception.</param>
@@ -53,12 +53,13 @@ namespace Csla.Server
         return;
 
       // Shortcut if we are running in development (max. developer productivity)
-      //if (_hostEnvironment.IsDevelopment())
-      //  return;
+      if (_hostEnvironment.IsDevelopment())
+        return;
 
       // Sanitize in all remaining scenarios
       string identifier = Guid.NewGuid().ToString();
-      _logger.LogError(Properties.Resources.ServerSideDataPortalException, identifier, ex.ToString());
+      string message = Properties.Resources.ServerSideDataPortalException + Environment.NewLine + ex.ToString();
+      _logger.LogError(message, identifier);
       throw new SanitizedServerSideDataPortalException(identifier);
     }
   }

--- a/Source/Csla/Server/ServerException.cs
+++ b/Source/Csla/Server/ServerException.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="SanitizedServerSideDataPortalException.cs" company="Marimer LLC">
+// <copyright file="ServerException.cs" company="Marimer LLC">
 //     Copyright (c) Marimer LLC. All rights reserved.
 //     Website: https://cslanet.com
 // </copyright>
@@ -16,7 +16,7 @@ namespace Csla.Server
   /// avoid the transmission of sensitive server-side information
   /// to the client in remote data portal operations
   /// </summary>
-  public class SanitizedServerSideDataPortalException : Exception
+  public class ServerException : Exception
   {
 
     private const string IdentifierKey = "identifier";
@@ -25,7 +25,7 @@ namespace Csla.Server
     /// Constructor.
     /// </summary>
     /// <param name="identifier">The unique identifier for this exception</param>
-    public SanitizedServerSideDataPortalException(string identifier) : base(Properties.Resources.SanitizedServerSideDataPortalException)
+    public ServerException(string identifier) : base(Properties.Resources.SanitizedServerSideDataPortalException)
     {
       Data.Add(IdentifierKey, identifier);
     }

--- a/Source/csla.netcore.test/DataPortal/DashboardTests.cs
+++ b/Source/csla.netcore.test/DataPortal/DashboardTests.cs
@@ -151,6 +151,7 @@ namespace csla.netcore.test.DataPortal
 
       // Initialise DI
       var services = new ServiceCollection();
+      services.AddCslaTesting();
 
       // Add Csla, using the real dashboard
       services.AddSingleton<IDashboard, Dashboard>();

--- a/Source/csla.netcore.test/Startup.cs
+++ b/Source/csla.netcore.test/Startup.cs
@@ -33,10 +33,9 @@ namespace Csla.Test
 
       // Initialise DI
       var services = new ServiceCollection();
+      services.AddCslaTesting();
 
       // Add Csla
-      services.AddSingleton<Csla.Server.Dashboard.IDashboard, Csla.Server.Dashboard.Dashboard>();
-      services.AddCsla();
       serviceProvider = services.BuildServiceProvider();
 
       // Initialise CSLA security


### PR DESCRIPTION
Sanitizing exception inspector, intended to reduce the risk of leaking of sensitive system information outside of the trust boundary of a remote data portal host.

Not enabled by default, for the moment. Enabling this places a dependency on the host to configure an implementation of both ILogger and IHostEnvironment, which feels slightly too heavy-handed at the moment. It is especially problematic for .NET Framework hosts, where DI is not such a baked in concept, and things like logging may not be configured by default.

This submission also includes fixes to the test projects which resolves the previous failures when trying to run them all at the same time.

Closes #2662