### PR TITLE
Fixes to more base tests in line with CSLA 6

### DIFF
--- a/Source/Csla.Analyzers/Csla.Analyzers.Tests/Csla.Analyzers.Tests.csproj
+++ b/Source/Csla.Analyzers/Csla.Analyzers.Tests/Csla.Analyzers.Tests.csproj
@@ -20,9 +20,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.9" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.9" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.9" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Csla.Blazor.Test/Csla.Blazor.Test.csproj
+++ b/Source/Csla.Blazor.Test/Csla.Blazor.Test.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.9" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.9" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/Csla.Generators/cs/Csla.Generators.CSharp.Tests/Csla.Generators.CSharp.Tests.csproj
+++ b/Source/Csla.Generators/cs/Csla.Generators.CSharp.Tests/Csla.Generators.CSharp.Tests.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.9" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.9" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/Csla.TestHelpers/ApplicationContextManagerUnitTests.cs
+++ b/Source/Csla.TestHelpers/ApplicationContextManagerUnitTests.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Csla.TestHelpers
+{
+  public class ApplicationContextManagerUnitTests : Csla.Core.ApplicationContextManagerAsyncLocal
+  {
+    public Guid InstanceId { get; private set; } = Guid.NewGuid();
+
+    public DateTime CreatedAt { get; private set; } = DateTime.Now;
+  }
+}

