### PR TITLE
Csla 6.0 additional test fixes

### DIFF
--- a/Source/Csla.test/Basic/Child.cs
+++ b/Source/Csla.test/Basic/Child.cs
@@ -18,7 +18,7 @@ namespace Csla.Test.Basic
     private string _data = "";
     private Guid _guid = System.Guid.NewGuid();
 
-    private GrandChildren _children = Csla.Test.Basic.GrandChildren.NewGrandChildren();
+    public static PropertyInfo<GrandChildren> GrandChildrenProperty = RegisterProperty<GrandChildren>(c => c.GrandChildren);
 
     protected override object GetIdValue()
     {
@@ -60,7 +60,7 @@ namespace Csla.Test.Basic
 
     public GrandChildren GrandChildren
     {
-      get { return _children; }
+      get { return GetProperty(GrandChildrenProperty); }
     }
 
     internal static Child NewChild(IDataPortal<Child> dataPortal, string data)
@@ -68,10 +68,10 @@ namespace Csla.Test.Basic
       return dataPortal.Create(data);
     }
 
-    internal static Child GetChild(IDataReader dr)
+    internal static Child GetChild(IDataPortal<Child> dataPortal, IDataReader dr)
     {
-      Child obj = new Child();
-      obj.Fetch(dr);
+      Child obj;
+      obj = dataPortal.Fetch(dr);
       return obj;
     }
 
@@ -81,16 +81,21 @@ namespace Csla.Test.Basic
     }
 
     [Create]
-    private void Create(string data)
+    [CreateChild]
+    private void Create(string data, [Inject] IChildDataPortal<GrandChildren> childDataPortal)
     {
       _data = data;
+      LoadProperty(GrandChildrenProperty, childDataPortal.CreateChild());
     }
 
-    private void Fetch(IDataReader dr)
+    [Fetch]
+    [FetchChild]
+    private void Fetch(IDataReader dr, [Inject] IChildDataPortal<GrandChildren> childDataPortal)
     {
-      MarkOld();
+      LoadProperty(GrandChildrenProperty, childDataPortal.CreateChild());
     }
 
+    [UpdateChild]
     internal void Update(IDbTransaction tr)
     {
       if (IsDeleted)

--- a/Source/Csla.test/Basic/Children.cs
+++ b/Source/Csla.test/Basic/Children.cs
@@ -30,14 +30,6 @@ namespace Csla.Test.Basic
       return null;
     }
 
