### PR TITLE
For issue #2798 - showing concept for LocalProxy doing DI and getting 

### DIFF
--- a/Source/Csla.AspNetCore/ApplicationContextManager.cs
+++ b/Source/Csla.AspNetCore/ApplicationContextManager.cs
@@ -3,7 +3,7 @@
 //     Copyright (c) Marimer LLC. All rights reserved.
 //     Website: https://cslanet.com
 // </copyright>
-// <summary>Application context manager that adapts for AspNetCore/SSB</summary>
+// <summary>Facade application context manager that adapts for AspNetCore/SSB by selecting the correct actual IContextManager based on context</summary>
 //-----------------------------------------------------------------------
 using Csla.Core;
 using System;
@@ -11,8 +11,6 @@ using Microsoft.AspNetCore.Http;
 #if NET5_0_OR_GREATER
 using Csla.AspNetCore.Blazor;
 using Microsoft.Extensions.DependencyInjection;
-#else
-using Microsoft.AspNetCore.Http;
 #endif
 
 namespace Csla.AspNetCore
@@ -20,10 +18,8 @@ namespace Csla.AspNetCore
   /// <summary>
   /// Application context manager that adapts for AspNetCore/SSB.
   /// </summary>
-  public class ApplicationContextManager : IContextManager, IDisposable
+  public class ApplicationContextManager : ApplicationContextManagerFacade
   {
-    private IContextManager ActiveContextManager { get; set; }
-
 #if NET5_0_OR_GREATER
     /// <summary>
     /// Creates an instance of the object.
@@ -31,9 +27,13 @@ namespace Csla.AspNetCore
     /// <param name="provider"></param>
     /// <param name="activeCircuitState"></param>
     /// <param name="httpContextAccessor"></param>
-    public ApplicationContextManager(IServiceProvider provider, ActiveCircuitState activeCircuitState, IHttpContextAccessor httpContextAccessor)
+    public ApplicationContextManager(IServiceProvider provider, ActiveCircuitState activeCircuitState, IHttpContextAccessor httpContextAccessor, Channels.Local.LocalProxyState localProxyState)
     {
-      if (activeCircuitState.CircuitExists)
+      if (localProxyState.NewScopeExists)
+      {
+        ActiveContextManager = (IContextManager)ActivatorUtilities.CreateInstance(provider, typeof(ApplicationContextManagerAsyncLocal));
+      }
+      else if (activeCircuitState.CircuitExists)
       {
         ActiveContextManager = (IContextManager)ActivatorUtilities.CreateInstance(provider, typeof(ApplicationContextManagerBlazor));
       }
@@ -57,118 +57,5 @@ namespace Csla.AspNetCore
     }
 #endif
 
-    /// <summary>
-    /// Gets a value indicating whether this
-    /// context manager is valid for use in
-    /// the current environment.
-    /// </summary>
-    public bool IsValid
-    {
-      get { return ActiveContextManager.IsValid; }
-    }
-
-    /// <summary>
-    /// Gets a value indicating whether the current runtime
-    /// is stateful (e.g. WPF, Blazor, etc.)
-    /// </summary>
-    public bool IsStatefulRuntime => ActiveContextManager.IsStatefulRuntime;
-
-    /// <summary>
-    /// Gets the current principal.
-    /// </summary>
-    public System.Security.Principal.IPrincipal GetUser()
-    {
-      return ActiveContextManager.GetUser();
-    }
-
-    /// <summary>
-    /// Sets the current principal.
-    /// </summary>
-    /// <param name="principal">Principal object.</param>
-    public void SetUser(System.Security.Principal.IPrincipal principal)
-    {
-      ActiveContextManager.SetUser(principal);
-    }
-
-    /// <summary>
-    /// Gets the local context.
-    /// </summary>
-    public ContextDictionary GetLocalContext()
-    {
-      return ActiveContextManager.GetLocalContext();
-    }
-
-    /// <summary>
-    /// Sets the local context.
-    /// </summary>
-    /// <param name="localContext">Local context.</param>
-    public void SetLocalContext(ContextDictionary localContext)
-    {
-      ActiveContextManager.SetLocalContext(localContext);
-    }
-
-    /// <summary>
-    /// Gets the client context.
-    /// </summary>
-    /// <param name="executionLocation"></param>
-    public ContextDictionary GetClientContext(ApplicationContext.ExecutionLocations executionLocation)
-    {
-      return ActiveContextManager.GetClientContext(executionLocation);
-    }
-
-    /// <summary>
-    /// Sets the client context.
-    /// </summary>
-    /// <param name="clientContext">Client context.</param>
-    /// <param name="executionLocation"></param>
-    public void SetClientContext(ContextDictionary clientContext, ApplicationContext.ExecutionLocations executionLocation)
-    {
-      ActiveContextManager.SetClientContext(clientContext, executionLocation);
-    }
-
-    private bool disposedValue;
-
-    /// <summary>
-    /// Gets or sets a reference to the current ApplicationContext.
-    /// </summary>
-    public virtual ApplicationContext ApplicationContext
-    {
-      get
-      {
-        return ActiveContextManager.ApplicationContext;
-      }
-      set
-      {
-        ActiveContextManager.ApplicationContext = value;
-      }
-    }
-
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="disposing"></param>
-    protected virtual void Dispose(bool disposing)
-    {
-      if (!disposedValue)
-      {
-        if (disposing)
-        {
-          if (ActiveContextManager is IDisposable disposable)
-            disposable.Dispose();
-        }
-
-        disposedValue = true;
-      }
-    }
-
-    /// <summary>
-    /// Dispose this instance.
-    /// </summary>
-    public void Dispose()
-    {
-      // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-      Dispose(disposing: true);
-      GC.SuppressFinalize(this);
-    }
   }
 }

