### PR TITLE
Added UpdateChildrenAsync and UpdateAllChildrenAsync to FieldDataManager

### DIFF
--- a/Source/Csla.test/FieldManager/Async/Child.cs
+++ b/Source/Csla.test/FieldManager/Async/Child.cs
@@ -1,0 +1,87 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Child.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>no summary</summary>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+
+namespace Csla.Test.FieldManager.Async
+{
+  [Serializable]
+  public class Child : BusinessBase<Child>
+  {
+    public static async Task<Child> NewChildAsync(IChildDataPortal<Child> childDataPortal)
+    {
+      return await childDataPortal.CreateChildAsync();
+    }
+
+    public static async Task<Child> GetChildAsync(IChildDataPortal<Child> childDataPortal)
+    {
+      return await childDataPortal.FetchChildAsync();
+    }
+
+    public Child()
+    {
+      MarkAsChild();
+    }
+
+    private static PropertyInfo<string> DataProperty = RegisterProperty<string>(typeof(Child), new PropertyInfo<string>("Data"));
+    public string Data
+    {
+      get { return GetProperty<string>(DataProperty); }
+      set { SetProperty<string>(DataProperty, value); }
+    }
+
+    private static PropertyInfo<string> RootDataProperty = RegisterProperty<string>(typeof(Child), new PropertyInfo<string>("RootData", string.Empty));
+    public string RootData
+    {
+      get { return GetProperty<string>(RootDataProperty); }
+      set { SetProperty<string>(RootDataProperty, value); }
+    }
+
+    private static PropertyInfo<string> StatusProperty = RegisterProperty<string>(c => c.Status);
+    public string Status
+    {
+      get { return GetProperty(StatusProperty); }
+    }
+
+    [CreateChild]
+    private async Task CreateAsync()
+    {
+      await Task.Delay(5);
+      LoadProperty(StatusProperty, "Created");
+    }
+
+    [FetchChild]
+    private async Task FetchAsync()
+    {
+      await Task.Delay(5);
+      LoadProperty(StatusProperty, "Fetched");
+    }
+
+    [InsertChild]
+    private async Task InsertAsync()
+    {
+      await Task.Delay(5);
+      LoadProperty(StatusProperty, "Inserted");
+    }
+
+    [UpdateChild]
+    private async Task UpdateAsync()
+    {
+      await Task.Delay(5);
+      LoadProperty(StatusProperty, "Updated");
+    }
+
+    [DeleteSelfChild]
+    private async Task DeleteSelfAsync()
+    {
+      await Task.Delay(5);
+      LoadProperty(StatusProperty, "Deleted");
+    }
+  }
+}

--- a/Source/Csla.test/FieldManager/Async/ChildList.cs
+++ b/Source/Csla.test/FieldManager/Async/ChildList.cs
@@ -1,0 +1,51 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ChildList.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>no summary</summary>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+
+namespace Csla.Test.FieldManager.Async
+{
+  [Serializable]
+  public class ChildList : BusinessListBase<ChildList, Child>
+  {
+    public static async Task<ChildList> GetListAsync(IChildDataPortal<ChildList> childDataPortal)
+    {
+      return await childDataPortal.FetchChildAsync();
+    }
+
+    public ChildList()
+    {
+    }
+
+    public object MyParent
+    {
+      get { return this.Parent; }
+    }
+
+    private string _status;
+    public string Status
+    {
+      get { return _status; }
+    }
+
+    [FetchChild]
+    private async Task Child_FetchAsync()
+    {
+      await Task.Delay(5);
+      _status = "Fetched";
+    }
+
+    [UpdateChild]
+    protected override async Task Child_UpdateAsync(params object[] p)
+    {
+      await base.Child_UpdateAsync(p);
+      _status = "Updated";
+    }
+  }
+}