-    internal void Update(IDbTransaction tr)
-    {
-      foreach (Child child in this)
-      {
-        child.Update(tr);
-      }
-    }
-
     public Children()
     {
       this.MarkAsChild();

--- a/Source/Csla.test/Basic/CollectionTests.cs
+++ b/Source/Csla.test/Basic/CollectionTests.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Linq;
 using System.Diagnostics;
+using Csla.TestHelpers;
 
 #if !NUNIT
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -26,15 +27,25 @@ namespace Csla.Test.Basic
   [TestClass]
   public class CollectionTests
   {
+    private static TestDIContext _testDIContext;
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext context)
+    {
+      _testDIContext = TestDIContextFactory.CreateDefaultContext();
+    }
+
     [TestMethod]
     public void SetLast()
     {
-      TestCollection list = new TestCollection();
-      list.Add(new TestItem());
-      list.Add(new TestItem());
-      TestItem oldItem = new TestItem();
+      IDataPortal<TestCollection> dataPortal = _testDIContext.CreateDataPortal<TestCollection>();
+      IDataPortal<TestItem> childDataPortal = _testDIContext.CreateDataPortal<TestItem>();
+      TestCollection list = dataPortal.Create();
+      list.Add(childDataPortal.Create());
+      list.Add(childDataPortal.Create());
+      TestItem oldItem = childDataPortal.Create();
       list.Add(oldItem);
-      TestItem newItem = new TestItem();
+      TestItem newItem = childDataPortal.Create();
       list[2] = newItem;
       Assert.AreEqual(3, list.Count, "List should have 3 items");
       Assert.AreEqual(newItem, list[2], "Last item should be newItem");
@@ -55,7 +66,11 @@ namespace Csla.Test.Basic
   {
     public TestCollection()
     {
-      AllowNew = true;
+    }
+
+    [Create]
+    private void Create()
+    {
     }
 
     private void DataPortal_Fetch([Inject] IChildDataPortal<TestItem> childDataPortal)
@@ -88,9 +103,13 @@ namespace Csla.Test.Basic
       MarkAsChild();
     }
 
+    [Create]
+    [CreateChild]
     protected override void Child_Create()
     { }
 
+    [Fetch]
+    [FetchChild]
     private void Child_Fetch(int id)
     {
       LoadProperty(IdProperty, id);

--- a/Source/Csla.test/DPException/DataPortalExceptionTests.cs
+++ b/Source/Csla.test/DPException/DataPortalExceptionTests.cs
@@ -12,6 +12,7 @@ using Csla.Test.Security;
 using System.Data;
 using System.Data.SqlClient;
 using Csla.TestHelpers;
+using Csla.Configuration;
 
 #if !NUNIT
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/Source/Csla.test/DataPortal/AuthorizeDataPortalTests.cs
+++ b/Source/Csla.test/DataPortal/AuthorizeDataPortalTests.cs
@@ -164,7 +164,7 @@ namespace Csla.Test.DataPortal
       var dp = _testDIContext.ServiceProvider.GetRequiredService<TestableDataPortal>();
       await dp.Create(typeof(TestBO), null, new DataPortalContext(applicationContext, applicationContext.Principal, false), true);
 
-      var result = (AuthorizeDataPortalStub)dp.AuthProvider;//This comes from App.Config
+      var result = (AuthorizeDataPortalStub)dp.AuthProvider;
 
       Assert.IsNotNull(result, "AuthorizeDataPortalStub not accessible");
       Assert.AreEqual(typeof(TestBO), result.ClientRequest?.ObjectType);
@@ -178,7 +178,7 @@ namespace Csla.Test.DataPortal
       var dp = _testDIContext.ServiceProvider.GetRequiredService<TestableDataPortal>();
       await dp.Fetch(typeof(TestBO), null, new DataPortalContext(applicationContext, applicationContext.Principal, false), true);
 
-      var result = (AuthorizeDataPortalStub)dp.AuthProvider;//This comes from App.Config
+      var result = (AuthorizeDataPortalStub)dp.AuthProvider;
 
       Assert.IsNotNull(result, "AuthorizeDataPortalStub not accessible");
       Assert.AreEqual(typeof(TestBO), result.ClientRequest?.ObjectType);
@@ -193,7 +193,7 @@ namespace Csla.Test.DataPortal
       await dp.Update(new TestBO(), new DataPortalContext(applicationContext, applicationContext.Principal, false), true);
 
 
-      var result = (AuthorizeDataPortalStub)dp.AuthProvider;//This comes from App.Config
+      var result = (AuthorizeDataPortalStub)dp.AuthProvider;
 
       Assert.IsNotNull(result, "AuthorizeDataPortalStub not accessible");
       Assert.AreEqual(typeof(TestBO), result.ClientRequest?.ObjectType);
@@ -207,13 +207,12 @@ namespace Csla.Test.DataPortal
       var dp = _testDIContext.ServiceProvider.GetRequiredService<TestableDataPortal>();
       await dp.Delete(typeof(TestBO), new object(), new DataPortalContext(applicationContext, applicationContext.Principal, false), true);
 
-      var result = (AuthorizeDataPortalStub)dp.AuthProvider;//This comes from App.Config
+      var result = (AuthorizeDataPortalStub)dp.AuthProvider;
 
       Assert.IsNotNull(result, "AuthorizeDataPortalStub not accessible");
       Assert.AreEqual(typeof(TestBO), result.ClientRequest?.ObjectType);
       Assert.AreEqual(DataPortalOperations.Delete, result.ClientRequest.Operation);
     }
-
 
     #endregion
   }

--- a/Source/Csla.test/DataPortal/ChildEntity.cs
+++ b/Source/Csla.test/DataPortal/ChildEntity.cs
@@ -11,52 +11,45 @@ using System.Text;
 
 namespace Csla.Test.DataBinding
 {
-    [Serializable()]
-    public class ChildEntity : BusinessBase<ChildEntity>
+  [Serializable()]
+  public class ChildEntity : BusinessBase<ChildEntity>
+  {
+    public static PropertyInfo<int> IDProperty = RegisterProperty<int>(c => c.ID);
+    public static PropertyInfo<string> FirstNameProperty = RegisterProperty<string>(c => c.FirstName);
+    public static PropertyInfo<string> LastNameProperty = RegisterProperty<string>(c => c.LastName);
+
+    public int ID
     {
-        private int _ID;
-        private string _firstName = "";
-        private string _lastName = "";
-
-        public int ID
-        {
-            get { return _ID; }
-        }
-
-        public string FirstName
-        {
-            get { return _firstName; }
-            set
-            {
-                if (_firstName != value)
-                    _firstName = value;
-            }
-        }
-
-        public string LastName
-        {
-            get { return _lastName; }
-            set
-            {
-                if (_lastName != value)
-                    _lastName = value;
-            }
-        }
-
-        #region "Object ID value"
-
-        protected override object GetIdValue()
-        {
-            return _ID;
-        }
-
-        #endregion
-
-        internal ChildEntity(int id, string firstName, string lastName)
-        {
-            _ID = id;
-            _firstName = firstName;
-            _lastName = lastName;
-        }
+      get { return GetProperty(IDProperty); }
     }
+
+    public string FirstName
+    {
+      get { return GetProperty(FirstNameProperty); }
+      set { SetProperty(FirstNameProperty, value); }
+    }
+
+    public string LastName
+    {
+      get { return GetProperty(LastNameProperty); }
+      set { SetProperty(LastNameProperty, value); }
+    }
+
+    #region "Object ID value"
+
+    protected override object GetIdValue()
+    {
+      return ReadProperty(IDProperty);
+    }
+
+    #endregion
+
+    [CreateChild]
+    private void Create(int id, string firstName, string lastName)
+    {
+      LoadProperty(IDProperty, id);
+      LoadProperty(FirstNameProperty, firstName);
+      LoadProperty(LastNameProperty, lastName);
+    }
+  }
 }

--- a/Source/Csla.test/DataPortal/ChildEntityList.cs
+++ b/Source/Csla.test/DataPortal/ChildEntityList.cs
@@ -17,17 +17,7 @@ namespace Csla.Test.DataBinding
     {
         public ChildEntityList()
         {
-            this.MarkAsChild();
         }
-
-        #region "factory methods"
-
-        public static ChildEntityList NewChildEntityList()
-        {
-            return new ChildEntityList();
-        }
-
-        #endregion
 
         #region "Criteria"
 
@@ -39,19 +29,11 @@ namespace Csla.Test.DataBinding
 
         #endregion
 
-        internal void update(IDbTransaction tr)
-        {
-            foreach (ChildEntity child in this)
-            {
-                //child.Update(tr);
-            }
-        }
-
         [Fetch]
-        private void DataPortal_Fetch(object criteria)
+        private void DataPortal_Fetch(object criteria, IChildDataPortal<ChildEntity> childDataPortal)
         {
             for (int i = 0; i < 10; i++)
-                Add(new ChildEntity(i, "first" + i, "last" + i));
+                Add(childDataPortal.CreateChild(i, "first" + i, "last" + i));
         }
     }
 }

