### PR TITLE
Fix build errors in Csla.Tests after fluent config code changes

### DIFF
--- a/Source/Csla.TestHelpers/ServiceCollectionExtensions.cs
+++ b/Source/Csla.TestHelpers/ServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Text;
 using Csla.Configuration;
 using Csla.TestHelpers;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -28,11 +29,11 @@ namespace Microsoft.Extensions.DependencyInjection
     /// <returns>The instance of IServiceCollection being extended, to support method chaining</returns>
     public static IServiceCollection AddCslaTesting(this IServiceCollection services)
     {
-      services.AddTransient<IHostEnvironment, TestHostEnvironment>();
+      services.TryAddTransient<IHostEnvironment, TestHostEnvironment>();
       services.AddLogging();
       services.AddCsla();
-      services.AddSingleton<Csla.Core.IContextManager, Csla.Core.ApplicationContextManagerStatic>();
-      services.AddSingleton<Csla.Server.Dashboard.IDashboard, Csla.Server.Dashboard.Dashboard>();
+      services.TryAddSingleton<Csla.Core.IContextManager, Csla.Core.ApplicationContextManagerStatic>();
+      services.TryAddSingleton<Csla.Server.Dashboard.IDashboard, Csla.Server.Dashboard.Dashboard>();
 
       return services;
     }

--- a/Source/Csla.TestHelpers/TestDIContextFactory.cs
+++ b/Source/Csla.TestHelpers/TestDIContextFactory.cs
@@ -13,6 +13,7 @@ using System.Text;
 using Csla.Configuration;
 using Csla.Core;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Csla.TestHelpers
 {
@@ -76,8 +77,8 @@ namespace Csla.TestHelpers
       var services = new ServiceCollection();
 
       // Add Csla
-      services.AddScoped<Core.IContextManager, Core.ApplicationContextManager>();
-      services.AddSingleton<Server.Dashboard.IDashboard, Server.Dashboard.Dashboard>();
+      services.TryAddScoped<Core.IContextManager, Core.ApplicationContextManager>();
+      services.TryAddSingleton<Server.Dashboard.IDashboard, Server.Dashboard.Dashboard>();
       services.AddCsla(customCslaOptions);
 
       serviceProvider = services.BuildServiceProvider();

--- a/Source/Csla.test/AppContext/AppContextTests.cs
+++ b/Source/Csla.test/AppContext/AppContextTests.cs
@@ -289,7 +289,7 @@ namespace Csla.Test.AppContext
     [TestMethod()]
     public void FailUpdateContext()
     {
-      TestDIContext testDIContext = TestDIContextFactory.CreateContext(opts => opts.DataPortal().DataPortalReturnObjectOnException(true));
+      TestDIContext testDIContext = TestDIContextFactory.CreateContext(opts => opts.DataPortal(cfg => cfg.DataPortalReturnObjectOnException(true)));
       IDataPortal<ExceptionRoot> dataPortal = testDIContext.CreateDataPortal<ExceptionRoot>();
       
       try

--- a/Source/Csla.test/Authorization/AuthTests.cs
+++ b/Source/Csla.test/Authorization/AuthTests.cs
@@ -472,11 +472,11 @@ namespace Csla.Test.Authorization
     [TestMethod]
     public void PerTypeAuthEditObject()
     {
-      TestDIContext testDIContext = TestDIContextFactory.CreateContext(options => options.
-      DataPortal().
-      AddServerSideDataPortal(cfg => cfg.RegisterActivator<PerTypeAuthDPActivator>()
-        )
-        );
+      TestDIContext testDIContext = TestDIContextFactory.CreateContext(
+        options => options.DataPortal(
+          dp => dp.AddServerSideDataPortal(
+            cfg => cfg.RegisterActivator<PerTypeAuthDPActivator>())
+        ));
       ApplicationContext applicationContext = testDIContext.CreateTestApplicationContext();
 
       Assert.IsFalse(BusinessRules.HasPermission(applicationContext, AuthorizationActions.EditObject, typeof(PerTypeAuthRoot)));
@@ -485,10 +485,10 @@ namespace Csla.Test.Authorization
     [TestMethod]
     public void PerTypeAuthEditObjectViaInterface()
     {
-      TestDIContext customDIContext = TestDIContextFactory.CreateContext(options => options
-      .DataPortal()
-      .AddServerSideDataPortal(cfg => cfg.RegisterActivator<PerTypeAuthDPActivator>())
-      );
+      TestDIContext customDIContext = TestDIContextFactory.CreateContext(
+        options => options.DataPortal(
+          dp => dp.AddServerSideDataPortal(cfg => cfg.RegisterActivator<PerTypeAuthDPActivator>())
+      ));
       ApplicationContext applicationContext = customDIContext.CreateTestApplicationContext();
 
       Assert.IsFalse(BusinessRules.HasPermission(applicationContext, AuthorizationActions.EditObject, typeof(IPerTypeAuthRoot)));

--- a/Source/Csla.test/BusyStatus/BusyStatusTests.cs
+++ b/Source/Csla.test/BusyStatus/BusyStatusTests.cs
@@ -38,7 +38,7 @@ namespace cslalighttest.BusyStatus
     public static void ClassInitialize(TestContext context)
     {
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
-      _noCloneOnUpdateDIContext = TestDIContextFactory.CreateContext(opt => opt.DataPortal().AutoCloneOnUpdate(false));
+      _noCloneOnUpdateDIContext = TestDIContextFactory.CreateContext(opt => opt.DataPortal(cfg => cfg.AutoCloneOnUpdate(false)));
     }
 
     [TestMethod]

--- a/Source/Csla.test/DataPortal/AuthorizeDataPortalTests.cs
+++ b/Source/Csla.test/DataPortal/AuthorizeDataPortalTests.cs
@@ -41,9 +41,11 @@ namespace Csla.Test.DataPortal
       _testDIContext = TestDIContextFactory.CreateContext(options =>
       {
         options.Services.AddTransient<TestableDataPortal>();
-        options.DataPortal().AddServerSideDataPortal(config => config.RegisterAuthorizerProvider<AuthorizeDataPortalStub>());
-      }
-      );
+        options.DataPortal(
+          dp => dp.AddServerSideDataPortal(
+            config => config.RegisterAuthorizerProvider<AuthorizeDataPortalStub>())
+          );
+      });
     }
     
     [TestInitialize]

--- a/Source/Csla.test/DataPortal/InterceptorTests.cs
+++ b/Source/Csla.test/DataPortal/InterceptorTests.cs
@@ -27,13 +27,12 @@ namespace Csla.Test.DataPortal
     {
       _testDIContext = TestDIContextFactory.CreateContext(
         options => options
-        .DataPortal()
-        .AddServerSideDataPortal(config => 
+        .DataPortal(dp => dp.AddServerSideDataPortal(config => 
         {
           config.AddInterceptorProvider<TestInterceptor>();
           config.RegisterActivator<TestActivator>();
         }
-        ));
+        )));
     }
 
     [TestMethod]

