### PR TITLE
More fixes to get tests to build after fluent config changes

### DIFF
--- a/Source/Csla.test/Authorization/AuthTests.cs
+++ b/Source/Csla.test/Authorization/AuthTests.cs
@@ -473,10 +473,9 @@ namespace Csla.Test.Authorization
     public void PerTypeAuthEditObject()
     {
       TestDIContext testDIContext = TestDIContextFactory.CreateContext(
-        options => options.DataPortal(
-          dp => dp.AddServerSideDataPortal(
-            cfg => cfg.RegisterActivator<PerTypeAuthDPActivator>())
-        ));
+        options => options.AddServerSideDataPortal(
+          cfg => cfg.RegisterActivator<PerTypeAuthDPActivator>())
+        );
       ApplicationContext applicationContext = testDIContext.CreateTestApplicationContext();
 
       Assert.IsFalse(BusinessRules.HasPermission(applicationContext, AuthorizationActions.EditObject, typeof(PerTypeAuthRoot)));
@@ -486,9 +485,8 @@ namespace Csla.Test.Authorization
     public void PerTypeAuthEditObjectViaInterface()
     {
       TestDIContext customDIContext = TestDIContextFactory.CreateContext(
-        options => options.DataPortal(
-          dp => dp.AddServerSideDataPortal(cfg => cfg.RegisterActivator<PerTypeAuthDPActivator>())
-      ));
+        options => options.AddServerSideDataPortal(cfg => cfg.RegisterActivator<PerTypeAuthDPActivator>())
+      );
       ApplicationContext applicationContext = customDIContext.CreateTestApplicationContext();
 
       Assert.IsFalse(BusinessRules.HasPermission(applicationContext, AuthorizationActions.EditObject, typeof(IPerTypeAuthRoot)));

--- a/Source/Csla.test/DataPortal/AuthorizeDataPortalTests.cs
+++ b/Source/Csla.test/DataPortal/AuthorizeDataPortalTests.cs
@@ -41,10 +41,8 @@ namespace Csla.Test.DataPortal
       _testDIContext = TestDIContextFactory.CreateContext(options =>
       {
         options.Services.AddTransient<TestableDataPortal>();
-        options.DataPortal(
-          dp => dp.AddServerSideDataPortal(
-            config => config.RegisterAuthorizerProvider<AuthorizeDataPortalStub>())
-          );
+        options.AddServerSideDataPortal(
+            config => config.RegisterAuthorizerProvider<AuthorizeDataPortalStub>());
       });
     }
     

--- a/Source/Csla.test/DataPortal/InterceptorTests.cs
+++ b/Source/Csla.test/DataPortal/InterceptorTests.cs
@@ -26,13 +26,12 @@ namespace Csla.Test.DataPortal
     public static void ClassInitialize(TestContext context)
     {
       _testDIContext = TestDIContextFactory.CreateContext(
-        options => options
-        .DataPortal(dp => dp.AddServerSideDataPortal(config => 
+        options => options.AddServerSideDataPortal(config => 
         {
           config.AddInterceptorProvider<TestInterceptor>();
           config.RegisterActivator<TestActivator>();
         }
-        )));
+        ));
     }
 
     [TestMethod]

--- a/Source/Csla.test/ObjectFactory/ObjectFactoryTests.cs
+++ b/Source/Csla.test/ObjectFactory/ObjectFactoryTests.cs
@@ -35,9 +35,9 @@ namespace Csla.Test.ObjectFactory
     public static void ClassInitialize(TestContext context)
     {
       _testDIContext = TestDIContextFactory.CreateContext(
-        options => options.DataPortal(dp => dp.AddServerSideDataPortal(
+        options => options.AddServerSideDataPortal(
           cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory>>())
-        ));
+        );
     }
 
     /// <summary>
@@ -59,8 +59,8 @@ namespace Csla.Test.ObjectFactory
       TestDIContext testDIContext = TestDIContextFactory.CreateContext(
       // TODO: What proxy can we use for this test? Old one was Remoting, now retired
       //  options => options.Services.AddTransient<DataPortalClient.IDataPortalProxy, Testing.Business.TestProxies.AppDomainProxy>(), 
-        opts => opts.DataPortal(
-          dp => dp.AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory>>())),
+        opts => opts.AddServerSideDataPortal(
+          cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory>>()),
         new System.Security.Claims.ClaimsPrincipal());
 
       IDataPortal<Root> dataPortal = testDIContext.CreateDataPortal<Root>();