--- a/Source/Csla.test/FieldManager/Async/ChildUpdateTests.cs
+++ b/Source/Csla.test/FieldManager/Async/ChildUpdateTests.cs
@@ -1,0 +1,70 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="DataPortalChildTests.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>no summary</summary>
+//-----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Csla.TestHelpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+#if !NUNIT
+
+#else
+using NUnit.Framework;
+using TestClass = NUnit.Framework.TestFixtureAttribute;
+using TestInitialize = NUnit.Framework.SetUpAttribute;
+using TestCleanup = NUnit.Framework.TearDownAttribute;
+using TestMethod = NUnit.Framework.TestAttribute;
+#endif
+
+namespace Csla.Test.FieldManager.Async
+{
+  [TestClass()]
+  public class ChildUpdateTests
+  {
+    private static TestDIContext _testDIContext;
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext context)
+    {
+      _testDIContext = TestDIContextFactory.CreateDefaultContext();
+    }
+
+    [TestMethod]
+    public async Task CreateAndSaveChildAsync()
+    {
+      IChildDataPortal<Child> childDataPortal = _testDIContext.CreateChildDataPortal<Child>();
+      IDataPortal<Root> dataPortal = _testDIContext.CreateDataPortal<Root>();
+
+      Root root = await dataPortal.CreateAsync();
+      await root.FetchChildAsync(childDataPortal);
+
+      Assert.IsFalse(root.Child.IsDirty, "Child should not be dirty");
+      Assert.AreEqual("Fetched", root.Child.Status, "Child status incorrect after fetch");
+
+      root = await root.SaveAsync();
+
+      Assert.AreEqual("Fetched", root.Child.Status, "Child status incorrect after Save");
+    }
+
+    [TestMethod]
+    public async Task CreateAndSaveAnyChildAsync()
+    {
+      IChildDataPortal<Child> childDataPortal = _testDIContext.CreateChildDataPortal<Child>();
+      IDataPortal<RootUpdateAllChildren> dataPortal = _testDIContext.CreateDataPortal<RootUpdateAllChildren>();
+
+      var root = await dataPortal.CreateAsync();
+      await root.FetchChildAsync(childDataPortal);
+
+      Assert.IsFalse(root.Child.IsDirty, "Child should not be dirty");
+      Assert.AreEqual("Fetched", root.Child.Status, "Child status incorrect after fetch");
+
+      root = await root.SaveAsync();
+
+      Assert.AreEqual("Updated", root.Child.Status, "Child status incorrect after Save");
+    }
+
+  }
+}

--- a/Source/Csla.test/FieldManager/Async/Root.cs
+++ b/Source/Csla.test/FieldManager/Async/Root.cs
@@ -1,0 +1,66 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Root.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>no summary</summary>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+
+namespace Csla.Test.FieldManager.Async
+{
+  [Serializable]
+  public class Root : BusinessBase<Root>
+  {
+    private static PropertyInfo<string> DataProperty = RegisterProperty<string>(typeof(Root), new PropertyInfo<string>("Data"));
+    public string Data
+    {
+      get { return GetProperty<string>(DataProperty); }
+      set { SetProperty<string>(DataProperty, value); }
+    }
+
+    private static PropertyInfo<Child> ChildProperty = RegisterProperty<Child>(typeof(Root), new PropertyInfo<Child>("Child"));
+    public Child Child
+    {
+      get 
+      {
+        return GetProperty<Child>(ChildProperty); 
+      }
+    }
+
+    private static PropertyInfo<ChildList> ChildListProperty = RegisterProperty<ChildList>(typeof(Root), new PropertyInfo<ChildList>("ChildList"));
+    public ChildList ChildList
+    {
+      get
+      {
+        return GetProperty<ChildList>(ChildListProperty);
+      }
+    }
+
+    public async Task FetchChildAsync(IChildDataPortal<Child> childDataPortal)
+    {
+      SetProperty(ChildProperty, await Child.GetChildAsync(childDataPortal));
+    }
+
+    [Create]
+    protected async Task CreateAsync([Inject] IChildDataPortal<Child> childDataPortal, [Inject]IChildDataPortal<ChildList> childListDataPortal)
+    {
+      LoadProperty(ChildProperty, await Child.NewChildAsync(childDataPortal));
+      LoadProperty(ChildListProperty, await ChildList.GetListAsync(childListDataPortal));
+    }
+
+    [Insert]
+    private async Task InsertAsync()
+    {
+      await FieldManager.UpdateChildrenAsync();
+    }
+
+    [Update]
+	private async Task UpdateAsync()
+    {
+      await FieldManager.UpdateChildrenAsync();
+    }
+  }
+}

--- a/Source/Csla.test/FieldManager/Async/RootUpdateAllChildren.cs
+++ b/Source/Csla.test/FieldManager/Async/RootUpdateAllChildren.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Csla.Test.FieldManager.Async
+{
+  [Serializable]
+  public class RootUpdateAllChildren : BusinessBase<RootUpdateAllChildren>
+  {
+    private static PropertyInfo<string> DataProperty = RegisterProperty<string>(typeof(RootUpdateAllChildren), new PropertyInfo<string>("Data"));
+    public string Data
+    {
+      get { return GetProperty<string>(DataProperty); }
+      set { SetProperty<string>(DataProperty, value); }
+    }
+
+    private static PropertyInfo<Child> ChildProperty = RegisterProperty<Child>(typeof(RootUpdateAllChildren), new PropertyInfo<Child>("Child"));
+    public Child Child
+    {
+      get 
+      {
+        return GetProperty<Child>(ChildProperty); 
+      }
+    }
+
+    private static PropertyInfo<ChildList> ChildListProperty = RegisterProperty<ChildList>(typeof(RootUpdateAllChildren), new PropertyInfo<ChildList>("ChildList"));
+    public ChildList ChildList
+    {
+      get
+      {
+        return GetProperty<ChildList>(ChildListProperty);
+      }
+    }
+
+    public async Task FetchChildAsync(IChildDataPortal<Child> childDataPortal)
+    {
+      SetProperty<Child>(ChildProperty, await Child.GetChildAsync(childDataPortal));
+    }
+
+    [Create]
+    private async Task CreateAsync([Inject]IChildDataPortal<Child> childDataPortal, [Inject]IChildDataPortal<ChildList> childListDataPortal)
+    {
+      LoadProperty(ChildProperty, await Child.NewChildAsync(childDataPortal));
+      LoadProperty(ChildListProperty, await ChildList.GetListAsync(childListDataPortal));
+    }
+
+    [Insert]
+    protected async Task InsertAsync()
+    {
+      await FieldManager.UpdateAllChildrenAsync();
+    }
+
+    [Update]
+	protected async Task UpdateAsync()
+    {
+      await FieldManager.UpdateAllChildrenAsync();
+    }
+  }
+}