--- a/Source/Csla.test/DataPortal/DataPortalTests.cs
+++ b/Source/Csla.test/DataPortal/DataPortalTests.cs
@@ -66,7 +66,7 @@ namespace Csla.Test.DataPortal
     {
       IDataPortal<TransactionalRoot> dataPortal = _testDIContext.CreateDataPortal<TransactionalRoot>();
 
-      Csla.Test.DataPortal.TransactionalRoot tr = Csla.Test.DataPortal.TransactionalRoot.NewTransactionalRoot(dataPortal);
+      TransactionalRoot tr = TransactionalRoot.NewTransactionalRoot(dataPortal);
       tr.FirstName = "Bill";
       tr.LastName = "Johnson";
       //setting smallColumn to a string less than or equal to 5 characters will

--- a/Source/Csla.test/DataPortal/ParentEntity.cs
+++ b/Source/Csla.test/DataPortal/ParentEntity.cs
@@ -18,7 +18,6 @@ namespace Csla.Test.DataBinding
   {
     #region "Business methods"
 
-    private ChildEntityList _children = ChildEntityList.NewChildEntityList();
     [NotUndoable()]
     private string _notUndoable;
 
@@ -42,16 +41,17 @@ namespace Csla.Test.DataBinding
       set { SetProperty(DataProperty, value); }
     }
 
+    public static PropertyInfo<ChildEntityList> ChildrenProperty = RegisterProperty<ChildEntityList>(p => p.Children);
     public ChildEntityList Children
     {
-      get { return _children; }
+      get { return GetProperty(ChildrenProperty); }
     }
 
     public override bool IsDirty
     {
       get
       {
-        return base.IsDirty || _children.IsDirty;
+        return base.IsDirty || Children.IsDirty;
       }
     }
 
@@ -118,16 +118,19 @@ namespace Csla.Test.DataBinding
 
     [RunLocal()]
     [Create]
-		protected void DataPortal_Create()
+	protected void DataPortal_Create([Inject] IChildDataPortal<ChildEntityList> childDataPortal)
     {
+      SetProperty(ChildrenProperty, childDataPortal.CreateChild());
       TestResults.Reinitialise();
       TestResults.Add("ParentEntity", "Created");
       BusinessRules.CheckRules();
       Console.WriteLine("DataPortal_Create");
     }
 
-    protected void DataPortal_Fetch(object criteria)
+    [Fetch]
+    protected void DataPortal_Fetch(object criteria, [Inject] IChildDataPortal<ChildEntityList> childDataPortal)
     {
+      SetProperty(ChildrenProperty, childDataPortal.CreateChild());
       Console.WriteLine("DataPortal_Fetch");
       TestResults.Reinitialise();
       TestResults.Add("ParentEntity", "Fetched");
@@ -143,7 +146,7 @@ namespace Csla.Test.DataBinding
     }
 
     [Update]
-		protected void DataPortal_Update()
+	protected void DataPortal_Update()
     {
       Console.WriteLine("DataPortal_Update");
       TestResults.Reinitialise();
@@ -159,7 +162,7 @@ namespace Csla.Test.DataBinding
     }
 
     [Delete]
-		protected void DataPortal_Delete(object criteria)
+	protected void DataPortal_Delete(object criteria)
     {
       Console.WriteLine("DataPortal_Delete");
       TestResults.Reinitialise();

--- a/Source/Csla.test/DataPortal/ParentEntity.cs
+++ b/Source/Csla.test/DataPortal/ParentEntity.cs
@@ -116,7 +116,6 @@ namespace Csla.Test.DataBinding
 
     #region "Data Access"
 
-    [RunLocal()]
     [Create]
 	protected void DataPortal_Create([Inject] IChildDataPortal<ChildEntityList> childDataPortal)
     {

--- a/Source/Csla.test/EditableRootList/ERitem.cs
+++ b/Source/Csla.test/EditableRootList/ERitem.cs
@@ -24,21 +24,23 @@ namespace Csla.Test.EditableRootList
     public ERitem()
     { }
 
-    private ERitem(string data)
+    [Create]
+    private void Create()
+    {
+    }
+
+    [Create]
+    private void Create(string data)
     {
       using (BypassPropertyChecks)
         Data = data;
-      MarkOld();
     }
 
-    public static ERitem NewItem()
+    [Fetch]
+    private void Fetch(string data)
     {
-      return new ERitem();
-    }
-
-    public static ERitem GetItem(string data)
-    {
-      return new ERitem(data);
+      using (BypassPropertyChecks)
+        Data = data;
     }
 
     [Insert]
@@ -48,7 +50,7 @@ namespace Csla.Test.EditableRootList
     }
 
     [Update]
-		protected void DataPortal_Update()
+	protected void DataPortal_Update()
     {
       TestResults.Add("DP", "Update");
     }
@@ -60,7 +62,7 @@ namespace Csla.Test.EditableRootList
     }
 
     [Delete]
-		protected void DataPortal_Delete(object criteria)
+	protected void DataPortal_Delete(object criteria)
     {
       TestResults.Add("DP", "Delete");
     }

--- a/Source/Csla.test/EditableRootList/ERlist.cs
+++ b/Source/Csla.test/EditableRootList/ERlist.cs
@@ -20,13 +20,6 @@ namespace Csla.Test.EditableRootList
       AllowRemove = true;
     }
 