@@ -80,7 +80,8 @@ namespace Csla.Test.ObjectFactory
       //  options => options.Services.AddTransient<DataPortalClient.IDataPortalProxy, Testing.Business.TestProxies.AppDomainProxy>(), 
       //);
       TestDIContext testDIContext = TestDIContextFactory.CreateContext(
-        opts => opts.DataPortal(dp => dp.AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactoryC>>()))
+        opts => opts.AddServerSideDataPortal(
+          cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactoryC>>())
         );
 
       IDataPortal<Root> dataPortal = testDIContext.CreateDataPortal<Root>();
@@ -98,7 +99,7 @@ namespace Csla.Test.ObjectFactory
       TestDIContext testDIContext = TestDIContextFactory.CreateContext(
       // TODO: What proxy can we use for this test? Old one was Remoting, now retired
       //  options => options.Services.AddTransient<DataPortalClient.IDataPortalProxy, Testing.Business.TestProxies.AppDomainProxy>(), 
-        opts => opts.DataPortal(dp => dp.AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory>>())),
+        opts => opts.AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory>>()),
         new System.Security.Claims.ClaimsPrincipal());
 
       IDataPortal<Root> dataPortal = testDIContext.CreateDataPortal<Root>();
@@ -119,8 +120,9 @@ namespace Csla.Test.ObjectFactory
       TestDIContext testDIContext = TestDIContextFactory.CreateContext(
       // TODO: What proxy can we use for this test? Old one was Remoting, now retired
       //  options => options.Services.AddTransient<DataPortalClient.IDataPortalProxy, Testing.Business.TestProxies.AppDomainProxy>(), 
-        opts => opts.DataPortal(dp => dp.AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory1>>())),
-        new System.Security.Claims.ClaimsPrincipal()
+        opts => opts.AddServerSideDataPortal(
+          cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory1>>()),
+          new System.Security.Claims.ClaimsPrincipal()
         );
 
       IDataPortal<Root> dataPortal = testDIContext.CreateDataPortal<Root>();
@@ -176,7 +178,8 @@ namespace Csla.Test.ObjectFactory
     public void UpdateTransactionScope()
     {
       TestDIContext testDIContext = TestDIContextFactory.CreateContext(
-        opts => opts.DataPortal(dp => dp.AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory1>>()))
+        opts => opts.AddServerSideDataPortal(
+          cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory1>>())
         );
       IDataPortal<Root> dataPortal = testDIContext.CreateDataPortal<Root>();
 
@@ -203,9 +206,8 @@ namespace Csla.Test.ObjectFactory
           .DefaultTransactionIsolationLevel(TransactionIsolationLevel.RepeatableRead)
           .DefaultTransactionTimeoutInSeconds(45)
         )
-        .DataPortal(
-          dp => dp.AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory4>>())
-          )
+        .AddServerSideDataPortal(
+          cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory4>>())
         );
       IDataPortal<Root> dataPortal = testDIContext.CreateDataPortal<Root>();
 
@@ -234,8 +236,8 @@ namespace Csla.Test.ObjectFactory
           .DefaultTransactionIsolationLevel(TransactionIsolationLevel.RepeatableRead)
           .DefaultTransactionTimeoutInSeconds(45)
         )
-        .DataPortal(
-          dp => dp.AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory5>>()))
+        .AddServerSideDataPortal(
+          cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory5>>())
         );
       IDataPortal<Root> dataPortal = testDIContext.CreateDataPortal<Root>();
 
@@ -269,8 +271,8 @@ namespace Csla.Test.ObjectFactory
     public void FetchLoadProperty()
     {
       TestDIContext testDIContext = TestDIContextFactory.CreateContext(
-        options => options.DataPortal(
-          dp => dp.AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory3>>()))
+        options => options.AddServerSideDataPortal(
+          cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory3>>())
         );
       IDataPortal<Root> dataPortal = testDIContext.CreateDataPortal<Root>();
 


### PR DESCRIPTION
A few fixes required after fluent config changes broke the build of the test projects. Not sure why this seems to have happened after I thought the fluent config changes were complete, but it seems to be the case.

This forms part of getting the tests upgraded to CSLA 6, work done under issue #2544, although that task has now been closed.