### PR TITLE
 proposed fixes 

### DIFF
--- a/Source/Csla/ApplicationContext.cs
+++ b/Source/Csla/ApplicationContext.cs
@@ -10,6 +10,7 @@ using System.Security.Principal;
 using Csla.Core;
 using System.Security.Claims;
 using Microsoft.Extensions.DependencyInjection;
+using System.ComponentModel;
 
 namespace Csla
 {
@@ -371,18 +372,19 @@ namespace Csla
     /// </summary>
     /// <typeparam name="T">Type of object to create.</typeparam>
     /// <param name="parameters">Parameters for constructor</param>
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
     public T CreateInstanceDI<T>(params object[] parameters)
     {
       return (T)CreateInstanceDI(typeof(T), parameters);
     }
 
     /// <summary>
-    /// Creates object via true DI using ServiceProvider.GetRequiredService. 
-    /// Requires service to be properly registered. Throws null exception 
-    /// if no service provider available.
+    /// Attempts to get service via DI using ServiceProviderServiceExtensions.GetRequiredService. 
+    /// Throws exception if service not properly registered with DI.
     /// </summary>
     /// <typeparam name="T">Type of service/object to create.</typeparam>
-    public T CreateInstanceViaServiceProvider<T>()
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    public T GetRequiredService<T>()
     {
       if (CurrentServiceProvider == null) 
         throw new NullReferenceException(nameof(CurrentServiceProvider));
@@ -398,6 +400,7 @@ namespace Csla
     /// </summary>
     /// <param name="objectType">Type of object to create</param>
     /// <param name="parameters">Manually passed in parameters for constructor</param>
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
     public object CreateInstanceDI(Type objectType, params object[] parameters)
     {
       object result;
@@ -431,6 +434,7 @@ namespace Csla
     /// </summary>
     /// <typeparam name="T">Type of object to create.</typeparam>
     /// <param name="parameters">Parameters for constructor</param>
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
     public T CreateInstance<T>(params object[] parameters)
     {
       return (T)CreateInstance(typeof(T), parameters);
@@ -441,6 +445,7 @@ namespace Csla
     /// </summary>
     /// <param name="objectType">Type of object to create</param>
     /// <param name="parameters">Parameters for constructor</param>
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
     public object CreateInstance(Type objectType, params object[] parameters)
     {
       object result;

--- a/Source/Csla/ApplicationContext.cs
+++ b/Source/Csla/ApplicationContext.cs
@@ -365,8 +365,9 @@ namespace Csla
     internal IServiceProvider CurrentServiceProvider => ApplicationContextAccessor.ServiceProvider;
 
     /// <summary>
-    /// Creates an object using dependency injection, falling back
-    /// to Activator if no service provider is available.
+    /// Creates an object using 'Activator.CreateInstance' using
+    /// service provider (if one is available) to populate any parameters 
+    /// in CTOR that are not manually passed in.
     /// </summary>
     /// <typeparam name="T">Type of object to create.</typeparam>
     /// <param name="parameters">Parameters for constructor</param>
@@ -376,16 +377,32 @@ namespace Csla
     }
 
     /// <summary>
-    /// Creates an object using dependency injection, falling back
-    /// to Activator if no service provider is available.
+    /// Creates object via true DI using ServiceProvider.GetRequiredService. 
+    /// Requires service to be properly registered. Throws null exception 
+    /// if no service provider available.
+    /// </summary>
+    /// <typeparam name="T">Type of service/object to create.</typeparam>
+    public T CreateInstanceViaServiceProvider<T>()
+    {
+      if (CurrentServiceProvider == null) 
+        throw new NullReferenceException(nameof(CurrentServiceProvider));
+
+      var result = CurrentServiceProvider.GetRequiredService<T>();
+      return result;
+    }
+
+    /// <summary>
+    /// Creates an object using 'Activator.CreateInstance' using
+    /// service provider (if one is available) to populate any parameters 
+    /// in CTOR that are not manually passed in.
     /// </summary>
     /// <param name="objectType">Type of object to create</param>
-    /// <param name="parameters">Parameters for constructor</param>
+    /// <param name="parameters">Manually passed in parameters for constructor</param>
     public object CreateInstanceDI(Type objectType, params object[] parameters)
     {
       object result;
       if (CurrentServiceProvider != null)
-        result = ActivatorUtilities.CreateInstance(CurrentServiceProvider, objectType, parameters);
+          result = ActivatorUtilities.CreateInstance(CurrentServiceProvider, objectType, parameters);
       else
         result = Activator.CreateInstance(objectType, parameters);
       if (result is IUseApplicationContext tmp)

--- a/Source/Csla/BusinessBindingListBase.cs
+++ b/Source/Csla/BusinessBindingListBase.cs
@@ -24,7 +24,7 @@ namespace Csla
     "Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix")]
   [Serializable()]
   public abstract class BusinessBindingListBase<T, C> :
-      Core.ExtendedBindingList<C>,
+      Core.ExtendedBindingList<C>, IContainsDeletedList,
       Core.IEditableCollection, Core.IUndoableObject, ICloneable,
       Core.ISavable, Core.ISavable<T>, Core.IParent, Server.IDataPortalTarget,
       INotifyBusy,
@@ -436,6 +436,11 @@ namespace Csla
         return _deletedList; 
       }
     }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+      "Microsoft.Design", "CA1002:DoNotExposeGenericLists")]
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    IEnumerable<IEditableBusinessObject> IContainsDeletedList.DeletedList => (IEnumerable<IEditableBusinessObject>)DeletedList;
 
     private void DeleteChild(C child)
     {

--- a/Source/Csla/BusinessListBase.cs
+++ b/Source/Csla/BusinessListBase.cs
@@ -31,7 +31,7 @@ namespace Csla
 #endif
   [Serializable]
   public abstract class BusinessListBase<T, C> :
-      ObservableBindingList<C>,
+      ObservableBindingList<C>, IContainsDeletedList,
       IEditableCollection, Core.IUndoableObject, ICloneable,
       ISavable, Core.ISavable<T>, Core.IParent,  Server.IDataPortalTarget,
       INotifyBusy,
@@ -156,6 +156,11 @@ namespace Csla
         return _deletedList;
       }
     }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+      "Microsoft.Design", "CA1002:DoNotExposeGenericLists")]
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    IEnumerable<IEditableBusinessObject> IContainsDeletedList.DeletedList => (IEnumerable<IEditableBusinessObject>)DeletedList;
 
     private void DeleteChild(C child)
     {

--- a/Source/Csla/DataPortalClient/LocalProxy.cs
+++ b/Source/Csla/DataPortalClient/LocalProxy.cs
@@ -89,6 +89,11 @@ namespace Csla.Channels.Local
             }
           }
         }