-    protected override object AddNewCore()
-    {
-      ERitem item = ERitem.NewItem();
-      this.Add(item);
-      return item;
-    }
-
     [Create]
     private void Create()
     {

--- a/Source/Csla.test/EditableRootList/EditableRootListTests.cs
+++ b/Source/Csla.test/EditableRootList/EditableRootListTests.cs
@@ -67,13 +67,14 @@ namespace Csla.Test.EditableRootList
     public void RemoveOldItem()
     {
       IDataPortal<ERlist> dataPortal = _testDIContext.CreateDataPortal<ERlist>();
+      IDataPortal<ERitem> itemDataPortal = _testDIContext.CreateDataPortal<ERitem>();
 
       TestResults.Reinitialise();
       _isListSaved = false;
 
       ERlist list = dataPortal.Create();
       
-      list.Add(ERitem.GetItem("test"));
+      list.Add(itemDataPortal.Fetch("test"));
       ERitem item = list[0];
       item.Saved += new EventHandler<Csla.Core.SavedEventArgs>(item_Saved);
       list.Saved += new EventHandler<Csla.Core.SavedEventArgs>(List_Saved);
@@ -104,6 +105,7 @@ namespace Csla.Test.EditableRootList
     public void InsertItem()
     {
       IDataPortal<ERlist> dataPortal = _testDIContext.CreateDataPortal<ERlist>();
+      TestResults.Reinitialise();
 
       _isListSaved = false;
 
@@ -126,12 +128,14 @@ namespace Csla.Test.EditableRootList
     public void UpdateItem()
     {
       IDataPortal<ERlist> dataPortal = _testDIContext.CreateDataPortal<ERlist>();
+      IDataPortal<ERitem> itemDataPortal = _testDIContext.CreateDataPortal<ERitem>();
+      TestResults.Reinitialise();
 
       _isListSaved = false;
 
       ERlist list = dataPortal.Create();
       list.Saved += new EventHandler<Csla.Core.SavedEventArgs>(List_Saved);
-      list.Add(ERitem.GetItem("test"));
+      list.Add(itemDataPortal.Fetch("test"));
       ERitem item = list[0];
       Assert.AreEqual(1, list.Count, "Incorrect count after add");
       Assert.IsFalse(list[0].IsNew, "Object should not be new");

--- a/Source/Csla.test/Fakes/Server/DataPortal/TestableDataPortal.cs
+++ b/Source/Csla.test/Fakes/Server/DataPortal/TestableDataPortal.cs
@@ -18,6 +18,8 @@ namespace Csla.Testing.Business.DataPortal
   /// </summary>
   public class TestableDataPortal : Csla.Server.DataPortal
   {
+    private IAuthorizeDataPortal _authorizer;
+
     public TestableDataPortal(
       ApplicationContext applicationContext,
       IDashboard dashboard,
@@ -39,31 +41,29 @@ namespace Csla.Testing.Business.DataPortal
       exceptionInspector,
       exceptionHandler
     )
-    { }
+    {
+      _authorizer = authorizer;
+    }
 
     public static void Setup()
     {
-      //TODO: Not sure how to recreate this test in Csla 6
-      //Authorizer = null;
     }
 
     public Type AuthProviderType
     {
-      get {
-        //TODO: Not sure how to recreate this test in Csla 6
-        //return Authorizer.GetType();
-        return null;
-        }
+      get
+      {
+        return _authorizer.GetType();
+      }
     }
 
     public IAuthorizeDataPortal AuthProvider
     {
-      get {
-        //TODO: Not sure how to recreate this test in Csla 6
-        //return Authorizer;
-        return null;
-        }
+      get
+      {
+        return _authorizer;
       }
+    }
 
     public bool NullAuthorizerUsed
     {

--- a/Source/Csla.test/LazyLoad/AChildList.cs
+++ b/Source/Csla.test/LazyLoad/AChildList.cs
@@ -14,10 +14,12 @@ namespace Csla.Test.LazyLoad
   [Serializable]
   public class AChildList : Csla.BusinessBindingListBase<AChildList, AChild>
   {
-    public AChildList()
+
+    [Fetch]
+    private void Fetch([Inject] IChildDataPortal<AChild> childDataPortal)
     {
       MarkAsChild();
-      this.Add(new AChild());
+      this.Add(childDataPortal.CreateChild());
     }
 
     public new int EditLevel

--- a/Source/Csla.test/LazyLoad/AParent.cs
+++ b/Source/Csla.test/LazyLoad/AParent.cs
@@ -22,14 +22,12 @@ namespace Csla.Test.LazyLoad
     }
 
     private static PropertyInfo<AChildList> ChildListProperty = 
-      RegisterProperty<AChildList>(c => c.ChildList, "Child list");
+      RegisterProperty<AChildList>(c => c.ChildList, "Child list", null, RelationshipTypes.LazyLoad);
     public AChildList ChildList
     {
       get 
       {
-        if (!FieldManager.FieldExists(ChildListProperty))
-          LoadProperty<AChildList>(ChildListProperty, new AChildList());
-        return GetProperty<AChildList>(ChildListProperty); 
+        return LazyGetProperty(ChildListProperty, FetchChildList);
       }
     }
 
@@ -39,7 +37,6 @@ namespace Csla.Test.LazyLoad
         return ReadProperty<AChildList>(ChildListProperty);
       else
         return null;
-      //return _children;
     }
 
     public new int EditLevel
@@ -47,10 +44,16 @@ namespace Csla.Test.LazyLoad
       get { return base.EditLevel; }
     }
 
-    public AParent()
+    [Create]
+    private void Create()
     {
       using (BypassPropertyChecks)
         Id = Guid.NewGuid();
+    }
+
+    private AChildList FetchChildList()
+    {
+      return GetDataPortal<AChildList>().Fetch();
     }
   }
 }

--- a/Source/Csla.test/LazyLoad/LazyLoadTests.cs
+++ b/Source/Csla.test/LazyLoad/LazyLoadTests.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Csla.TestHelpers;
 
 #if !NUNIT
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -25,10 +26,18 @@ namespace Csla.Test.LazyLoad
   [TestClass]
   public class LazyLoadTests
   {
+    private static TestDIContext _testDIContext;
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext context)
+    {
+      _testDIContext = TestDIContextFactory.CreateDefaultContext();
+    }
+
     [TestMethod]
     public void NullApplyEdit()
     {
-      AParent parent = new AParent();
+      AParent parent = CreateAParent();
       Assert.IsNull(parent.GetChildList(), "GetChildList should be null");
 
       parent.BeginEdit();
@@ -43,7 +52,7 @@ namespace Csla.Test.LazyLoad
     [TestMethod]
     public void NullCancelEdit()
     {
-      AParent parent = new AParent();
+      AParent parent = CreateAParent();
       Assert.IsNull(parent.GetChildList(), "GetChildList should be null");
 
       parent.BeginEdit();
@@ -66,7 +75,7 @@ namespace Csla.Test.LazyLoad
     [TestMethod]
     public void NewChildEditLevel()
     {
-      AParent parent = new AParent();
+      AParent parent = CreateAParent();
       Assert.IsNull(parent.GetChildList(), "GetChildList should be null");
 
       parent.BeginEdit();
@@ -87,7 +96,7 @@ namespace Csla.Test.LazyLoad
     [TestMethod]
     public void NewChildEditLevelCancel()
     {
-      AParent parent = new AParent();
+      AParent parent = CreateAParent();
       Assert.IsNull(parent.GetChildList(), "GetChildList should be null");
 
       parent.BeginEdit();
@@ -107,7 +116,7 @@ namespace Csla.Test.LazyLoad
     [TestMethod]
     public void NewChildEditLevelApply()
     {
-      AParent parent = new AParent();
+      AParent parent = CreateAParent();
       Assert.IsNull(parent.GetChildList(), "GetChildList should be null");
 
       parent.BeginEdit();
@@ -124,6 +133,13 @@ namespace Csla.Test.LazyLoad
       list = parent.GetChildList();
       Assert.AreEqual(0, list.EditLevel, "Child list edit level should be 0");
       Assert.AreEqual(0, list[0].EditLevel, "Child edit level should be 0");
+    }
+
+    private AParent CreateAParent()
+    {
+      IDataPortal<AParent> dataPortal = _testDIContext.CreateDataPortal<AParent>();
+
+      return dataPortal.Create();
     }
   }
 }

--- a/Source/Csla.test/LogicalExecutionLocation/LocationBusinessBase.cs
+++ b/Source/Csla.test/LogicalExecutionLocation/LocationBusinessBase.cs
@@ -65,13 +65,8 @@ namespace Csla.Test.LogicalExecutionLocation
       }
     }
 
-    [Update]
-	protected void DataPortal_Update()
-    {
-      
-    }
-
-    protected void DataPortal_Fetch([Inject]IDataPortal<LocationBusinessBase> dataPortal)
+    [Fetch]
+    protected void Fetch([Inject]IDataPortal<LocationBusinessBase> dataPortal)
     {
       SetProperty(DataProperty, ApplicationContext.LogicalExecutionLocation.ToString());
 #pragma warning disable CS0436 // Type conflicts with imported type
@@ -80,9 +75,17 @@ namespace Csla.Test.LogicalExecutionLocation
       NestedData = nested.Data;
     }
 
-    protected void DataPortal_Fetch(int criteria)
+    [Fetch]
+    protected void Fetch(int criteria)
     {
       SetProperty(DataProperty, ApplicationContext.LogicalExecutionLocation.ToString());
     }
+
+    [Update]
+	protected void DataPortal_Update()
+    {
+      
+    }
+
   }
 }