--- a/Source/Csla/BusinessListBase.cs
+++ b/Source/Csla/BusinessListBase.cs
@@ -899,6 +899,30 @@ namespace Csla
       }
     }
 
+    /// <summary>
+    /// Asynchronously saves all items in the list, automatically
+    /// performing insert, update or delete operations as necessary.
+    /// </summary>
+    /// <param name="parameters">
+    /// Optional parameters passed to child update
+    /// methods.
+    /// </param>
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    [UpdateChild]
+    protected virtual async Task Child_UpdateAsync(params object[] parameters)
+    {
+      using (LoadListMode)
+      {
+        var dp = ApplicationContext.CreateInstanceDI<DataPortal<C>>();
+        foreach (var child in DeletedList)
+          await dp.UpdateChildAsync(child, parameters).ConfigureAwait(false);
+        DeletedList.Clear();
+
+        foreach (var child in this)
+          if (child.IsDirty) await dp.UpdateChildAsync(child, parameters).ConfigureAwait(false);
+      }
+    }
+
     #endregion
 
     #region Data Access

--- a/Source/Csla/Core/FieldManager/FieldDataManager.cs
+++ b/Source/Csla/Core/FieldManager/FieldDataManager.cs
@@ -18,7 +18,7 @@ using Csla.Runtime;
 using Csla.Properties;
 using Csla.Serialization;
 using Csla.Serialization.Mobile;
-
+using System.Threading.Tasks;
 
 namespace Csla.Core.FieldManager
 {
@@ -664,9 +664,48 @@ namespace Csla.Core.FieldManager
       }
     }
 
-#endregion
+    /// <summary>
+    /// Asynchronously invokes the data portal to update
+    /// all child objects contained in the list of fields.
+    /// </summary>
+    /// <param name="parameters">Parameters for method</param>
+    public async Task UpdateChildrenAsync(params object[] parameters)
+    {
+      Server.ChildDataPortal portal = new Server.ChildDataPortal(ApplicationContext);
+      foreach (var item in _fieldData)
+      {
+        if (item != null)
+        {
+          object obj = item.Value;
+          if (obj is IEditableBusinessObject || obj is IEditableCollection)
+            await portal.UpdateAsync(obj, parameters).ConfigureAwait(false);
+        }
+      }
+    }
 
-#region IMobileObject Members
+    /// <summary>
+    /// Asynchronously invokes the data portal to update
+    /// all child objects, including those which are not dirty,
+    /// contained in the list of fields.
+    /// </summary>
+    /// <param name="parameters">Parameters for method</param>
+    public async Task UpdateAllChildrenAsync(params object[] parameters)
+    {
+      Server.ChildDataPortal portal = new Server.ChildDataPortal(ApplicationContext);
+      foreach (var item in _fieldData)
+      {
+        if (item != null)
+        {
+          object obj = item.Value;
+          if (obj is IEditableBusinessObject || obj is IEditableCollection)
+            await portal.UpdateAllAsync(obj, parameters).ConfigureAwait(false);
+        }
+      }
+    }
+
+    #endregion
+
+    #region IMobileObject Members
 
     /// <summary>
     /// Override this method to insert your field values


### PR DESCRIPTION
Added UpdateChildrenAsync to support the use of async code in the data access methods of child objects without sync over async en route. Resolves outstanding issue #2393 

I gave careful thought to whether the underlying dictionary needs to be replaced with a thread-safe version to support this change, and have decided that it doesn't. The child object updates won't be running in parallel, so there is no more risk of threading issues for the Insert, Update and Delete methods as there already would be for Create and Fetch, both of which have been shown to work just fine with async implementations.

Unit tests created to exercise the code, and they pass (even though they are in a test project that is currently not part of the CI tests, as there are still failing tests within the full test suite because of other issues.)