### PR TITLE
Provide support for DI-based DataAnnotations validation attributes

### DIFF
--- a/Source/Csla.test/ValidationRules/DIBasedAttribute.cs
+++ b/Source/Csla.test/ValidationRules/DIBasedAttribute.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Csla.Test.ValidationRules
+{
+
+  /// <summary>
+  /// Test validation attribute that makes use of DI to create an instance of something
+  /// </summary>
+  internal class DIBasedTestAttribute : ValidationAttribute
+  {
+    public DIBasedTestAttribute() : base("Unknown validation error") { }
+
+    public override bool RequiresValidationContext => true;
+
+    /// <summary>
+    /// Override for the IsValid method, used to perform the appropriate validation work
+    /// </summary>
+    /// <param name="value">The value that is to be validated</param>
+    /// <param name="validationContext">The context within which we are to perform validation</param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException">Validation context is not provided</exception>
+    protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+    {
+      ApplicationContext applicationContext;
+
+      if (value is null) return ValidationResult.Success;
+      if (validationContext is null) throw new ArgumentNullException(nameof(validationContext));
+
+      applicationContext = (ApplicationContext)validationContext.GetService(typeof(ApplicationContext));
+
+      if (applicationContext is null)
+      {
+        return new ValidationResult("Service provider failed to create the appropriate class!");
+      }
+
+      return ValidationResult.Success;
+    }
+  }
+}

--- a/Source/Csla.test/ValidationRules/DIBasedTestAttribute.cs
+++ b/Source/Csla.test/ValidationRules/DIBasedTestAttribute.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿//-----------------------------------------------------------------------
+// <copyright file="DIBasedTestAttribute.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>Data Annotations attribute that makes use of DI</summary>
+//-----------------------------------------------------------------------
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;

--- a/Source/Csla.test/ValidationRules/DataAnnotationsTests.cs
+++ b/Source/Csla.test/ValidationRules/DataAnnotationsTests.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Csla.TestHelpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Csla.Test.ValidationRules
+{
+  [TestClass]
+  public class DataAnnotationsTests
+  {
+    private static TestDIContext _testDIContext;
+
+    [ClassInitialize]
+    public static void Initialize(TestContext testcontext)
+    {
+      _testDIContext = TestDIContextFactory.CreateDefaultContext();
+    }
+
+    [TestMethod]
+    public void BrokenRulesCollection_ValidTestObject_ReturnsZeroBrokenRules()
+    {
+      // Arrange
+      IDataPortal<TestObject> dataPortal = _testDIContext.CreateDataPortal<TestObject>();
+      TestObject testObject = dataPortal.Create();
+      int expected = 0;
+      int actual;
+
+      // Act
+      actual = testObject.BrokenRulesCollection.Count;
+
+      // Assert
+      Assert.AreEqual(expected, actual);
+
+    }
+
+    #region Private Helper Classes
+
+    private class TestObject : BusinessBase<TestObject>
+    {
+      public static PropertyInfo<string> TestPropertyProperty = RegisterProperty<string>(nameof(TestProperty));
+
+      [Required]
+      [DIBasedTest]
+      public string TestProperty 
+      { 
+        get { return GetProperty(TestPropertyProperty); } 
+        set { SetProperty(TestPropertyProperty, value); }
+      }
+
+      [Create]
+      private void Create() 
+      {
+        using (BypassPropertyChecks)
+        {
+          LoadProperty(TestPropertyProperty, "Test");
+        }
+        BusinessRules.CheckRules();
+      }
+    }
+
+    #endregion
+  }
+}

--- a/Source/Csla.test/ValidationRules/DataAnnotationsTests.cs
+++ b/Source/Csla.test/ValidationRules/DataAnnotationsTests.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿//-----------------------------------------------------------------------
+// <copyright file="DataAnnotationsTests.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>Tests for functionality around Data Annotations attributes</summary>
+//-----------------------------------------------------------------------
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;

--- a/Source/Csla/Rules/CommonRules.cs
+++ b/Source/Csla/Rules/CommonRules.cs
@@ -73,7 +73,7 @@ namespace Csla.Rules.CommonRules
     /// <param name="context">Rule context.</param>
     protected override void Execute(IRuleContext context)
     {
-      var ctx = new System.ComponentModel.DataAnnotations.ValidationContext(context.Target, null, null);
+      var ctx = new System.ComponentModel.DataAnnotations.ValidationContext(context.Target, context.ApplicationContext.CurrentServiceProvider, null);
       if (PrimaryProperty != null)
         ctx.MemberName = PrimaryProperty.FriendlyName;
 


### PR DESCRIPTION
Pass ServiceProvider to ValidationContext constructor to support DataAnnotations validation attributes inheriting from ValidationAttribute which make use of DI.

Includes a test which showed the original problem, and the fix which made the test pass.

Fixes #2953