### PR TITLE
Fixes to tests using command objects - must use data portal to create them

### DIFF
--- a/Source/Csla.test/Basic/BasicTests.cs
+++ b/Source/Csla.test/Basic/BasicTests.cs
@@ -86,7 +86,7 @@ namespace Csla.Test.Basic
       IDataPortal<CommandObject> dataPortal = _testDIContext.CreateDataPortal<CommandObject>();
 
       TestResults.Reinitialise();
-      CommandObject obj = new CommandObject();
+      CommandObject obj = dataPortal.Create();
       obj = dataPortal.Execute(obj);
       Assert.AreEqual("Executed", obj.AProperty);
     }

--- a/Source/Csla.test/Basic/CommandObject.cs
+++ b/Source/Csla.test/Basic/CommandObject.cs
@@ -26,6 +26,11 @@ namespace Csla.Test.Basic
       set { LoadProperty(APropertyProperty, value); }
     }
 
+    [RunLocal]
+    [Create]
+    private void Create()
+    { }
+
     [Execute]
 	protected void DataPortal_Execute()
     {

--- a/Source/Csla.test/CommandBase/CommandBaseTest.cs
+++ b/Source/Csla.test/CommandBase/CommandBaseTest.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Csla.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Csla.TestHelpers;
 
 namespace Csla.Test.CommandBase
 {
@@ -17,7 +18,8 @@ namespace Csla.Test.CommandBase
     {
     }
 
-    private TestContext testContextInstance;
+    private TestContext _testContextInstance;
+    private TestDIContext _testDIContext = TestDIContextFactory.CreateDefaultContext();
 
     /// <summary>
     ///Gets or sets the test context which provides
@@ -27,12 +29,18 @@ namespace Csla.Test.CommandBase
     {
       get
       {
-        return testContextInstance;
+        return _testContextInstance;
       }
       set
       {
-        testContextInstance = value;
+        _testContextInstance = value;
       }
+    }
+
+    [ClassInitialize()]
+    public static void ClassInitialize(TestContext testContext) 
+    { 
+
     }
 
     #region Additional test attributes
@@ -57,12 +65,11 @@ namespace Csla.Test.CommandBase
     //
     #endregion
 
-
-    
     [TestMethod]
     public void CommandBase_AssertDefaultValues()
     {
-      var cmd = new CommandObject();
+      IDataPortal<CommandObject> dataPortal = _testDIContext.CreateDataPortal<CommandObject>();
+      var cmd = dataPortal.Create();
 
       Assert.AreEqual(string.Empty, cmd.Name);
       Assert.AreEqual(0, cmd.Num);
@@ -71,7 +78,8 @@ namespace Csla.Test.CommandBase
     [TestMethod]
     public void CommandBase_CanLoadProperties_WithObjectFactory()
     {
-      var cmd = new CommandObject();
+      IDataPortal<CommandObject> dataPortal = _testDIContext.CreateDataPortal<CommandObject>();
+      var cmd = dataPortal.Create();
 
       LoadProperty(cmd, CommandObject.NameProperty, "Rocky");
       LoadProperty(cmd, CommandObject.NumProperty, 8);
@@ -84,7 +92,8 @@ namespace Csla.Test.CommandBase
     [TestMethod]
     public void CommandBase_CanLoadPropertiesUsingNonGenericPropertyInfo_WithObjectFactory()
     {
-      var cmd = new CommandObject();
+      IDataPortal<CommandObject> dataPortal = _testDIContext.CreateDataPortal<CommandObject>();
+      var cmd = dataPortal.Create();
 
       IPropertyInfo nameProperty = (IPropertyInfo) CommandObject.NameProperty;
       IPropertyInfo numProperty = (IPropertyInfo)CommandObject.NumProperty;
@@ -100,7 +109,8 @@ namespace Csla.Test.CommandBase
     [TestMethod]
     public void CommandBase_CanReadProperties_WithObjectFactory()
     {
-      var cmd = new CommandObject();
+      IDataPortal<CommandObject> dataPortal = _testDIContext.CreateDataPortal<CommandObject>();
+      var cmd = dataPortal.Create();
 
       LoadProperty(cmd, CommandObject.NameProperty, "Rocky");
       LoadProperty(cmd, CommandObject.NumProperty, 8);
@@ -116,7 +126,8 @@ namespace Csla.Test.CommandBase
     [TestMethod]
     public void CommandBase_CanReadPropertiesUsingNonGenericPropertyInfo_WithObjectFactory()
     {
-      var cmd = new CommandObject();
+      IDataPortal<CommandObject> dataPortal = _testDIContext.CreateDataPortal<CommandObject>();
+      var cmd = dataPortal.Create();
 
       IPropertyInfo nameProperty = (IPropertyInfo)CommandObject.NameProperty;
       IPropertyInfo numProperty = (IPropertyInfo)CommandObject.NumProperty;

--- a/Source/Csla.test/CommandBase/CommandObject.cs
+++ b/Source/Csla.test/CommandBase/CommandObject.cs
@@ -19,5 +19,11 @@ namespace Csla.Test.CommandBase
       get { return ReadProperty(NumProperty); }
       private set { LoadProperty(NumProperty, value); }
     }
+
+    [RunLocal]
+    [Create]
+    private void Create()
+    { }
+
   }
 }

--- a/Source/Csla.test/DataPortal/AsynchDataPortalTest.cs
+++ b/Source/Csla.test/DataPortal/AsynchDataPortalTest.cs
@@ -282,7 +282,7 @@ namespace Csla.Test.DataPortal
     {
       IDataPortal<CommandObject> dataPortal = _testDIContext.CreateDataPortal<CommandObject>();
 
-      var command = new CommandObject();
+      var command = dataPortal.Create();
       var result = await dataPortal.ExecuteAsync(command);
       Assert.AreEqual("Executed", result.AProperty);
     }
@@ -292,8 +292,8 @@ namespace Csla.Test.DataPortal
     {
       IDataPortal<SingleCommand> dataPortal = _testDIContext.CreateDataPortal<SingleCommand>();
 
-      var result = await dataPortal.ExecuteAsync(
-        new SingleCommand { Value = 123 });
+      SingleCommand cmd = dataPortal.Create(123);
+      var result = await dataPortal.ExecuteAsync(cmd);
       Assert.IsNotNull(result);
       Assert.AreEqual(124, result.Value);
     }
@@ -308,8 +308,8 @@ namespace Csla.Test.DataPortal
 
         try
         {
-          var result = await dataPortal.ExecuteAsync(
-            new SingleCommand() { Value = 555 });
+          var cmd = dataPortal.Create(555);
+          var result = await dataPortal.ExecuteAsync(cmd);
           Assert.Fail("Expected exception not thrown");
         }
         catch (Exception ex)
@@ -345,7 +345,7 @@ namespace Csla.Test.DataPortal
       string expectedCulture = Thread.CurrentThread.CurrentCulture.Name;
       string expectedUICulture = Thread.CurrentThread.CurrentUICulture.Name;
 
-      var command = new AsyncPortalWithCulture();
+      var command = dataPortal.Create();
       var result = await dataPortal.ExecuteAsync(command);
       Assert.AreEqual(expectedCulture, result.CurrentCulture);
       Assert.AreEqual(expectedUICulture, result.CurrentUICulture);

--- a/Source/Csla.test/DataPortal/InterceptorTests.cs
+++ b/Source/Csla.test/DataPortal/InterceptorTests.cs
@@ -137,7 +137,8 @@ namespace Csla.Test.DataPortal
 
       TestResults.Reinitialise();
 
-      var obj = new InterceptorCommand();
+      var obj = dataPortal.Create();
+      TestResults.Reinitialise();
       obj = dataPortal.Execute(obj);
 
       Assert.AreEqual("Execute", TestResults.GetResult("InterceptorCommand"), "Execute should have run");
@@ -239,6 +240,11 @@ namespace Csla.Test.DataPortal
   [Serializable]
   public class InterceptorCommand : CommandBase<InterceptorCommand>
   {
+    [RunLocal]
+    [Create]
+    private void Create()
+    { }
+
     [Execute]
 	protected void DataPortal_Execute()
     {

--- a/Source/Csla.test/Fakes/Server/DataPortal/AsyncPortalWithCulture.cs
+++ b/Source/Csla.test/Fakes/Server/DataPortal/AsyncPortalWithCulture.cs
@@ -48,6 +48,11 @@ namespace Csla.Testing.Business.DataPortal
 
     public AsyncPortalWithCulture() { }
 
+    [RunLocal]
+    [Create]
+    private void Create()
+    { }
+
     [Execute]
 	protected void DataPortal_Execute()
     {    

--- a/Source/Csla.test/Fakes/Server/DataPortal/SetAppSettingValueCmd.cs
+++ b/Source/Csla.test/Fakes/Server/DataPortal/SetAppSettingValueCmd.cs
@@ -43,8 +43,13 @@ namespace  Csla.Testing.Business.DataPortal
 
     protected SetAppSettingValueCmd() { }
 
+    [RunLocal]
+    [Create]
+    private void Create()
+    { }
+
     [Execute]
-		protected void DataPortal_Execute()
+	protected void DataPortal_Execute()
     {
       //As the value of the _authorizer is loaded from App.Config we consider it as variable that is
       //set once per AppDomain - it had initial value of null and once it is set to a certain type its

--- a/Source/Csla.test/Fakes/Server/DataPortal/Single.cs
+++ b/Source/Csla.test/Fakes/Server/DataPortal/Single.cs
@@ -216,6 +216,18 @@ namespace Csla.Test.DataPortalTest
       set { LoadProperty(ValueProperty, value); }
     }
 
+    [RunLocal]
+    [Create]
+    private void Create()
+    { }
+
+    [RunLocal]
+    [Create]
+    private void Create(int value)
+    {
+      Value = value;
+    }
+
     [Execute]
 	protected void DataPortal_Execute()
     {

--- a/Source/Csla.test/PropertyGetSet/PropertyGetSetTests.cs
+++ b/Source/Csla.test/PropertyGetSet/PropertyGetSetTests.cs
@@ -98,11 +98,13 @@ namespace Csla.Test.PropertyGetSet
       root.LoadInternalAndPrivate("Test");
       Assert.AreEqual("Test", root.M08);
 
-      var cmd = new Command();
+      IDataPortal<Command> commandDataPortal = _testDIContext.CreateDataPortal<Command>();
+      var cmd = commandDataPortal.Create();
       cmd.Load("abc");
       Assert.AreEqual("abc", cmd.Name);
 
-      var ro = new ReadOnly();
+      IDataPortal<ReadOnly> roDataPortal = _testDIContext.CreateDataPortal<ReadOnly>();
+      var ro = roDataPortal.Fetch();
       ro.Load("abc");
       Assert.AreEqual("abc", ro.Name);
     }
@@ -853,6 +855,12 @@ namespace Csla.Test.PropertyGetSet
     {
       LoadProperty((Csla.Core.IPropertyInfo)NameProperty, name);
     }
+
+    [RunLocal]
+    [Create]
+    private void Create()
+    { }
+
   }
 
   [Serializable]
@@ -882,5 +890,9 @@ namespace Csla.Test.PropertyGetSet
       LoadProperty((Csla.Core.IPropertyInfo)_originalNameProperty, name);
       LoadProperty((Csla.Core.IPropertyInfo)_originalNamePrivateProperty, name);
     }
+
+    [Fetch]
+    private void Fetch()
+    { }
   }
 }

--- a/Source/Csla.test/Serialization/SerializationTests.cs
+++ b/Source/Csla.test/Serialization/SerializationTests.cs
@@ -120,9 +120,11 @@ namespace Csla.Test.Serialization
     [TestMethod()]
     public void Clone()
     {
+      IDataPortal<SerializationRoot> dataPortal = _testDIContext.CreateDataPortal<SerializationRoot>();
+
       TestResults.Reinitialise();
       UnitTestContext context = GetContext();
-      SerializationRoot root = new SerializationRoot();
+      SerializationRoot root = dataPortal.Create();
 
       root = (SerializationRoot)root.Clone();
 
@@ -558,9 +560,10 @@ namespace Csla.Test.Serialization
     [TestMethod]
     public void SerializeCommand()
     {
+      IDataPortal<TestCommand> dataPortal = _testDIContext.CreateDataPortal<TestCommand>();
       ApplicationContext applicationContext = _testDIContext.CreateTestApplicationContext();
 
-      var cmd = new TestCommand();
+      var cmd = dataPortal.Create();
       cmd.Name = "test data";
 
       // TODO: Not sure how to replicate the object cloner in Csla 6
@@ -594,7 +597,7 @@ namespace Csla.Test.Serialization
       //);
       IDataPortal<TestCommand> dataPortal = customDIContext.CreateDataPortal<TestCommand>();
 
-      var cmd = new TestCommand();
+      var cmd = dataPortal.Create();
       cmd.Name = "test data";
 
       var result = dataPortal.Execute(cmd);
@@ -646,6 +649,11 @@ namespace Csla.Test.Serialization
       get { return ReadProperty(NameProperty); }
       set { LoadProperty(NameProperty, value); }
     }
+
+    [RunLocal]
+    [Create]
+    private void Create()
+    { }
 
     [Execute]
     protected void DataPortal_Execute()


### PR DESCRIPTION
#2859 - Change to tests involving command objects - command objects must now be created via the data portal.