--- a/Source/Csla.test/ObjectFactory/ObjectFactoryTests.cs
+++ b/Source/Csla.test/ObjectFactory/ObjectFactoryTests.cs
@@ -35,8 +35,9 @@ namespace Csla.Test.ObjectFactory
     public static void ClassInitialize(TestContext context)
     {
       _testDIContext = TestDIContextFactory.CreateContext(
-        options => options.DataPortal().AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory>>())
-        );
+        options => options.DataPortal(dp => dp.AddServerSideDataPortal(
+          cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory>>())
+        ));
     }
 
     /// <summary>
@@ -58,11 +59,12 @@ namespace Csla.Test.ObjectFactory
       TestDIContext testDIContext = TestDIContextFactory.CreateContext(
       // TODO: What proxy can we use for this test? Old one was Remoting, now retired
       //  options => options.Services.AddTransient<DataPortalClient.IDataPortalProxy, Testing.Business.TestProxies.AppDomainProxy>(), 
-        opts => opts.DataPortal().AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory>>()), 
+        opts => opts.DataPortal(
+          dp => dp.AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory>>())),
         new System.Security.Claims.ClaimsPrincipal());
 
       IDataPortal<Root> dataPortal = testDIContext.CreateDataPortal<Root>();
-      
+
       var root = dataPortal.Create();
       Assert.AreEqual("Create", root.Data, "Data should match");
       Assert.AreEqual(Csla.ApplicationContext.ExecutionLocations.Server, root.Location, "Location should match");
@@ -78,7 +80,8 @@ namespace Csla.Test.ObjectFactory
       //  options => options.Services.AddTransient<DataPortalClient.IDataPortalProxy, Testing.Business.TestProxies.AppDomainProxy>(), 
       //);
       TestDIContext testDIContext = TestDIContextFactory.CreateContext(
-        opts => opts.DataPortal().AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactoryC>>()));
+        opts => opts.DataPortal(dp => dp.AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactoryC>>()))
+        );
 
       IDataPortal<Root> dataPortal = testDIContext.CreateDataPortal<Root>();
 