+
+        if (useApplicationContext is IContainsDeletedList containsDeletedList)
+          foreach (var item in containsDeletedList.DeletedList)
+            SetApplicationContext(item, applicationContext);
+
         if (useApplicationContext is IEnumerable list)
           foreach (var item in list)
             SetApplicationContext(item, applicationContext);

--- a/Source/Csla/IContainsDeletedList.cs
+++ b/Source/Csla/IContainsDeletedList.cs
@@ -1,4 +1,12 @@
-﻿using System;
+﻿//-----------------------------------------------------------------------
+// <copyright file="IContainsDeletedList.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>Interface implemented by a list which tracks its deleted items</summary>
+//-----------------------------------------------------------------------
+
+using System;
 using Csla.Core;
 using System.ComponentModel;
 using Csla.Serialization.Mobile;

--- a/Source/Csla/IContainsDeletedList.cs
+++ b/Source/Csla/IContainsDeletedList.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Csla.Core;
+using System.ComponentModel;
+using Csla.Serialization.Mobile;
+using System.Collections.Specialized;
+using System.Collections.Generic;
+
+namespace Csla
+{
+  /// <summary>
+  /// Defines an object that holds a list of deleted items.
+  /// </summary>
+  public interface IContainsDeletedList
+  {
+    /// <summary>
+    /// List of deleted child objects
+    /// </summary>
+    IEnumerable<IEditableBusinessObject> DeletedList { get; }
+  }
+}


### PR DESCRIPTION
#2841 and #2842

- New method `CreateInstanceViaServiceProvider` which uses **true** DI for object creation instead of CreateInstance. 

 [This answer](https://stackoverflow.com/a/45778712) from David Fowler finally helped me realize the difference between the current methods using CreateInstance versus ServiceProvider.GetRequiredService.  

The current methods create the object by CreateInstance without requiring DI registration.  During that operation the ServiceProvider (if present) merely attempts to resolve any missing parameters in its CTOR that were not manually passed in. 

Whereas, the new method actually uses DI for both _object creation AND for parameter resolution_.
I updated the comments on those existing methods to hopefully add clarity and distinctness.


- New interface `IContainsDeletedList` for the two objects which have a `DeletedList`


- Process `IContainsDeletedList` objects in LocalProxy for `SetApplicationContext`