--- a/Source/Csla.test/LogicalExecutionLocation/LogicalExecutionLocationTests.cs
+++ b/Source/Csla.test/LogicalExecutionLocation/LogicalExecutionLocationTests.cs
@@ -45,8 +45,8 @@ namespace Csla.Test.LogicalExecutionLocation
       LocationBusinessBase item = LocationBusinessBase.GetLocationBusinessBase(dataPortal);
 #pragma warning restore CS0436 // Type conflicts with imported type
 
-      Assert.AreEqual(item.Data,Csla.ApplicationContext.LogicalExecutionLocations.Server.ToString(), "Should be server");
-      Assert.AreEqual(item.NestedData, Csla.ApplicationContext.LogicalExecutionLocations.Server.ToString(), "Nested should be server");
+      Assert.AreEqual(Csla.ApplicationContext.LogicalExecutionLocations.Server.ToString(), item.Data, "Should be server");
+      Assert.AreEqual(Csla.ApplicationContext.LogicalExecutionLocations.Server.ToString(), item.NestedData, "Nested should be server");
 
       Assert.AreEqual(Csla.ApplicationContext.LogicalExecutionLocations.Client, applicationContext.LogicalExecutionLocation, "Should be client");
 

--- a/Source/Csla.test/PropertyGetSet/EditableGetSet.cs
+++ b/Source/Csla.test/PropertyGetSet/EditableGetSet.cs
@@ -152,21 +152,23 @@ namespace Csla.Test.PropertyGetSet
       }
     }
 