@@ -95,7 +98,7 @@ namespace Csla.Test.ObjectFactory
       TestDIContext testDIContext = TestDIContextFactory.CreateContext(
       // TODO: What proxy can we use for this test? Old one was Remoting, now retired
       //  options => options.Services.AddTransient<DataPortalClient.IDataPortalProxy, Testing.Business.TestProxies.AppDomainProxy>(), 
-        opts => opts.DataPortal().AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory>>()),
+        opts => opts.DataPortal(dp => dp.AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory>>())),
         new System.Security.Claims.ClaimsPrincipal());
 
       IDataPortal<Root> dataPortal = testDIContext.CreateDataPortal<Root>();
@@ -116,8 +119,9 @@ namespace Csla.Test.ObjectFactory
       TestDIContext testDIContext = TestDIContextFactory.CreateContext(
       // TODO: What proxy can we use for this test? Old one was Remoting, now retired
       //  options => options.Services.AddTransient<DataPortalClient.IDataPortalProxy, Testing.Business.TestProxies.AppDomainProxy>(), 
-        opts => opts.DataPortal().AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory1>>()),
-        new System.Security.Claims.ClaimsPrincipal());
+        opts => opts.DataPortal(dp => dp.AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory1>>())),
+        new System.Security.Claims.ClaimsPrincipal()
+        );
 
       IDataPortal<Root> dataPortal = testDIContext.CreateDataPortal<Root>();
 
@@ -172,7 +176,8 @@ namespace Csla.Test.ObjectFactory
     public void UpdateTransactionScope()
     {
       TestDIContext testDIContext = TestDIContextFactory.CreateContext(
-        opts => opts.DataPortal().AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory1>>()));
+        opts => opts.DataPortal(dp => dp.AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory1>>()))
+        );
       IDataPortal<Root> dataPortal = testDIContext.CreateDataPortal<Root>();
 
       var root = dataPortal.Fetch();
@@ -193,12 +198,15 @@ namespace Csla.Test.ObjectFactory
     {
       TestDIContext testDIContext = TestDIContextFactory.CreateContext(
         options => options
-        .Data(cfg => cfg
-        .DefaultTransactionIsolationLevel(TransactionIsolationLevel.RepeatableRead)
-        .DefaultTransactionTimeoutInSeconds(45)
+        .Data(
+          cfg => cfg
+          .DefaultTransactionIsolationLevel(TransactionIsolationLevel.RepeatableRead)
+          .DefaultTransactionTimeoutInSeconds(45)
         )
-        .DataPortal()
-        .AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory4>>()));
+        .DataPortal(
+          dp => dp.AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory4>>())
+          )
+        );
       IDataPortal<Root> dataPortal = testDIContext.CreateDataPortal<Root>();
 
       var root = dataPortal.Create();
@@ -221,12 +229,14 @@ namespace Csla.Test.ObjectFactory
     {
       TestDIContext testDIContext = TestDIContextFactory.CreateContext(
         options => options
-        .Data(cfg => cfg
-        .DefaultTransactionIsolationLevel(TransactionIsolationLevel.RepeatableRead)
-        .DefaultTransactionTimeoutInSeconds(45)
+        .Data(
+          cfg => cfg
+          .DefaultTransactionIsolationLevel(TransactionIsolationLevel.RepeatableRead)
+          .DefaultTransactionTimeoutInSeconds(45)
         )
-        .DataPortal()
-        .AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory5>>()));
+        .DataPortal(
+          dp => dp.AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory5>>()))
+        );
       IDataPortal<Root> dataPortal = testDIContext.CreateDataPortal<Root>();
 
       var root = dataPortal.Create();
@@ -259,7 +269,9 @@ namespace Csla.Test.ObjectFactory
     public void FetchLoadProperty()
     {
       TestDIContext testDIContext = TestDIContextFactory.CreateContext(
-        options => options.DataPortal().AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory3>>()));
+        options => options.DataPortal(
+          dp => dp.AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory3>>()))
+        );
       IDataPortal<Root> dataPortal = testDIContext.CreateDataPortal<Root>();
 
       var root = dataPortal.Fetch();
@@ -287,7 +299,7 @@ namespace Csla.Test.ObjectFactory
     {
       TestDIContext testDIContext = TestDIContextFactory.CreateDefaultContext();
       IDataPortal<CommandObjectMissingFactoryMethod> dataPortal = testDIContext.CreateDataPortal<CommandObjectMissingFactoryMethod>();
-      
+
       try
       {
         TestResults.Reinitialise();


### PR DESCRIPTION
Changes to the test-related code to reflect the updates to the fluent configuration code in preview 4.

Includes switch to TryAdd for service registrations, as a further example of best practice within the library.

Part of the ongoing work to resolve #2544 