--- a/Source/Csla.AspNetCore/Blazor/ActiveCircuitState.cs
+++ b/Source/Csla.AspNetCore/Blazor/ActiveCircuitState.cs
@@ -3,7 +3,7 @@
 //     Copyright (c) Marimer LLC. All rights reserved.
 //     Website: https://cslanet.com
 // </copyright>
-// <summary>Circuit handler indicating if code in server-side Blazor</summary>
+// <summary>Service which interacts with ActiveCircuitHandler and indicates if code is in server-side Blazor</summary>
 //-----------------------------------------------------------------------
 #if NET5_0_OR_GREATER
 

--- a/Source/Csla/Core/ApplicationContextManagerFacade.cs
+++ b/Source/Csla/Core/ApplicationContextManagerFacade.cs
@@ -1,0 +1,136 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ApplicationContextManagerFacade.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>Abstract context manager that stateful environment ApplicationContextManagers can inherit from that conditionally create and set an ActiveContextManager</summary>
+//-----------------------------------------------------------------------
+using System;
+using System.Security.Principal;
+using System.Threading;
+
+namespace Csla.Core
+{
+  /// <summary>
+  /// Default context manager for the user property
+  /// and local/client/global context dictionaries.
+  /// </summary>
+  public abstract class ApplicationContextManagerFacade : IContextManager
+  {
+    protected IContextManager ActiveContextManager { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether this
+    /// context manager is valid for use in
+    /// the current environment.
+    /// </summary>
+    public bool IsValid
+    {
+      get { return ActiveContextManager.IsValid; }
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the current runtime
+    /// is stateful (e.g. WPF, Blazor, etc.)
+    /// </summary>
+    public bool IsStatefulRuntime => ActiveContextManager.IsStatefulRuntime;
+
+    /// <summary>
+    /// Gets the current principal.
+    /// </summary>
+    public System.Security.Principal.IPrincipal GetUser()
+    {
+      return ActiveContextManager.GetUser();
+    }
+
+    /// <summary>
+    /// Sets the current principal.
+    /// </summary>
+    /// <param name="principal">Principal object.</param>
+    public void SetUser(System.Security.Principal.IPrincipal principal)
+    {
+      ActiveContextManager.SetUser(principal);
+    }
+
+    /// <summary>
+    /// Gets the local context.
+    /// </summary>
+    public ContextDictionary GetLocalContext()
+    {
+      return ActiveContextManager.GetLocalContext();
+    }
+
+    /// <summary>
+    /// Sets the local context.
+    /// </summary>
+    /// <param name="localContext">Local context.</param>
+    public void SetLocalContext(ContextDictionary localContext)
+    {
+      ActiveContextManager.SetLocalContext(localContext);
+    }
+
+    /// <summary>
+    /// Gets the client context.
+    /// </summary>
+    /// <param name="executionLocation"></param>
+    public ContextDictionary GetClientContext(ApplicationContext.ExecutionLocations executionLocation)
+    {
+      return ActiveContextManager.GetClientContext(executionLocation);
+    }
+
+    /// <summary>
+    /// Sets the client context.
+    /// </summary>
+    /// <param name="clientContext">Client context.</param>
+    /// <param name="executionLocation"></param>
+    public void SetClientContext(ContextDictionary clientContext, ApplicationContext.ExecutionLocations executionLocation)
+    {
+      ActiveContextManager.SetClientContext(clientContext, executionLocation);
+    }
+
+    private bool disposedValue;
+
+    /// <summary>
+    /// Gets or sets a reference to the current ApplicationContext.
+    /// </summary>
+    public virtual ApplicationContext ApplicationContext
+    {
+      get
+      {
+        return ActiveContextManager.ApplicationContext;
+      }
+      set
+      {
+        ActiveContextManager.ApplicationContext = value;
+      }
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="disposing"></param>
+    protected virtual void Dispose(bool disposing)
+    {
+      if (!disposedValue)
+      {
+        if (disposing)
+        {
+          if (ActiveContextManager is IDisposable disposable)
+            disposable.Dispose();
+        }
+
+        disposedValue = true;
+      }
+    }
+
+    /// <summary>
+    /// Dispose this instance.
+    /// </summary>
+    public void Dispose()
+    {
+      // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+      Dispose(disposing: true);
+      GC.SuppressFinalize(this);
+    }
+  }
+}

--- a/Source/Csla/DataPortalClient/LocalProxy.cs
+++ b/Source/Csla/DataPortalClient/LocalProxy.cs
@@ -47,6 +47,15 @@ namespace Csla.Channels.Local
 
         //now get manager from DI for new scope
         var manager = provider.GetRequiredService<Core.IContextManager>();
+
+        //since we are in a new scope - ensure that the type returned correctly implements the facade which should be built to respect us wanting one type here vs normal
+        if (!typeof(Core.ApplicationContextManagerFacade).IsAssignableFrom(manager.GetType()))
+        {
+          throw new Exception(nameof(Core.IContextManager) + " must inherit from " + nameof(Core.ApplicationContextManagerFacade) + " if using the Local DataPortal");
+        }
+
+        //?do we want to go further to ensure here that the type of manager is the concrete type or implements some interface?
+
         manager.SetClientContext(parentContext.ClientContext, parentContext.ExecutionLocation);
         manager.SetUser(parentContext.User);
         ApplicationContext = new ApplicationContext(manager, provider);

--- a/Source/Csla/DataPortalClient/LocalProxy.cs
+++ b/Source/Csla/DataPortalClient/LocalProxy.cs
@@ -37,9 +37,16 @@ namespace Csla.Channels.Local
         _scope = ApplicationContext.CurrentServiceProvider.CreateScope();
         var provider = _scope.ServiceProvider;
 
+        //initialize a service in this scope which indicates to stateful ApplicationContextManagers that we are in a new scope which allows them to create
+        //  an instance of ApplicationContextManagerAsyncLocal
+        var localScopeState = provider.GetRequiredService<Channels.Local.LocalProxyState>();
+        localScopeState.NewScopeExists = true;
+
         // create and initialize new "server-side" ApplicationContext and manager
         var parentContext = applicationContext;
-        var manager = new Csla.Core.ApplicationContextManagerAsyncLocal();
+
+        //now get manager from DI for new scope
+        var manager = provider.GetRequiredService<Core.IContextManager>();
         manager.SetClientContext(parentContext.ClientContext, parentContext.ExecutionLocation);
         manager.SetUser(parentContext.User);
         ApplicationContext = new ApplicationContext(manager, provider);

--- a/Source/Csla/DataPortalClient/LocalProxyExtensions.cs
+++ b/Source/Csla/DataPortalClient/LocalProxyExtensions.cs
@@ -40,6 +40,11 @@ namespace Csla.Configuration
       options?.Invoke(proxyOptions);
       config.Services.AddTransient<IDataPortalProxy, LocalProxy>();
       config.Services.AddTransient((p) => proxyOptions);
+
+#if NET5_0_OR_GREATER
+      config.Services.AddScoped<LocalProxyState>();
+#endif      
+
       return config;
     }
   }

--- a/Source/Csla/DataPortalClient/LocalProxyExtensions.cs
+++ b/Source/Csla/DataPortalClient/LocalProxyExtensions.cs
@@ -40,10 +40,7 @@ namespace Csla.Configuration
       options?.Invoke(proxyOptions);
       config.Services.AddTransient<IDataPortalProxy, LocalProxy>();
       config.Services.AddTransient((p) => proxyOptions);
-
-#if NET5_0_OR_GREATER
       config.Services.AddScoped<LocalProxyState>();
-#endif      
 
       return config;
     }