-    private static Csla.PropertyInfo<EditableGetSet> ManagedChildProperty = RegisterProperty(typeof(EditableGetSet), new Csla.PropertyInfo<EditableGetSet>("ManagedChild"));
+    private static Csla.PropertyInfo<EditableGetSet> ManagedChildProperty = RegisterProperty(
+      typeof(EditableGetSet), new Csla.PropertyInfo<EditableGetSet>("ManagedChild", RelationshipTypes.LazyLoad));
     public EditableGetSet ManagedChild
     {
       get 
       { 
-        return GetProperty(ManagedChildProperty); 
+        return LazyGetProperty(ManagedChildProperty, () => GetDataPortal<EditableGetSet>().Create()); 
       }
     }
 
-    private static Csla.PropertyInfo<ChildList> ManagedChildListProperty = RegisterProperty(typeof(EditableGetSet), new Csla.PropertyInfo<ChildList>("ManagedChildList"));
+    private static Csla.PropertyInfo<ChildList> ManagedChildListProperty = RegisterProperty(
+      typeof(EditableGetSet), new Csla.PropertyInfo<ChildList>("ManagedChildList", RelationshipTypes.LazyLoad));
     public ChildList ManagedChildList
     {
       get
       {
-        return GetProperty(ManagedChildListProperty);
+        return LazyGetProperty(ManagedChildListProperty, () => GetDataPortal<ChildList>().Create());
       }
     }
 