--- a/Source/Csla.TestHelpers/TestDIContextFactory.cs
+++ b/Source/Csla.TestHelpers/TestDIContextFactory.cs
@@ -70,14 +70,14 @@ namespace Csla.TestHelpers
     /// <returns>A TestDIContext that can be used to perform testing dependent upon DI</returns>
     public static TestDIContext CreateContext(Action<CslaOptions> customCslaOptions, ClaimsPrincipal principal)
     {
-      ServiceProvider serviceProvider;
+      IServiceProvider serviceProvider;
       ApplicationContext context;
 
       // Initialise DI
       var services = new ServiceCollection();
 
       // Add Csla
-      services.TryAddScoped<Core.IContextManager, Core.ApplicationContextManager>();
+      services.TryAddSingleton<Core.IContextManager, ApplicationContextManagerUnitTests>();
       services.TryAddSingleton<Server.Dashboard.IDashboard, Server.Dashboard.Dashboard>();
       services.AddCsla(customCslaOptions);
 

--- a/Source/Csla.test/AppContext/TestContextManager.cs
+++ b/Source/Csla.test/AppContext/TestContextManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
+using System.Security.Claims;
 using System.Security.Principal;
 using System.Text;
 using System.Threading;
@@ -14,6 +15,7 @@ namespace Csla.Test.AppContext
   {
     [ThreadStatic]
     private static HybridDictionary _myContext = new HybridDictionary();
+    private readonly AsyncLocal<IPrincipal> _principal = new();
 
     private const string _localContextName = "Csla.ClientContext";
     private const string _clientContextName = "Csla.ClientContext";
@@ -30,7 +32,7 @@ namespace Csla.Test.AppContext
 
     public IPrincipal GetUser()
     {
-      IPrincipal result = Thread.CurrentPrincipal;
+      IPrincipal result = _principal.Value;
       if (result == null)
       {
         result = new System.Security.Claims.ClaimsPrincipal();
@@ -41,7 +43,7 @@ namespace Csla.Test.AppContext
 
     public void SetUser(IPrincipal principal)
     {
-      Thread.CurrentPrincipal = principal;
+      _principal.Value = principal;
     }
 
     public ContextDictionary GetLocalContext()

--- a/Source/Csla.test/Authorization/PermissionsRoot2.cs
+++ b/Source/Csla.test/Authorization/PermissionsRoot2.cs
@@ -68,6 +68,10 @@ namespace Csla.Test.Security
 
     public static void AddObjectAuthorizationRules()
     {
+      // add rules for multiple rulesets
+      BusinessRules.AddRule(typeof(PermissionsRoot2), new IsInRole(AuthorizationActions.DeleteObject, "User"));
+      BusinessRules.AddRule(typeof(PermissionsRoot2), new IsInRole(AuthorizationActions.DeleteObject, "Admin"), "custom1");
+      BusinessRules.AddRule(typeof(PermissionsRoot2), new IsInRole(AuthorizationActions.DeleteObject, "User", "Admin"), "custom2");
     }
 
     protected override void AddBusinessRules()
@@ -75,24 +79,7 @@ namespace Csla.Test.Security
       BusinessRules.AddRule(new Csla.Rules.CommonRules.IsInRole(Rules.AuthorizationActions.ReadProperty, FirstNameProperty, new List<string> { "Admin" }));
       BusinessRules.AddRule(new Csla.Rules.CommonRules.IsInRole(Rules.AuthorizationActions.WriteProperty, FirstNameProperty, new List<string> { "Admin" }));
       BusinessRules.AddRule(new Csla.Rules.CommonRules.IsInRole(Rules.AuthorizationActions.ExecuteMethod, DoWorkMethod, new List<string> { "Admin" }));
-
-      // TODO: I moved this from AddObjectAuthorizationRules; is that right?
-      //// add rules for default ruleset
-      var orgRuleSet = BusinessRules.RuleSet;
-      try
-      {
-        BusinessRules.RuleSet = ApplicationContext.DefaultRuleSet;
-        BusinessRules.AddRule(typeof(PermissionsRoot2), new IsInRole(AuthorizationActions.DeleteObject, "User"));
-        BusinessRules.RuleSet = "custom1";
-        BusinessRules.AddRule(typeof(PermissionsRoot2), new IsInRole(AuthorizationActions.DeleteObject, "Admin"));
-        BusinessRules.RuleSet = "custom2";
-        BusinessRules.AddRule(typeof(PermissionsRoot2), new IsInRole(AuthorizationActions.DeleteObject, "User", "Admin"));
-      }
-      finally
-      {
-        BusinessRules.RuleSet = orgRuleSet;
-      }
-}
+    }
 
     #endregion
 

--- a/Source/Csla.test/Basic/Child.cs
+++ b/Source/Csla.test/Basic/Child.cs
@@ -15,27 +15,19 @@ namespace Csla.Test.Basic
   [Serializable()]
   public class Child : BusinessBase<Child>
   {
-    private string _data = "";
-    private Guid _guid = System.Guid.NewGuid();
-
+    public static PropertyInfo<string> DataProperty = RegisterProperty<string>(nameof(Data));
+    public static PropertyInfo<Guid> GuidProperty = RegisterProperty<Guid>(nameof(Guid));
     public static PropertyInfo<GrandChildren> GrandChildrenProperty = RegisterProperty<GrandChildren>(c => c.GrandChildren);
 
     protected override object GetIdValue()
     {
-      return _data;
+      return ReadProperty(DataProperty);
     }
 
     public string Data
     {
-      get { return _data; }
-      set
-      {
-        if (_data != value)
-        {
-          _data = value;
-          MarkDirty();
-        }
-      }
+      get { return GetProperty(DataProperty); }
+      set { SetProperty(DataProperty, value); }
     }
 
     public override bool Equals(object obj)
@@ -45,7 +37,7 @@ namespace Csla.Test.Basic
         return false;
       }
 
-      return _data == ((Child)(obj))._data;
+      return ReadProperty(DataProperty) == ((Child)(obj)).ReadProperty(DataProperty);
     }
 
     public override int GetHashCode()
@@ -55,7 +47,7 @@ namespace Csla.Test.Basic
 
     public Guid Guid
     {
-      get { return _guid; }
+      get { return ReadProperty(GuidProperty); }
     }
 
     public GrandChildren GrandChildren
@@ -84,7 +76,8 @@ namespace Csla.Test.Basic
     [CreateChild]
     private void Create(string data, [Inject] IChildDataPortal<GrandChildren> childDataPortal)
     {
-      _data = data;
+      LoadProperty(GuidProperty, Guid.NewGuid());
+      LoadProperty(DataProperty, data);
       LoadProperty(GrandChildrenProperty, childDataPortal.CreateChild());
     }
 

--- a/Source/Csla.test/BusyStatus/BusyStatusTests.cs
+++ b/Source/Csla.test/BusyStatus/BusyStatusTests.cs
@@ -13,6 +13,7 @@ using UnitDriven;
 using Csla.Testing.Business.BusyStatus;
 using System.Threading.Tasks;
 using Csla.TestHelpers;
+using Csla.Test;
 
 #if NUNIT
 using NUnit.Framework;
@@ -46,6 +47,8 @@ namespace cslalighttest.BusyStatus
     {
       IDataPortal<ItemWithAsynchRule> dataPortal = _noCloneOnUpdateDIContext.CreateDataPortal<ItemWithAsynchRule>();
 
+      TestResults.Reinitialise();
+      
       UnitTestContext context = GetContext();
       var item = await dataPortal.FetchAsync("an id");
       item.RuleField = "some value";
@@ -60,6 +63,8 @@ namespace cslalighttest.BusyStatus
     {
       IDataPortal<ItemWithAsynchRuleList> dataPortal = _noCloneOnUpdateDIContext.CreateDataPortal<ItemWithAsynchRuleList>();
 
+      TestResults.Reinitialise();
+      
       UnitTestContext context = GetContext();
       ItemWithAsynchRuleList items = ItemWithAsynchRuleList.GetListWithItems(dataPortal);
       items[0].RuleField = "some value";
@@ -73,6 +78,8 @@ namespace cslalighttest.BusyStatus
     public async Task TestSaveWhileBusy()
     {
       IDataPortal<ItemWithAsynchRule> dataPortal = _testDIContext.CreateDataPortal<ItemWithAsynchRule>();
+
+      TestResults.Reinitialise();
       
       UnitTestContext context = GetContext();
       var item = await dataPortal.FetchAsync("an id");
@@ -100,6 +107,8 @@ namespace cslalighttest.BusyStatus
     {
       IDataPortal<ItemWithAsynchRuleList> dataPortal = _noCloneOnUpdateDIContext.CreateDataPortal<ItemWithAsynchRuleList>();
 
+      TestResults.Reinitialise();
+      
       UnitTestContext context = GetContext();
       ItemWithAsynchRuleList items = ItemWithAsynchRuleList.GetListWithItems(dataPortal);
       items[0].RuleField = "some value";
@@ -126,6 +135,8 @@ namespace cslalighttest.BusyStatus
     {
       IDataPortal<ItemWithAsynchRule> dataPortal = _testDIContext.CreateDataPortal<ItemWithAsynchRule>();
 
+      TestResults.Reinitialise();
+      
       UnitTestContext context = GetContext();
       var item = await dataPortal.FetchAsync("an id");
       item.ValidationComplete += (o2, e2) =>
@@ -145,6 +156,8 @@ namespace cslalighttest.BusyStatus
     {
       IDataPortal<ItemWithAsynchRuleList> dataPortal = _noCloneOnUpdateDIContext.CreateDataPortal<ItemWithAsynchRuleList>();
 
+      TestResults.Reinitialise();
+      
       UnitTestContext context = GetContext();
       ItemWithAsynchRuleList items = ItemWithAsynchRuleList.GetListWithItems(dataPortal);
       items[0].ValidationComplete += (o2, e2) =>
@@ -163,6 +176,8 @@ namespace cslalighttest.BusyStatus
     public void ListTestSaveWhileNotBusy()
     {
       IDataPortal<ItemWithAsynchRuleList> dataPortal = _noCloneOnUpdateDIContext.CreateDataPortal<ItemWithAsynchRuleList>();
+
+      TestResults.Reinitialise();
 
       UnitTestContext context = GetContext();
       ItemWithAsynchRuleList items = ItemWithAsynchRuleList.GetListWithItems(dataPortal);
@@ -187,6 +202,8 @@ namespace cslalighttest.BusyStatus
     {
       IDataPortal<ItemWithAsynchRule> dataPortal = _testDIContext.CreateDataPortal<ItemWithAsynchRule>();
 
+      TestResults.Reinitialise();
+      
       UnitTestContext context = GetContext();
       var item = await dataPortal.FetchAsync("an id");
       item.RuleField = "some value";
@@ -202,6 +219,8 @@ namespace cslalighttest.BusyStatus
     {
       IDataPortal<ItemWithAsynchRuleList> dataPortal = _noCloneOnUpdateDIContext.CreateDataPortal<ItemWithAsynchRuleList>();
 
+      TestResults.Reinitialise();
+      
       UnitTestContext context = GetContext();
       ItemWithAsynchRuleList items = ItemWithAsynchRuleList.GetListWithItems(dataPortal);
 
@@ -230,6 +249,8 @@ namespace cslalighttest.BusyStatus
     {
       IDataPortal<ItemWithAsynchRule> dataPortal = _noCloneOnUpdateDIContext.CreateDataPortal<ItemWithAsynchRule>();
 
+      TestResults.Reinitialise();
+      
       UnitTestContext context = GetContext();
       var item = await dataPortal.FetchAsync("an id");
       item.ValidationComplete += (o2, e2) =>
@@ -251,6 +272,8 @@ namespace cslalighttest.BusyStatus
     {
       IDataPortal<ItemWithAsynchRuleList> dataPortal = _noCloneOnUpdateDIContext.CreateDataPortal<ItemWithAsynchRuleList>();
 
+      TestResults.Reinitialise();
+      
       UnitTestContext context = GetContext();
       ItemWithAsynchRuleList items = ItemWithAsynchRuleList.GetListWithItems(dataPortal);
 
@@ -278,6 +301,8 @@ namespace cslalighttest.BusyStatus
     {
       IDataPortal<ItemWithAsynchRule> dataPortal = _noCloneOnUpdateDIContext.CreateDataPortal<ItemWithAsynchRule>();
 
+      TestResults.Reinitialise();
+      
       UnitTestContext context = GetContext();
       var item = await dataPortal.FetchAsync("an id");
       item.OperationResult = "something";
@@ -295,6 +320,8 @@ namespace cslalighttest.BusyStatus
     {
       IDataPortal<ItemWithAsynchRuleList> dataPortal = _noCloneOnUpdateDIContext.CreateDataPortal<ItemWithAsynchRuleList>();
 
+      TestResults.Reinitialise();
+      
       UnitTestContext context = GetContext();
       ItemWithAsynchRuleList items = ItemWithAsynchRuleList.GetListWithItems(dataPortal);
 

--- a/Source/Csla.test/BypassPropertyChecks/BypassPropertyChecksTests.cs
+++ b/Source/Csla.test/BypassPropertyChecks/BypassPropertyChecksTests.cs
@@ -129,8 +129,8 @@ namespace Csla.Test.BypassPropertyChecks
     [TestMethod]
     public void TestBypassReadWriteWithRights()
     {
-      TestDIContext testDIContext = TestDIContextFactory.CreateContext(GetPrincipal("Admin"));
-      IDataPortal<BypassBusinessBase> dataPortal = testDIContext.CreateDataPortal<BypassBusinessBase>();
+      TestDIContext customDIContext = TestDIContextFactory.CreateContext(GetPrincipal("Admin"));
+      IDataPortal<BypassBusinessBase> dataPortal = customDIContext.CreateDataPortal<BypassBusinessBase>();
 
       UnitTestContext context = GetContext();
       bool propertyChangedFired = false;

--- a/Source/Csla.test/Csla.Tests.csproj
+++ b/Source/Csla.test/Csla.Tests.csproj
@@ -63,8 +63,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.9" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.9" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
     <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
@@ -103,6 +103,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="DataPortalTestDatabase.mdf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="DataPortalTestDatabase_log.ldf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/Source/Csla.test/DPException/DataPortalExceptionTests.cs
+++ b/Source/Csla.test/DPException/DataPortalExceptionTests.cs
@@ -27,130 +27,134 @@ using TestMethod = NUnit.Framework.TestAttribute;
 
 namespace Csla.Test.DPException
 {
-    [TestClass()]
-    public class DataPortalExceptionTests
-    {
-        private static TestDIContext _testDIContext;
+  [TestClass()]
+  public class DataPortalExceptionTests
+  {
+    private static TestDIContext _testDIContext;
 
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
-        {
-          _testDIContext = TestDIContextFactory.CreateDefaultContext();
-        }
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext context)
+    {
+      _testDIContext = TestDIContextFactory.CreateDefaultContext();
+    }
 
 #if DEBUG
-        [TestMethod()]
-        
-        public void CheckInnerExceptionsOnSave()
-        {
-            IDataPortal<DataPortal.TransactionalRoot> dataPortal = _testDIContext.CreateDataPortal<DataPortal.TransactionalRoot>();
-            TestResults.Reinitialise();
+    [TestMethod()]
 
-            DataPortal.TransactionalRoot root = DataPortal.TransactionalRoot.NewTransactionalRoot(dataPortal);
-            root.FirstName = "Billy";
-            root.LastName = "lastname";
-            root.SmallColumn = "too long for the database"; //normally would be prevented through validation
-            
-            string baseException = string.Empty;
-            string baseInnerException = string.Empty;
-            string baseInnerInnerException = string.Empty;
-            string exceptionSource = string.Empty;
+    public void CheckInnerExceptionsOnSave()
+    {
+      IDataPortal<DataPortal.TransactionalRoot> dataPortal = _testDIContext.CreateDataPortal<DataPortal.TransactionalRoot>();
+      TestResults.Reinitialise();
 
-            try
-            {
-                root = root.Save();
-            }
-            catch (Csla.DataPortalException ex)
-            {
-                baseException = ex.Message;
-                baseInnerException = ex.InnerException.Message;
-                baseInnerInnerException = ex.InnerException.InnerException?.Message;
-                exceptionSource = ex.InnerException.InnerException?.Source;
-                Assert.IsNull(ex.BusinessObject, "Business object shouldn't be returned");
-            }
+      DataPortal.TransactionalRoot root = DataPortal.TransactionalRoot.NewTransactionalRoot(dataPortal);
+      root.FirstName = "Billy";
+      root.LastName = "lastname";
+      root.SmallColumn = "too long for the database"; //normally would be prevented through validation
 
-            //check base exception
-            Assert.IsTrue(baseException.StartsWith("DataPortal.Update failed"), "Exception should start with 'DataPortal.Update failed'");
-            Assert.IsTrue(baseException.Contains("String or binary data would be truncated."), 
-              "Exception should contain 'String or binary data would be truncated.'");
-            //check inner exception
-            Assert.AreEqual("TransactionalRoot.DataPortal_Insert method call failed", baseInnerException);
-            //check inner exception of inner exception
-            Assert.AreEqual("String or binary data would be truncated.\r\nThe statement has been terminated.", baseInnerInnerException);
+      string baseException = string.Empty;
+      string baseInnerException = string.Empty;
+      string baseInnerInnerException = string.Empty;
+      string exceptionSource = string.Empty;
 
-            //check what caused inner exception's inner exception (i.e. the root exception)
-            Assert.AreEqual(".Net SqlClient Data Provider", exceptionSource);
+      try
+      {
+        root = root.Save();
+      }
+      catch (Csla.DataPortalException ex)
+      {
+        baseException = ex.Message;
+        baseInnerException = ex.InnerException.Message;
+        baseInnerInnerException = ex.InnerException.InnerException?.Message;
+        exceptionSource = ex.InnerException.InnerException?.Source;
+        Assert.IsNull(ex.BusinessObject, "Business object shouldn't be returned");
+      }
 
-            //verify that the implemented method, DataPortal_OnDataPortal 
-            //was called for the business object that threw the exception
-            Assert.AreEqual("Called", TestResults.GetResult("OnDataPortalException"));
-        }
+      //check base exception
+      Assert.IsTrue(baseException.StartsWith("DataPortal.Update failed"), "Exception should start with 'DataPortal.Update failed'");
+      Assert.IsTrue(baseException.Contains("String or binary data would be truncated."),
+        "Exception should contain 'String or binary data would be truncated.'");
+      //check inner exception
+      Assert.AreEqual("TransactionalRoot.DataPortal_Insert method call failed", baseInnerException);
+      //check inner exception of inner exception
+      Assert.AreEqual("String or binary data would be truncated.\r\nThe statement has been terminated.", baseInnerInnerException);
+
+      //check what caused inner exception's inner exception (i.e. the root exception)
+#if (NETFRAMEWORK)
+      Assert.AreEqual(".Net SqlClient Data Provider", exceptionSource);
+#else
+      Assert.AreEqual("Core .Net SqlClient Data Provider", exceptionSource);
 #endif
 
-        [TestMethod()]
-        public void CheckInnerExceptionsOnDelete()
-        {
-            IDataPortal<DataPortal.TransactionalRoot> dataPortal = _testDIContext.CreateDataPortal<DataPortal.TransactionalRoot>();
-            TestResults.Reinitialise();
-
-            string baseException = string.Empty;
-            string baseInnerException = string.Empty;
-            string baseInnerInnerException = string.Empty;
-
-            try
-            {
-              //this will throw an exception
-              Csla.Test.DataPortal.TransactionalRoot.DeleteTransactionalRoot(13, dataPortal);
-            }
-            catch (Csla.DataPortalException ex)
-            {
-              baseException = ex.Message;
-              baseInnerException = ex.InnerException.Message;
-              baseInnerInnerException = ex.InnerException.InnerException.Message;
-            }
-
-            Assert.IsTrue(baseException.StartsWith("DataPortal.Delete failed"), "Should start with 'DataPortal.Delete failed'");
-            Assert.IsTrue(baseException.Contains("DataPortal_Delete: you chose an unlucky number"));
-            Assert.AreEqual("TransactionalRoot.DataPortal_Delete method call failed", baseInnerException);
-            Assert.AreEqual("DataPortal_Delete: you chose an unlucky number", baseInnerInnerException);
-
-            //verify that the implemented method, DataPortal_OnDataPortal 
-            //was called for the business object that threw the exception
-            Assert.AreEqual("Called", TestResults.GetResult("OnDataPortalException"));
-        }
-
-        [TestMethod()]
-        public void CheckInnerExceptionsOnFetch()
-        {
-            IDataPortal<DataPortal.TransactionalRoot> dataPortal = _testDIContext.CreateDataPortal<DataPortal.TransactionalRoot>();
-            TestResults.Reinitialise();
-
-            string baseException = string.Empty;
-            string baseInnerException = string.Empty;
-            string baseInnerInnerException = string.Empty;
-
-            try
-            {
-                //this will throw an exception
-                Csla.Test.DataPortal.TransactionalRoot root = 
-                    Csla.Test.DataPortal.TransactionalRoot.GetTransactionalRoot(13, dataPortal);
-            }
-            catch (Csla.DataPortalException ex)
-            {
-                baseException = ex.Message;
-                baseInnerException = ex.InnerException.Message;
-                baseInnerInnerException = ex.InnerException.InnerException.Message;
-            }
-
-            Assert.IsTrue(baseException.StartsWith("DataPortal.Fetch failed"), "Should start with 'DataPortal.Fetch failed'");
-            Assert.IsTrue(baseException.Contains("DataPortal_Fetch: you chose an unlucky number"), 
-              "Should contain with 'DataPortal_Fetch: you chose an unlucky number'");
-            Assert.AreEqual("TransactionalRoot.DataPortal_Fetch method call failed", baseInnerException);
-            Assert.AreEqual("DataPortal_Fetch: you chose an unlucky number", baseInnerInnerException);
-
-            //verify that the implemented method, DataPortal_OnDataPortal 
-            //was called for the business object that threw the exception
-            Assert.AreEqual("Called", TestResults.GetResult("OnDataPortalException"));
-        }
+      //verify that the implemented method, DataPortal_OnDataPortal 
+      //was called for the business object that threw the exception
+      Assert.AreEqual("Called", TestResults.GetResult("OnDataPortalException"));
     }
+#endif
+
+    [TestMethod()]
+    public void CheckInnerExceptionsOnDelete()
+    {
+      IDataPortal<DataPortal.TransactionalRoot> dataPortal = _testDIContext.CreateDataPortal<DataPortal.TransactionalRoot>();
+      TestResults.Reinitialise();
+
+      string baseException = string.Empty;
+      string baseInnerException = string.Empty;
+      string baseInnerInnerException = string.Empty;
+
+      try
+      {
+        //this will throw an exception
+        Csla.Test.DataPortal.TransactionalRoot.DeleteTransactionalRoot(13, dataPortal);
+      }
+      catch (Csla.DataPortalException ex)
+      {
+        baseException = ex.Message;
+        baseInnerException = ex.InnerException.Message;
+        baseInnerInnerException = ex.InnerException.InnerException.Message;
+      }
+
+      Assert.IsTrue(baseException.StartsWith("DataPortal.Delete failed"), "Should start with 'DataPortal.Delete failed'");
+      Assert.IsTrue(baseException.Contains("DataPortal_Delete: you chose an unlucky number"));
+      Assert.AreEqual("TransactionalRoot.DataPortal_Delete method call failed", baseInnerException);
+      Assert.AreEqual("DataPortal_Delete: you chose an unlucky number", baseInnerInnerException);
+
+      //verify that the implemented method, DataPortal_OnDataPortal 
+      //was called for the business object that threw the exception
+      Assert.AreEqual("Called", TestResults.GetResult("OnDataPortalException"));
+    }
+
+    [TestMethod()]
+    public void CheckInnerExceptionsOnFetch()
+    {
+      IDataPortal<DataPortal.TransactionalRoot> dataPortal = _testDIContext.CreateDataPortal<DataPortal.TransactionalRoot>();
+      TestResults.Reinitialise();
+
+      string baseException = string.Empty;
+      string baseInnerException = string.Empty;
+      string baseInnerInnerException = string.Empty;
+
+      try
+      {
+        //this will throw an exception
+        Csla.Test.DataPortal.TransactionalRoot root =
+            Csla.Test.DataPortal.TransactionalRoot.GetTransactionalRoot(13, dataPortal);
+      }
+      catch (Csla.DataPortalException ex)
+      {
+        baseException = ex.Message;
+        baseInnerException = ex.InnerException.Message;
+        baseInnerInnerException = ex.InnerException.InnerException.Message;
+      }
+
+      Assert.IsTrue(baseException.StartsWith("DataPortal.Fetch failed"), "Should start with 'DataPortal.Fetch failed'");
+      Assert.IsTrue(baseException.Contains("DataPortal_Fetch: you chose an unlucky number"),
+        "Should contain with 'DataPortal_Fetch: you chose an unlucky number'");
+      Assert.AreEqual("TransactionalRoot.DataPortal_Fetch method call failed", baseInnerException);
+      Assert.AreEqual("DataPortal_Fetch: you chose an unlucky number", baseInnerInnerException);
+
+      //verify that the implemented method, DataPortal_OnDataPortal 
+      //was called for the business object that threw the exception
+      Assert.AreEqual("Called", TestResults.GetResult("OnDataPortalException"));
+    }
+  }
 }

--- a/Source/Csla.test/DataPortal/DpRoot.cs
+++ b/Source/Csla.test/DataPortal/DpRoot.cs
@@ -148,7 +148,8 @@ namespace Csla.Test.DataPortal
       get
       {
         if (CanReadProperty("DenyReadOnProperty"))
-          throw new Csla.Security.SecurityException("Not allowed 1");
+          //return "Not allowed 1";
+          return ((TestHelpers.ApplicationContextManagerUnitTests)ApplicationContext.ContextManager).InstanceId.ToString();
 
         else
           return "[DenyReadOnProperty] Can't read property";
@@ -185,7 +186,7 @@ namespace Csla.Test.DataPortal
       get
       {
         if (CanReadProperty("DenyReadWriteOnProperty"))
-          throw new Csla.Security.SecurityException("Not allowed 3");
+          return "Not allowed 3";
 
         else
           return "[DenyReadWriteOnProperty] Can't read property";
@@ -209,7 +210,7 @@ namespace Csla.Test.DataPortal
           return _auth;
 
         else
-          throw new Csla.Security.SecurityException("Should be allowed 5");
+          return "Should be allowed 5";
       }
       set
       {

--- a/Source/Csla.test/DataPortal/TransactionalRoot.cs
+++ b/Source/Csla.test/DataPortal/TransactionalRoot.cs
@@ -123,7 +123,7 @@ namespace Csla.Test.DataPortal
     [Transactional(TransactionalTypes.TransactionScope)]
     [Insert]
     protected void DataPortal_Insert()
-    {
+    { 
       SqlConnection cn = new SqlConnection(WellKnownValues.DataPortalTestDatabase);
       string firstName = this.FirstName;
       string lastName = this.LastName;

--- a/Source/Csla.test/LazyLoad/AChild.cs
+++ b/Source/Csla.test/LazyLoad/AChild.cs
@@ -28,6 +28,12 @@ namespace Csla.Test.LazyLoad
 
     public AChild()
     {
+    }
+
+    [Create]
+    [CreateChild]
+    private void Create()
+    {
       MarkAsChild();
       using (BypassPropertyChecks)
         Id = Guid.NewGuid();

--- a/Source/Csla.test/LazyLoad/AParent.cs
+++ b/Source/Csla.test/LazyLoad/AParent.cs
@@ -53,7 +53,8 @@ namespace Csla.Test.LazyLoad
 
     private AChildList FetchChildList()
     {
-      return GetDataPortal<AChildList>().Fetch();
+      IDataPortal<AChildList> dataPortal = ApplicationContext.GetRequiredService<IDataPortal<AChildList>>();
+      return dataPortal.Fetch();
     }
   }
 }

--- a/Source/Csla.test/LazySingelton/LazySingeltonTest.cs
+++ b/Source/Csla.test/LazySingelton/LazySingeltonTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using UnitDriven;
+using Csla.TestHelpers;
 
 #if NUNIT
 using NUnit.Framework;
@@ -23,6 +24,14 @@ namespace Csla.Test.LazySingelton
   [TestClass]
   public class LazySingeltonTest
   {
+
+    private static TestDIContext _testDIContext;
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext context)
+    {
+      _testDIContext = TestDIContextFactory.CreateDefaultContext();
+    }
 
     [TestMethod]
     public void LazySingeltonDefaultConstructorCreatesObject()
@@ -73,5 +82,13 @@ namespace Csla.Test.LazySingelton
       Assert.AreEqual(typeof(Dictionary<string, object>), lazy.Value.GetType());
     }
 
+    #region Private Helper Methods
+
+    private LazySingleton<T> CreateLazySingleton<T>() where T:class
+    {
+      return new LazySingleton<T>();
+    }
+
+    #endregion
   }
 }

--- a/Source/Csla.test/Linq/LinqObservableCollectionTest.cs
+++ b/Source/Csla.test/Linq/LinqObservableCollectionTest.cs
@@ -49,7 +49,6 @@ namespace Csla.Test.Linq
     {
       IDataPortal<TestList> dataPortal = _testDIContext.CreateDataPortal<TestList>();
 
-      // TODO: I don't understand why some types need a public constructor and others don't?
       var source = dataPortal.Create();
       var synced = source.ToSyncList(c => c.Id > 100);
       Assert.AreEqual(3, synced.Count);
@@ -61,7 +60,6 @@ namespace Csla.Test.Linq
     {
       IDataPortal<TestList> dataPortal = _testDIContext.CreateDataPortal<TestList>();
 
-      // TODO: I don't understand why some types need a public constructor and others don't?
       var source = dataPortal.Create();
       var synced = source.ToSyncList(from r in source
                   where r.Id > 100
@@ -74,7 +72,6 @@ namespace Csla.Test.Linq
     {
       IDataPortal<TestList> dataPortal = _testDIContext.CreateDataPortal<TestList>();
 
-      // TODO: I don't understand why some types need a public constructor and others don't?
       var source = dataPortal.Create();
       var synced = source.ToSyncList(from r in source
                                      orderby r.Name
@@ -88,7 +85,6 @@ namespace Csla.Test.Linq
     {
       IDataPortal<TestList> dataPortal = _testDIContext.CreateDataPortal<TestList>();
 
-      // TODO: I don't understand why some types need a public constructor and others don't?
       var source = dataPortal.Create();
       var synced = (from r in source
                      where r.Id > 100
@@ -102,7 +98,6 @@ namespace Csla.Test.Linq
       IDataPortal<TestList> dataPortal = _testDIContext.CreateDataPortal<TestList>();
       IChildDataPortal<TestItem> childDataPortal = _testDIContext.CreateChildDataPortal<TestItem>();
 
-      // TODO: I don't understand why some types need a public constructor and others don't?
       var source = dataPortal.Create();
       var query = from r in source
                   where r.Id > 100
@@ -123,7 +118,6 @@ namespace Csla.Test.Linq
     {
       IDataPortal<TestList> dataPortal = _testDIContext.CreateDataPortal<TestList>();
 
-      // TODO: I don't understand why some types need a public constructor and others don't?
       var source = dataPortal.Create();
       var query = from r in source
                   where r.Id > 100
@@ -144,7 +138,6 @@ namespace Csla.Test.Linq
     {
       IDataPortal<TestList> dataPortal = _testDIContext.CreateDataPortal<TestList>();
 
-      // TODO: I don't understand why some types need a public constructor and others don't?
       var source = dataPortal.Create();
       var query = from r in source
                   where r.Id > 100
@@ -465,7 +458,7 @@ namespace Csla.Test.Linq
   [Serializable]
   public class TestList : BusinessListBase<TestList, TestItem>
   {
-    private TestList()
+    public TestList()
     {
     }
 

--- a/Source/Csla.test/ObjectFactory/CommandObject.cs
+++ b/Source/Csla.test/ObjectFactory/CommandObject.cs
@@ -32,7 +32,7 @@ namespace Csla.Test.ObjectFactory
       if (!CanExecuteCommand())
         throw new Csla.Security.SecurityException("Not authorized to execute command");
 
-      CommandObject cmd = new CommandObject();
+      CommandObject cmd = dataPortal.Create();
       cmd.BeforeServer();
       cmd = dataPortal.Execute(cmd);
       cmd.AfterServer();

--- a/Source/Csla.test/ObjectFactory/CommandObjectFactory.cs
+++ b/Source/Csla.test/ObjectFactory/CommandObjectFactory.cs
@@ -18,6 +18,12 @@ namespace Csla.Test.ObjectFactory
     {
     }
 
+    [RunLocal]
+    public object Create()
+    {
+      return ApplicationContext.CreateInstanceDI<CommandObject>();
+    }
+
     public object Execute(CommandObject command)
     {
       command.Result = true;

--- a/Source/Csla.test/ObjectFactory/CommandObjectMissingFactoryMethod.cs
+++ b/Source/Csla.test/ObjectFactory/CommandObjectMissingFactoryMethod.cs
@@ -32,7 +32,7 @@ namespace Csla.Test.ObjectFactory
       if (!CanExecuteCommand())
         throw new Csla.Security.SecurityException("Not authorized to execute command");
 
-      CommandObjectMissingFactoryMethod cmd = new CommandObjectMissingFactoryMethod();
+      CommandObjectMissingFactoryMethod cmd = dataPortal.Create();
       cmd.BeforeServer();
       cmd = dataPortal.Execute(cmd);
       cmd.AfterServer();
@@ -59,6 +59,11 @@ namespace Csla.Test.ObjectFactory
     }
 
     #endregion
+
+    [RunLocal]
+    [Create]
+    private void Create()
+    { }
 
   }
 }

--- a/Source/Csla.test/ObjectFactory/ObjectFactoryLoader.cs
+++ b/Source/Csla.test/ObjectFactory/ObjectFactoryLoader.cs
@@ -64,23 +64,23 @@ namespace Csla.Test.ObjectFactory
         switch (_mode)
         {
           case 1:
-            return new RootFactory1();
+            return new RootFactory1(_applicationContext);
           case 2:
             throw new NotImplementedException("Enterprise Services is no longer supported!");
           case 3:
             return new RootFactory3(_applicationContext);
           case 4:
-            return new RootFactory4();
+            return new RootFactory4(_applicationContext);
           case 5:
-            return new RootFactory5();
+            return new RootFactory5(_applicationContext);
           case 6:
             throw new NotImplementedException("Enterprise Services is no longer supported!");
           case 7:
             throw new NotImplementedException("Enterprise Services is no longer supported!");
           case 8:
-            return new RootFactoryC();
+            return new RootFactoryC(_applicationContext);
           default:
-            return new RootFactory();
+            return new RootFactory(_applicationContext);
         }
       }
       else

--- a/Source/Csla.test/ObjectFactory/ObjectFactoryLoaderT.cs
+++ b/Source/Csla.test/ObjectFactory/ObjectFactoryLoaderT.cs
@@ -12,8 +12,14 @@ using System.Text;
 
 namespace Csla.Test.ObjectFactory
 {
-  public class ObjectFactoryLoader<T> : Csla.Server.IObjectFactoryLoader where T: class, new()
+  public class ObjectFactoryLoader<T> : Csla.Server.IObjectFactoryLoader where T: class
   {
+    private readonly ApplicationContext _applicationContext;
+    public ObjectFactoryLoader(ApplicationContext applicationContext)
+    {
+      _applicationContext = applicationContext;
+    }
+
     public Type GetFactoryType(string factoryName)
     {
       if (factoryName == "Csla.Test.ObjectFactory.RootFactory, Csla.Tests")
@@ -28,7 +34,7 @@ namespace Csla.Test.ObjectFactory
     {
       if (factoryName == "Csla.Test.ObjectFactory.RootFactory, Csla.Tests")
       {
-        return new T();
+        return _applicationContext.CreateInstanceDI<T>();
       }
       else
         return null;

--- a/Source/Csla.test/ObjectFactory/ObjectFactoryTests.cs
+++ b/Source/Csla.test/ObjectFactory/ObjectFactoryTests.cs
@@ -268,12 +268,10 @@ namespace Csla.Test.ObjectFactory
     [TestMethod]
     public void FetchLoadProperty()
     {
-      TestDIContext testDIContext = TestDIContextFactory.CreateDefaultContext();
-      // TODO: Not sure how to have a generic factory loader now an ApplicationContext is required on the class :-(
-      //TestDIContext testDIContext = TestDIContextFactory.CreateContext(
-      //  options => options.DataPortal(
-      //    dp => dp.AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory3>>()))
-      //  );
+      TestDIContext testDIContext = TestDIContextFactory.CreateContext(
+        options => options.DataPortal(
+          dp => dp.AddServerSideDataPortal(cfg => cfg.RegisterObjectFactoryLoader<ObjectFactoryLoader<RootFactory3>>()))
+        );
       IDataPortal<Root> dataPortal = testDIContext.CreateDataPortal<Root>();
 
       var root = dataPortal.Fetch();

--- a/Source/Csla.test/ObjectFactory/Root.cs
+++ b/Source/Csla.test/ObjectFactory/Root.cs
@@ -17,35 +17,35 @@ namespace Csla.Test.ObjectFactory
   [Serializable]
   public class Root : BusinessBase<Root>
   {
-    internal static PropertyInfo<string> DataProperty = RegisterProperty(new PropertyInfo<string>("Data"));
+    internal static PropertyInfo<string> DataProperty = RegisterProperty<string>(nameof(Data));
     public string Data
     {
       get { return GetProperty(DataProperty); }
       set { SetProperty(DataProperty, value); }
     }
 
-    private static PropertyInfo<Csla.ApplicationContext.ExecutionLocations> LocationProperty = RegisterProperty(new PropertyInfo<Csla.ApplicationContext.ExecutionLocations>("Location"));
+    private static PropertyInfo<Csla.ApplicationContext.ExecutionLocations> LocationProperty = RegisterProperty<Csla.ApplicationContext.ExecutionLocations>(nameof(Location));
     public Csla.ApplicationContext.ExecutionLocations Location
     {
       get { return GetProperty(LocationProperty); }
       set { SetProperty(LocationProperty, value); }
     }
 
-    private static PropertyInfo<TransactionalTypes> TransactionalTypeProperty = RegisterProperty(new PropertyInfo<TransactionalTypes>("TransactionalType"));
+    private static PropertyInfo<TransactionalTypes> TransactionalTypeProperty = RegisterProperty<TransactionalTypes>(nameof(TransactionalType));
     public TransactionalTypes TransactionalType
     {
       get { return GetProperty(TransactionalTypeProperty); }
       set { SetProperty(TransactionalTypeProperty, value); }
     }
 
-    private static PropertyInfo<string> IsolationLevelProperty = RegisterProperty(new PropertyInfo<string>("IsolationLevel"));
+    private static PropertyInfo<string> IsolationLevelProperty = RegisterProperty<string>(nameof(IsolationLevel));
     public string IsolationLevel
     {
       get { return GetProperty(IsolationLevelProperty); }
       set { SetProperty(IsolationLevelProperty, value); }
     }
 
-    private static PropertyInfo<int> TransactionTimeoutProperty = RegisterProperty(new PropertyInfo<int>("TransactionTimeout"));
+    private static PropertyInfo<int> TransactionTimeoutProperty = RegisterProperty<int>(nameof(TransactionTimeout));
     public int TransactionTimeout
     {
       get { return GetProperty(TransactionTimeoutProperty); }

--- a/Source/Csla.test/ObjectFactory/RootFactory.cs
+++ b/Source/Csla.test/ObjectFactory/RootFactory.cs
@@ -12,12 +12,14 @@ using System.Text;
 
 namespace Csla.Test.ObjectFactory
 {
-  public class RootFactory
+  public class RootFactory : Csla.Server.ObjectFactory
   {
+    public RootFactory(ApplicationContext applicationContext)
+      : base(applicationContext) { }
+
     public object Create()
     {
-      var obj = new Root();
-      // TODO: How do we set ApplicationContext here? Create object using something injected?
+      var obj = ApplicationContext.CreateInstanceDI<Root>();
       obj.Data = "Create";
       obj.Location = obj.ExecutionLocation;
       obj.MarkAsNew();
@@ -33,8 +35,7 @@ namespace Csla.Test.ObjectFactory
     [RunLocal]
     public object Create(string criteria)
     {
-      var obj = new Root();
-      // TODO: How do we set ApplicationContext here? Create object using something injected?
+      var obj = ApplicationContext.CreateInstanceDI<Root>();
       obj.Data = "Create " + criteria;
       obj.Location = obj.ExecutionLocation;
       obj.MarkAsNew();
@@ -43,7 +44,7 @@ namespace Csla.Test.ObjectFactory
 
     public object Fetch()
     {
-      var obj = new Root();
+      var obj = ApplicationContext.CreateInstanceDI<Root>();
       obj.Data = "Fetch";
       obj.MarkAsOld();
       return obj;
@@ -51,8 +52,7 @@ namespace Csla.Test.ObjectFactory
 
     public object Fetch(string criteria)
     {
-      var obj = new Root();
-      // TODO: How do we set ApplicationContext here? Create object using something injected?
+      var obj = ApplicationContext.CreateInstanceDI<Root>();
       obj.Data = criteria;
       obj.MarkAsOld();
       return obj;
@@ -97,8 +97,11 @@ namespace Csla.Test.ObjectFactory
     }
   }
 
-  public class RootFactoryC
+  public class RootFactoryC : Csla.Server.ObjectFactory
   {
+    public RootFactoryC(ApplicationContext applicationContext) 
+      : base(applicationContext) { }
+
     public object Create(int test)
     {
       // add overload to test reflection
@@ -108,8 +111,7 @@ namespace Csla.Test.ObjectFactory
     [RunLocal]
     public object Create(string criteria)
     {
-      var obj = new Root();
-      // TODO: How do we set ApplicationContext here? Create object using something injected?
+      var obj = ApplicationContext.CreateInstanceDI<Root>();
       obj.Data = "Create " + criteria;
       obj.Location = obj.ExecutionLocation;
       obj.MarkAsNew();
@@ -124,8 +126,19 @@ namespace Csla.Test.ObjectFactory
     }
   }
 
-  public class RootFactory1
+  public class RootFactory1 : Csla.Server.ObjectFactory
   {
+    public RootFactory1(ApplicationContext applicationContext)
+      : base(applicationContext) { }
+
+    public object Fetch()
+    {
+      var obj = ApplicationContext.CreateInstanceDI<Root>();
+      LoadProperty(obj, Root.DataProperty, "Fetch");
+      this.MarkOld(obj);
+      return obj;
+    }
+    
     [Transactional(TransactionalTypes.TransactionScope)]
     public object Update(Root obj)
     {
@@ -167,22 +180,32 @@ namespace Csla.Test.ObjectFactory
 
   public class RootFactory3 : Csla.Server.ObjectFactory
   {
-    public RootFactory3(ApplicationContext applicationContext) : base(applicationContext)
-    {
-    }
+    public RootFactory3(ApplicationContext applicationContext) 
+      : base(applicationContext) { }
 
     public object Fetch()
     {
-      var obj = new Root();
-      // TODO: How do we set ApplicationContext here? Create object using something injected?
+      var obj = ApplicationContext.CreateInstanceDI<Root>();
       LoadProperty(obj, Root.DataProperty, "Fetch");
       this.MarkOld(obj);
       return obj;
     }
   }
 
-  public class RootFactory4
+  public class RootFactory4 : Csla.Server.ObjectFactory
   {
+    public RootFactory4(ApplicationContext applicationContext)
+      : base(applicationContext) { }
+
+    [RunLocal]
+    public object Create()
+    {
+      var obj = ApplicationContext.CreateInstanceDI<Root>();
+      obj.Location = obj.ExecutionLocation;
+      obj.MarkAsNew();
+      return obj;
+    }
+    
     [Transactional(TransactionalTypes.TransactionScope, TransactionIsolationLevel.ReadCommitted, 100)]
     public object Update(Root obj)
     {
@@ -203,8 +226,20 @@ namespace Csla.Test.ObjectFactory
     }
   }
 
-  public class RootFactory5
+  public class RootFactory5 : Csla.Server.ObjectFactory
   {
+    public RootFactory5(ApplicationContext applicationContext)
+      : base(applicationContext) { }
+
+    [RunLocal]
+    public object Create()
+    {
+      var obj = ApplicationContext.CreateInstanceDI<Root>();
+      obj.Location = obj.ExecutionLocation;
+      obj.MarkAsNew();
+      return obj;
+    }
+
     [Transactional(TransactionalTypes.TransactionScope)]
     public object Update(Root obj)
     {

--- a/Source/Csla.test/PropertyGetSet/EditableGetSet.cs
+++ b/Source/Csla.test/PropertyGetSet/EditableGetSet.cs
@@ -295,6 +295,20 @@ namespace Csla.Test.PropertyGetSet
     }
 
     #endregion
+
+    #region Private Helper Methods
+
+    /// <summary>
+    /// Construct an instance of IDataPortal<typeparamref name="T"/>
+    /// </summary>
+    /// <typeparam name="T">The type which is to be accessed</typeparam>
+    /// <returns>An instance of IDataPortal for use in data access</returns>
+    private IDataPortal<T> GetDataPortal<T>() where T:class
+    {
+      return ApplicationContext.GetRequiredService<IDataPortal<T>>();
+    }
+
+    #endregion
   }
 
   [Serializable]

--- a/Source/Csla.test/Startup.cs
+++ b/Source/Csla.test/Startup.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Csla.Test
+{
+  [TestClass]
+  public class Startup
+  {
+
+    [AssemblyInitialize]
+    public static void AssemblyInitialize(TestContext context)
+    {
+      string path = AppDomain.CurrentDomain.BaseDirectory;
+      if (path.EndsWith(@"\"))
+      {
+        path = path.Substring(0, path.Length - 1);
+      }
+      AppDomain.CurrentDomain.SetData("DataDirectory", path);
+    }
+  }
+}

--- a/Source/Csla.test/ValidationRules/HasChildren.cs
+++ b/Source/Csla.test/ValidationRules/HasChildren.cs
@@ -81,5 +81,20 @@ namespace Csla.Test.ValidationRules
     {
       await BusinessRules.CheckRulesAsync();
     }
+
+    #region Private Helper Methods
+
+    /// <summary>
+    /// Construct an instance of IDataPortal<typeparamref name="T"/>
+    /// </summary>
+    /// <typeparam name="T">The type which is to be accessed</typeparam>
+    /// <returns>An instance of IDataPortal for use in data access</returns>
+    private IDataPortal<T> GetDataPortal<T>() where T : class
+    {
+      return ApplicationContext.GetRequiredService<IDataPortal<T>>();
+    }
+
+    #endregion
+
   }
 }

--- a/Source/Csla.test/WellKnownValues.cs
+++ b/Source/Csla.test/WellKnownValues.cs
@@ -14,12 +14,14 @@ namespace Csla.Test
 
     static WellKnownValues()
     {
-      ConnectionStringSettingsCollection conStrings = AppConfig.ConnectionStrings.ConnectionStrings;
-      DataPortalTestDatabase = conStrings["DataPortalTestDatabase"].ConnectionString;
-      DataPortalTestDatabaseWithInvalidDBValue = conStrings["DataPortalTestDatabaseWithInvalidDBValue"].ConnectionString;
-      DataPortalTestDatabaseEntities = conStrings["DataPortalTestDatabaseEntities"].ConnectionString;
-      EntityConnectionWithMissingDB = conStrings["DataPortalTestDatabaseEntitiesWithInvalidDBValue"].ConnectionString;
+      DataDirectory = BuildDataDirectory();
+      DataPortalTestDatabase = GetConnectionString("DataPortalTestDatabase");
+      DataPortalTestDatabaseWithInvalidDBValue = GetConnectionString("DataPortalTestDatabaseWithInvalidDBValue");
+      DataPortalTestDatabaseEntities = GetConnectionString("DataPortalTestDatabaseEntities");
+      EntityConnectionWithMissingDB = GetConnectionString("DataPortalTestDatabaseEntitiesWithInvalidDBValue");
     }
+
+    public static string DataDirectory { get; }
 
     public static string EntityConnectionWithMissingDBConnectionStringName = "DataPortalTestDatabaseEntitiesWithInvalidDBValue";
     public static string EntityConnectionWithMissingDB {get;} 
@@ -28,5 +30,29 @@ namespace Csla.Test
 
     public static string DataPortalTestDatabase { get; }
     public static string TestLinqToSqlContextDataContext { get; }
+
+    #region Private Helper Methods
+
+    private static string BuildDataDirectory()
+    {
+      string dataDirectory = AppDomain.CurrentDomain.GetData("DataDirectory")?.ToString() ?? AppDomain.CurrentDomain.BaseDirectory;
+      if (dataDirectory.EndsWith(@"\"))
+      {
+        dataDirectory = dataDirectory.Substring(0, dataDirectory.Length - 1);
+      }
+      return dataDirectory;
+    }
+
+    private static string GetConnectionString(string connectionName)
+    {
+      string connectionString;
+      ConnectionStringSettingsCollection conStrings = AppConfig.ConnectionStrings.ConnectionStrings;
+
+      connectionString = conStrings[connectionName].ConnectionString;
+      connectionString = connectionString.Replace("|DataDirectory|", DataDirectory);
+      return connectionString;
+    }
+
+    #endregion
   }
 }

--- a/Source/Csla.test/testConnectionStrings.config
+++ b/Source/Csla.test/testConnectionStrings.config
@@ -1,6 +1,6 @@
 ﻿<connectionStrings>
-  <add name="DataPortalTestDatabase" connectionString="Data Source=.\SQLEXPRESS;AttachDbFilename=|DataDirectory|\DataPortalTestDatabase.mdf;Integrated Security=True;User Instance=True"/>
-  <add name="DataPortalTestDatabaseWithInvalidDBValue" connectionString="Data Source=.\SQLEXPRESS;AttachDbFilename=|DataDirectory|\NoSuchDB.mdf;Integrated Security=True;User Instance=True"/>
+  <add name="DataPortalTestDatabase" connectionString="Data Source=(LocalDb)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\DataPortalTestDatabase.mdf;Integrated Security=True"/>
+  <add name="DataPortalTestDatabaseWithInvalidDBValue" connectionString="Data Source=(LocalDb)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\NoSuchDB.mdf;Integrated Security=True"/>
   <add name="DataPortalTestDatabaseEntities" connectionString="metadata=res://*/Data.TestEFContext.csdl|res://*/Data.TestEFContext.ssdl|res://*/Data.TestEFContext.msl;provider=System.Data.SqlClient;provider connection string=&quot;Data Source=.\SQLEXPRESS;AttachDbFilename=|DataDirectory|\DataPortalTestDatabase.mdf;Integrated Security=True;User Instance=True;MultipleActiveResultSets=True&quot;" providerName="System.Data.EntityClient"/>
   <add name="DataPortalTestDatabaseEntitiesWithInvalidDBValue" connectionString="metadata=res://*/Data.TestEFContext.csdl|res://*/Data.TestEFContext.ssdl|res://*/Data.TestEFContext.msl;provider=System.Data.SqlClient;provider connection string=&quot;Data Source=.\SQLEXPRESS;AttachDbFilename=|DataDirectory|\NoSuchDB.mdf;Integrated Security=True;User Instance=True;MultipleActiveResultSets=True&quot;" providerName="System.Data.EntityClient"/>
 </connectionStrings>

--- a/Source/csla.netcore.test/csla.netcore.test.csproj
+++ b/Source/csla.netcore.test/csla.netcore.test.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.9" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.9" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes to more tests today, mostly issues with the tests due to a lack of experience with some parts of the framework. However, there was one issue with the Csla.TestHelpers that it was important to resolve.

Only 51 failing now under .NET 6, and 130 under .NET Framework

I think there are some outstanding issues with CSLA 6 around how PropertyChanged is called; a number of tests are failing because the number of PropertyChanged events raised is not the same as in previous versions.

There may also be a problem with per-property authorization. We have some per-property auth tests that only fail when all of the tests are run at once; they pass if you run the auth tests on their own. I'm wondering if this is an issue caused by high thread usage or something, to do with the AsyncLocal context manager? Not sure yet.