### PR TITLE
Pr/swegele/2773

### DIFF
--- a/NuGet/Definition/Csla.Blazor.NuSpec
+++ b/NuGet/Definition/Csla.Blazor.NuSpec
@@ -37,11 +37,17 @@
   </metadata>
   <files>
     <!-- NetStandard Assembly -->
-    <file src="..\..\bin\Release\netstandard2.1\**\Csla.Blazor.*" target="lib\netstandard2.1" />
+    <file src="..\..\bin\Release\netstandard2.1\**\Csla.Blazor.dll" target="lib\netstandard2.1" />
+    <file src="..\..\bin\Release\netstandard2.1\**\Csla.Blazor.pdb" target="lib\netstandard2.1" />
+    <file src="..\..\bin\Release\netstandard2.1\**\Csla.Blazor.xml" target="lib\netstandard2.1" />
     <!-- Net5.0 Assembly -->
-    <file src="..\..\bin\Release\net5.0\**\Csla.Blazor.*" target="lib\net5.0" />
+    <file src="..\..\bin\Release\net5.0\**\Csla.Blazor.dll" target="lib\net5.0" />
+    <file src="..\..\bin\Release\net5.0\**\Csla.Blazor.pdb" target="lib\net5.0" />
+    <file src="..\..\bin\Release\net5.0\**\Csla.Blazor.xml" target="lib\net5.0" />
     <!-- Net6.0 Assembly -->
-    <file src="..\..\bin\Release\net6.0\**\Csla.Blazor.*" target="lib\net6.0" />
+    <file src="..\..\bin\Release\net6.0\**\Csla.Blazor.dll" target="lib\net6.0" />
+    <file src="..\..\bin\Release\net6.0\**\Csla.Blazor.pdb" target="lib\net6.0" />
+    <file src="..\..\bin\Release\net6.0\**\Csla.Blazor.xml" target="lib\net6.0" />
     <!-- resources -->
     <file src="..\..\Support\Logos\csla.png" target="images\" />
   </files>

--- a/Source/Csla.AspNetCore/ApplicationContextManager.cs
+++ b/Source/Csla.AspNetCore/ApplicationContextManager.cs
@@ -7,11 +7,10 @@
 //-----------------------------------------------------------------------
 using Csla.Core;
 using System;
+using Microsoft.AspNetCore.Http;
 #if NET5_0_OR_GREATER
 using Csla.AspNetCore.Blazor;
 using Microsoft.Extensions.DependencyInjection;
-#else
-using Microsoft.AspNetCore.Http;
 #endif
 
 namespace Csla.AspNetCore
@@ -29,9 +28,10 @@ namespace Csla.AspNetCore
     /// </summary>
     /// <param name="provider"></param>
     /// <param name="activeCircuitState"></param>