@@ -174,7 +176,7 @@ namespace Csla.Test.PropertyGetSet
       RegisterProperty(new PropertyInfo<ChildList>("LazyChild", "Child list", null, RelationshipTypes.LazyLoad));
     public ChildList LazyChild
     {
-      get { return GetProperty(LazyChildProperty); }
+      get { return LazyGetProperty(LazyChildProperty, () => GetDataPortal<ChildList>().Create()); }
       set { SetProperty(LazyChildProperty, value); }
     }
 
@@ -219,33 +221,27 @@ namespace Csla.Test.PropertyGetSet
     #region Data Access
 
     [Create]
-    private void Create([Inject] IChildDataPortal<EditableGetSet> dataPortal, [Inject]IChildDataPortal<ChildList> listDataPortal)
+    private void Create([Inject] IChildDataPortal<EditableGetSet> dataPortal)
     {
       LoadProperty(M06Property, null);
-      LoadProperty(ManagedChildProperty, EditableGetSet.NewChildObject(dataPortal));
-      LoadProperty(ManagedChildListProperty, ChildList.NewChildObject(listDataPortal));
     }
 
     [CreateChild]
-    private void CreateChild([Inject] IChildDataPortal<ChildList> listDataPortal)
+    private void CreateChild()
     {
       LoadProperty(M06Property, null);
-      LoadProperty(ManagedChildListProperty, ChildList.NewChildObject(listDataPortal));
     }
 
     [Fetch]
-    private void DataPortal_Fetch([Inject] IChildDataPortal<EditableGetSet> dataPortal, [Inject] IChildDataPortal<ChildList> listDataPortal)
+    private void DataPortal_Fetch()
     {
       LoadProperty(M06Property, null);
-      LoadProperty(ManagedChildProperty, EditableGetSet.GetChildObject(dataPortal));
-      LoadProperty(ManagedChildListProperty, ChildList.GetChildObject(listDataPortal));
     }
 
     [FetchChild]
-    private void DataPortal_FetchChild([Inject] IChildDataPortal<EditableGetSet> dataPortal, [Inject] IChildDataPortal<ChildList> listDataPortal)
+    private void DataPortal_FetchChild()
     {
       LoadProperty(M06Property, null);
-      LoadProperty(ManagedChildListProperty, ChildList.GetChildObject(listDataPortal));
     }
 
     [Insert]

--- a/Source/Csla.test/PropertyGetSet/PropertyGetSetTests.cs
+++ b/Source/Csla.test/PropertyGetSet/PropertyGetSetTests.cs
@@ -303,10 +303,6 @@ namespace Csla.Test.PropertyGetSet
       EditableGetSet child = root.ManagedChild;
       Assert.IsNotNull(child, "Child should not be null");
 
-      // TODO: I changed the EditableGetSet object from lazy loading children to loading
-      // them in the DP_Fetch method. I had to do this because the old code simply newed up the
-      // child, which is no longer supported in Csla 6
-      // This test will fail until we change it back - but not sure how to do lazy loading in Csla 6
       Assert.AreEqual("ManagedChild", _changingName, "ManagedChild should have been changing");
 
       Assert.AreEqual("ManagedChild", _changedName, "ManagedChild should have changed");
@@ -454,10 +450,6 @@ namespace Csla.Test.PropertyGetSet
       EditableGetSet initialChild = root.ManagedChild;
       Assert.AreEqual(1, initialChild.EditLevel, "Child edit level after being created");
 
-      // TODO: I changed the EditableGetSet object from lazy loading children to loading
-      // them in the DP_Fetch method. I had to do this because the old code simply newed up the
-      // child, which is no longer supported in Csla 6
-      // This test will fail until we change it back - but not sure how to do lazy loading in Csla 6
       Assert.IsTrue(root.IsDirty, "Root should be dirty");
 
       root.CancelEdit();
@@ -503,10 +495,6 @@ namespace Csla.Test.PropertyGetSet
 
       EditableGetSet initialChild = root.ManagedChild;
 
-      // TODO: I changed the EditableGetSet object from lazy loading children to loading
-      // them in the DP_Fetch method. I had to do this because the old code simply newed up the
-      // child, which is no longer supported in Csla 6
-      // This test will fail until we change it back - but not sure how to do lazy loading in Csla 6
       Assert.IsTrue(root.IsDirty, "Root should be dirty");
       Assert.IsTrue(initialChild.IsDirty, "Child should be dirty");
 
@@ -532,10 +520,6 @@ namespace Csla.Test.PropertyGetSet
       EditableGetSet initialChild = root.ManagedChild;
       Assert.AreEqual(1, initialChild.EditLevel, "Child edit level after being created");
 
-      // TODO: I changed the EditableGetSet object from lazy loading children to loading
-      // them in the DP_Fetch method. I had to do this because the old code simply newed up the
-      // child, which is no longer supported in Csla 6
-      // This test will fail until we change it back - but not sure how to do lazy loading in Csla 6
       Assert.IsTrue(root.IsDirty, "Root should be dirty");
 
       root.ApplyEdit();