--- a/Source/Csla/DataPortalClient/LocalProxyState.cs
+++ b/Source/Csla/DataPortalClient/LocalProxyState.cs
@@ -1,0 +1,22 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="LocalProxyState.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>Service which interacts with LocalProxy and indicates if a new scope was created</summary>
+//-----------------------------------------------------------------------
+
+namespace Csla.Channels.Local
+{
+  /// <summary>
+  /// Provides information about the state of the LocalProxy if used
+  /// </summary>
+  public class LocalProxyState
+  {
+    /// <summary>
+    /// True if LocalProxy is in use and has created a new scope.  
+    /// Only happens in stateful technologies where <see cref="ApplicationContext.IsStatefulRuntime"/> equals true)
+    /// </summary>
+    public bool NewScopeExists { get; set; }
+  }
+}


### PR DESCRIPTION
POC for #2798 

This is a POC example of how `LocalProxy`, in a new scope, can get a `ApplicationContextManagerAsyncLocal` via DI that also flows through to subsequent calls from Business objects that call DI for `IContextManager` or `ApplicationContext`.

@rockfordlhotka  and @TheCakeMonster 
I've tested this out and it works great.  ClientContext values flow through as expected and all classes within the new LocalProxy scope get the one IContextManager that was created there.

I did not take the time yet to do this pattern to the other stateful ApplicationContextManagers for WPF, WASM etc. because I didn't know if you would like this.  If you like it the only thing left to do would be to make a couple more instances of `ApplicationContextManager` classes that inherit from `ApplicationContextManagerFacade`

Let me know.