-    public ApplicationContextManager(IServiceProvider provider, ActiveCircuitState activeCircuitState)
+    /// <param name="httpContextAccessor"></param>
+    public ApplicationContextManager(IServiceProvider provider, Core.Blazor.ActiveCircuitState activeCircuitState, IHttpContextAccessor httpContextAccessor)
     {
-      if (activeCircuitState.CircuitExists)
+      if (activeCircuitState.CircuitExists || httpContextAccessor.HttpContext is null)
       {
         ActiveContextManager = (IContextManager)ActivatorUtilities.CreateInstance(provider, typeof(ApplicationContextManagerBlazor));
       }

--- a/Source/Csla.AspNetCore/Blazor/ActiveCircuitHandler.cs
+++ b/Source/Csla.AspNetCore/Blazor/ActiveCircuitHandler.cs
@@ -21,12 +21,12 @@ namespace Csla.AspNetCore.Blazor
     /// Creates an instance of the type.
     /// </summary>
     /// <param name="activeCircuitState"></param>
-    public ActiveCircuitHandler(ActiveCircuitState activeCircuitState)
+    public ActiveCircuitHandler(Core.Blazor.ActiveCircuitState activeCircuitState)
     {
       ActiveCircuitState = activeCircuitState;
     }
 
-    private ActiveCircuitState ActiveCircuitState { get; set; }
+    private Core.Blazor.ActiveCircuitState ActiveCircuitState { get; set; }
 
     /// <summary>
     /// Handler for the OnCircuitOpenedAsync call

--- a/Source/Csla.AspNetCore/ConfigurationExtensions.cs
+++ b/Source/Csla.AspNetCore/ConfigurationExtensions.cs
@@ -41,7 +41,6 @@ namespace Csla.Configuration
       var localOptions = new AspNetCoreConfigurationOptions();
       options?.Invoke(localOptions);
 #if NET5_0_OR_GREATER
-      config.Services.AddScoped<ActiveCircuitState>();
       config.Services.AddScoped(typeof(CircuitHandler), typeof(ActiveCircuitHandler));
 #endif
       config.Services.TryAddTransient((p) => new Channels.Local.LocalProxyOptions { CreateScopePerCall = false });

--- a/Source/Csla/Configuration/ConfigurationExtensions.cs
+++ b/Source/Csla/Configuration/ConfigurationExtensions.cs
@@ -42,6 +42,12 @@ namespace Csla.Configuration
       // capture options object
       services.AddScoped((p) => cslaOptions);
 
+#if NET5_0_OR_GREATER
+      
+      services.AddScoped<Core.Blazor.ActiveCircuitState>();
+      
+#endif
+
       // ApplicationContext defaults
       services.AddScoped<ApplicationContext>();
       RegisterContextManager(services);

--- a/Source/Csla/Core/Blazor/ActiveCircuitState.cs
+++ b/Source/Csla/Core/Blazor/ActiveCircuitState.cs
@@ -7,7 +7,7 @@
 //-----------------------------------------------------------------------
 #if NET5_0_OR_GREATER
 
-namespace Csla.AspNetCore.Blazor
+namespace Csla.Core.Blazor
 {
   /// <summary>
   /// Provides access to server-side Blazor

--- a/Source/Csla/DataPortalClient/DataPortalFactory.cs
+++ b/Source/Csla/DataPortalClient/DataPortalFactory.cs
@@ -5,6 +5,8 @@
 // </copyright>
 // <summary>Implements a data portal service</summary>
 //-----------------------------------------------------------------------
+using System;
+
 namespace Csla.DataPortalClient
 {
   /// <summary>
@@ -16,13 +18,13 @@ namespace Csla.DataPortalClient
     /// <summary>
     /// Creates an instance of the type.
     /// </summary>
-    /// <param name="applicationContext">ApplicationContext instance</param>
-    public DataPortalFactory(ApplicationContext applicationContext)
+    /// <param name="serviceProvider">Current ServiceProvider</param>
+    public DataPortalFactory(IServiceProvider serviceProvider)
     {
-      ApplicationContext = applicationContext;
+      ServiceProvider = serviceProvider;
     }
 
-    private ApplicationContext ApplicationContext { get; set; }
+    private IServiceProvider ServiceProvider { get; set; }
 
     /// <summary>
     /// Get a client-side data portal instance.
@@ -30,7 +32,7 @@ namespace Csla.DataPortalClient
     /// <typeparam name="T">Root business object type</typeparam>
     public IDataPortal<T> GetPortal<T>()
     {
-      return ApplicationContext.CreateInstanceDI<IDataPortal<T>>();
+      return (IDataPortal<T>)ServiceProvider.GetService(typeof(IDataPortal<T>));
     }
   }
 }

--- a/Source/Csla/DataPortalClient/LocalProxy.cs
+++ b/Source/Csla/DataPortalClient/LocalProxy.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Csla.Server;
 using Microsoft.Extensions.DependencyInjection;
 
+
 namespace Csla.Channels.Local
 {
   /// <summary>
@@ -36,9 +37,18 @@ namespace Csla.Channels.Local
         // create new DI scope and provider
         _scope = ApplicationContext.CurrentServiceProvider.CreateScope();
         var provider = _scope.ServiceProvider;
+        var parentContext = applicationContext;
+
+#if NET5_0_OR_GREATER
+
+        //copy circuitexists from parent context into this new scope to ensure that we get the proper ContextManager if applicable
+        var parentContextCircuitState = parentContext.CurrentServiceProvider.GetRequiredService<Core.Blazor.ActiveCircuitState>();
+        var newScopeCircuitState = provider.GetRequiredService<Core.Blazor.ActiveCircuitState>();
+        newScopeCircuitState.CircuitExists = parentContextCircuitState.CircuitExists;
+
+#endif
 
         // create and initialize new "server-side" ApplicationContext and manager
-        var parentContext = applicationContext;
         var manager = provider.GetRequiredService<Core.IContextManager>();
         manager.SetClientContext(parentContext.ClientContext, parentContext.ExecutionLocation);
         manager.SetUser(parentContext.User);

--- a/Source/Csla/Server/ChildDataPortalFactory.cs
+++ b/Source/Csla/Server/ChildDataPortalFactory.cs
@@ -5,6 +5,8 @@
 // </copyright>
 // <summary>Implements a data portal service</summary>
 //-----------------------------------------------------------------------
+using System;
+
 namespace Csla.Server
 {
   /// <summary>
@@ -16,13 +18,13 @@ namespace Csla.Server
     /// <summary>
     /// Creates an instance of the type.
     /// </summary>
-    /// <param name="applicationContext">ApplicationContext instance</param>
-    public ChildDataPortalFactory(ApplicationContext applicationContext)
+    /// <param name="serviceProvider">Current ServiceProvider</param>
+    public ChildDataPortalFactory(IServiceProvider serviceProvider)
     {
-      ApplicationContext = applicationContext;
+      ServiceProvider = serviceProvider;
     }
 
-    private ApplicationContext ApplicationContext { get; set; }
+    private IServiceProvider ServiceProvider { get; set; }
 
     /// <summary>
     /// Get a client-side data portal instance.
@@ -30,7 +32,7 @@ namespace Csla.Server
     /// <typeparam name="T">Root business object type</typeparam>
     public IChildDataPortal<T> GetPortal<T>()
     {
-      return ApplicationContext.CreateInstanceDI<IChildDataPortal<T>>();
+      return (IChildDataPortal<T>)ServiceProvider.GetService(typeof(IChildDataPortal<T>));
     }
   }
 }


### PR DESCRIPTION
This is my suggested attempt to fix two remaining issues:

1. HostedService always throws error because HttpContext is null AND circuit is null.  So I added an if clause to make the Blazor app context manager get selected in this scenario

2. When a BSS razor page accesses a business object (in context of a circuit), the hybrid application context manager correctly selects the Blazor app context manager.  BUT on the logical server side in LocalProxy, a new scope is created, which causes the `CircuitExists` property to now be default/false.  Subsequently this causes the selection of the Http app context manager which is discouraged by microsoft when in BSS context.  Both sides of dataportal should get the Blazor app context manager in this scenario.

I struggled for hours to figure out a way to send a signal to the `Csla.AspNetCore.ApplicationContextManager` so it knows, on logical server side, to select the correct active context manager.  Chicken/egg scenario over and over.  The only way I could accomplish this was to bump the ActiveCircuitState service up into Csla.Core.Blazor.  Maybe not ideal but fairly minor change.  This allows the LocalProxy to fetch it from service provider before and after new scope in order to copy the boolean value across for CircuitExists property.  Maybe you can think of a better way to get that done.  But this is tested and works great.