@@ -575,10 +559,6 @@ namespace Csla.Test.PropertyGetSet
       Assert.AreEqual(0, root.EditLevel, "Root edit level after CancelEdit");
       ChildList secondList = root.ManagedChildList;
       Assert.AreEqual(0, secondList.EditLevel, "Second list edit level after CancelEdit");
-      // TODO: I changed the EditableGetSet object from lazy loading children to loading
-      // them in the DP_Fetch method. I had to do this because the old code simply newed up the
-      // child, which is no longer supported in Csla 6
-      // This test will fail until we change it back - but not sure how to do lazy loading in Csla 6
       Assert.IsFalse(ReferenceEquals(list, secondList), "List objects should not be the same");
 
       Assert.IsFalse(root.IsDirty, "Root should not be dirty after CancelEdit");

--- a/Source/Csla.test/SmartDate/SmartDateTests.cs
+++ b/Source/Csla.test/SmartDate/SmartDateTests.cs
@@ -432,6 +432,7 @@ namespace Csla.Test.SmartDate
       Assert.AreEqual(d2, clone, "Dates should have ben the same");
 
       d2 = new Csla.SmartDate(DateTime.Now, false);
+      memoryStream = new MemoryStream();
       mobileFormatter = new MobileFormatter(applicationContext);
       mobileFormatter.Serialize(memoryStream, d2);
       memoryStream.Seek(0, SeekOrigin.Begin);
@@ -440,6 +441,7 @@ namespace Csla.Test.SmartDate
 
       d2 = new Csla.SmartDate(DateTime.Now.AddDays(10), false);
       d2.FormatString = "YYYY/DD/MM";
+      memoryStream = new MemoryStream();
       mobileFormatter = new MobileFormatter(applicationContext);
       mobileFormatter.Serialize(memoryStream, d2);
       memoryStream.Seek(0, SeekOrigin.Begin);

--- a/Source/Csla.test/ValidationRules/ChildList.cs
+++ b/Source/Csla.test/ValidationRules/ChildList.cs
@@ -18,9 +18,10 @@ namespace Csla.Test.ValidationRules
   [Serializable]
   public class ChildList : BusinessBindingListBase<ChildList, Child>
   {
-    public static ChildList NewList(IChildDataPortal<ChildList> childDataPortal)
+    [Create]
+    private void Create()
     {
-      return childDataPortal.CreateChild();
+
     }
   }
 }

--- a/Source/Csla.test/ValidationRules/HasChildren.cs
+++ b/Source/Csla.test/ValidationRules/HasChildren.cs
@@ -27,12 +27,12 @@ namespace Csla.Test.ValidationRules
       set { SetProperty(IdProperty, value); }
     }
 
-    private static PropertyInfo<ChildList> ChildListProperty = RegisterProperty<ChildList>(c => c.ChildList, "Child list");
+    private static PropertyInfo<ChildList> ChildListProperty = RegisterProperty<ChildList>(c => c.ChildList, "Child list", null, RelationshipTypes.LazyLoad);
     public ChildList ChildList
     {
       get 
       {
-        return GetProperty(ChildListProperty); 
+        return LazyGetProperty(ChildListProperty, () => GetDataPortal<ChildList>().Create()); 
       }
     }
 
@@ -77,9 +77,8 @@ namespace Csla.Test.ValidationRules
     }
 
     [Create]
-    private async Task Create([Inject] IChildDataPortal<ChildList> childDataPortal)
+    private async Task Create()
     {
-      LoadProperty(ChildListProperty, ChildList.NewList(childDataPortal));
       await BusinessRules.CheckRulesAsync();
     }
   }

--- a/Source/Csla.test/ValidationRules/ValidationTests.cs
+++ b/Source/Csla.test/ValidationRules/ValidationTests.cs
@@ -325,9 +325,6 @@ namespace Csla.Test.ValidationRules
     {
       TestResults.Reinitialise();
       UnitTestContext context = GetContext();
-      // TODO: I changed the HasChildren class from lazy-loading of the child list to 
-      // creating it during the Create data access method. This test will fail until it 
-      // is changed back, but I don't know how to do lazy loading in Csla 6
       var root = await CreateWithoutCriteriaAsync<HasChildren>();
       context.Assert.AreEqual(false, root.IsValid);
       root.BeginEdit();

--- a/Source/csla.netcore.test/csla.netcore.test.csproj
+++ b/Source/csla.netcore.test/csla.netcore.test.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I've taken another pass through the .NET Core version of the tests and resolved some more bugs, all of which were with the tests themselves (mostly issues to do with the upgrade of test object definitions to match CSLA 6 requirements, especially associated with the data portal switching from static to instantiated via DI)

Includes a couple of small changes to the package references to bring them up to the same version used for all other projects.
