### PR TITLE
Stabilisation during checks of failing tests

### DIFF
--- a/Source/Csla.test/AppContext/AppContextTests.cs
+++ b/Source/Csla.test/AppContext/AppContextTests.cs
@@ -36,13 +36,7 @@ namespace Csla.Test.AppContext
     }
 
     [TestInitialize]
-    public void SetScopedSp()
-    {
-      TestResults.Reinitialise();
-    }
-
-    [TestCleanup]
-    public void ClearContextsAfterEachTest()
+    public void Initialize()
     {
       TestResults.Reinitialise();
     }
@@ -55,7 +49,6 @@ namespace Csla.Test.AppContext
       IDataPortal<SimpleRoot> dataPortal = _testDIContext.CreateDataPortal<SimpleRoot>();
 
       // TODO: How do we do this test in Csla 6?
-      TestResults.Reinitialise();
       //ApplicationContext.ClientContext["v1"] = "client";
 
       SimpleRoot root = dataPortal.Fetch(new SimpleRoot.Criteria("data"));
@@ -83,8 +76,6 @@ namespace Csla.Test.AppContext
     {
       List<AppContextThread> AppContextThreadList = new List<AppContextThread>();
       List<Thread> ThreadList = new List<Thread>();
-
-      TestResults.Reinitialise();
 
       for (int x = 0; x < 10; x++)
       {
@@ -144,8 +135,6 @@ namespace Csla.Test.AppContext
       IDataPortal<Basic.Root> dataPortal = _testDIContext.CreateDataPortal<Basic.Root>();
       ApplicationContext applicationContext = _testDIContext.CreateTestApplicationContext();
 
-      TestResults.Reinitialise();
-
       applicationContext.ClientContext.Add("clientcontext", "client context data");
       Assert.AreEqual("client context data", applicationContext.ClientContext["clientcontext"], "Matching data not retrieved");
 
@@ -155,7 +144,6 @@ namespace Csla.Test.AppContext
       Assert.AreEqual(true, root.IsDirty, "Object should be dirty");
       Assert.AreEqual(true, root.IsValid, "Object should be valid");
 
-      TestResults.Reinitialise();
       root = root.Save();
 
       Assert.IsNotNull(root, "Root object should not be null");
@@ -192,7 +180,6 @@ namespace Csla.Test.AppContext
     {
       IDataPortal<Basic.Root> dataPortal = _testDIContext.CreateDataPortal<Basic.Root>();
 
-      TestResults.Reinitialise();
       TestResults.Add("global", "global");
 
       //dataPortal.DataPortalInvoke += new Action<DataPortalEventArgs>(OnDataPortaInvoke);
@@ -234,8 +221,6 @@ namespace Csla.Test.AppContext
     {
       IDataPortal<ExceptionRoot> dataPortal = _testDIContext.CreateDataPortal<ExceptionRoot>();
       
-      TestResults.Reinitialise();
-
       ExceptionRoot root;
       try
       {
@@ -261,7 +246,6 @@ namespace Csla.Test.AppContext
     {
       IDataPortal<ExceptionRoot> dataPortal = _testDIContext.CreateDataPortal<ExceptionRoot>();
       
-      TestResults.Reinitialise();
       ExceptionRoot root = null;
       try
       {
@@ -294,8 +278,6 @@ namespace Csla.Test.AppContext
       
       try
       {
-        TestResults.Reinitialise();
-
         ExceptionRoot root;
         try
         {
@@ -339,7 +321,6 @@ namespace Csla.Test.AppContext
     public void FailDeleteContext()
     {
       IDataPortal<ExceptionRoot> dataPortal = _testDIContext.CreateDataPortal<ExceptionRoot>();
-      TestResults.Reinitialise();
 
       ExceptionRoot root = null;
       try

--- a/Source/Csla.test/Authorization/AuthTests.cs
+++ b/Source/Csla.test/Authorization/AuthTests.cs
@@ -58,13 +58,17 @@ namespace Csla.Test.Authorization
       _adminDIContext = TestDIContextFactory.CreateContext(GetPrincipal("Admin"));
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod()]
     public void TestAuthCloneRules()
     {
       IDataPortal<DataPortal.DpRoot> dataPortal = _adminDIContext.CreateDataPortal<DataPortal.DpRoot>();
       ApplicationContext applicationContext = _adminDIContext.CreateTestApplicationContext();
-
-      TestResults.Reinitialise();
 
       DataPortal.DpRoot root = dataPortal.Fetch(new DataPortal.DpRoot.Criteria());
 
@@ -106,8 +110,6 @@ namespace Csla.Test.Authorization
       //Do they work under cloning as well?
       DataPortal.DpRoot newRoot = root.Clone();
 
-      TestResults.Reinitialise();
-
       //Is it denying read properly?
       Assert.AreEqual("[DenyReadOnProperty] Can't read property", newRoot.DenyReadOnProperty,
           "Read should have been denied 7");
@@ -146,8 +148,6 @@ namespace Csla.Test.Authorization
       TestDIContext customDIContext = TestDIContextFactory.CreateContext(GetPrincipal("Admin"));
       IDataPortal<DataPortal.DpRoot> dataPortal = customDIContext.CreateDataPortal<DataPortal.DpRoot>();
       ApplicationContext applicationContext = customDIContext.CreateTestApplicationContext();
-
-      TestResults.Reinitialise();
 
       DataPortal.DpRoot root = dataPortal.Create(new DataPortal.DpRoot.Criteria());
 
@@ -270,8 +270,6 @@ namespace Csla.Test.Authorization
       IDataPortal<PermissionsRoot> dataPortal = customDIContext.CreateDataPortal<PermissionsRoot>();
       ApplicationContext applicationContext = customDIContext.CreateTestApplicationContext();
 
-      TestResults.Reinitialise();
-
       PermissionsRoot pr = dataPortal.Create();
 
       pr.FirstName = "something";
@@ -292,8 +290,6 @@ namespace Csla.Test.Authorization
     public void TestUnauthorizedAccessToGet()
     {
       IDataPortal<PermissionsRoot> dataPortal = _anonymousDIContext.CreateDataPortal<PermissionsRoot>();
-
-      TestResults.Reinitialise();
 
       PermissionsRoot pr = dataPortal.Create();
 
@@ -320,8 +316,6 @@ namespace Csla.Test.Authorization
       IDataPortal<PermissionsRoot> dataPortal = customDIContext.CreateDataPortal<PermissionsRoot>();
       ApplicationContext applicationContext = customDIContext.CreateTestApplicationContext();
 
-      TestResults.Reinitialise();
-
       PermissionsRoot pr = dataPortal.Create();
 
       //should work, because we are now logged in as an admin
@@ -343,8 +337,6 @@ namespace Csla.Test.Authorization
       IDataPortal<PermissionsRoot> dataPortal = customDIContext.CreateDataPortal<PermissionsRoot>();
       ApplicationContext applicationContext = customDIContext.CreateTestApplicationContext();
 
-      TestResults.Reinitialise();
-
       PermissionsRoot pr = dataPortal.Create();
       //should work, because we are now logged in as an admin
       pr.DoWork();
@@ -364,8 +356,6 @@ namespace Csla.Test.Authorization
       IDataPortal<PermissionsRoot> dataPortal = _anonymousDIContext.CreateDataPortal<PermissionsRoot>();
       ApplicationContext applicationContext = _anonymousDIContext.CreateTestApplicationContext();
 
-      TestResults.Reinitialise();
-
       Assert.AreEqual(false, applicationContext.User.IsInRole("Admin"));
 
       PermissionsRoot pr = dataPortal.Create();
@@ -379,8 +369,6 @@ namespace Csla.Test.Authorization
     {
       IDataPortal<PermissionsRoot> dataPortal = _adminDIContext.CreateDataPortal<PermissionsRoot>();
       ApplicationContext applicationContext = _adminDIContext.CreateTestApplicationContext();
-
-      TestResults.Reinitialise();
 
       var root = dataPortal.Create();
 
@@ -408,8 +396,6 @@ namespace Csla.Test.Authorization
     {
       IDataPortal<PermissionsRoot2> dataPortal = _adminDIContext.CreateDataPortal<PermissionsRoot2>();
       ApplicationContext applicationContext = _adminDIContext.CreateTestApplicationContext();
-
-      TestResults.Reinitialise();
 
       var root = dataPortal.Create();
 

--- a/Source/Csla.test/Basic/BasicTests.cs
+++ b/Source/Csla.test/Basic/BasicTests.cs
@@ -33,12 +33,17 @@ namespace Csla.Test.Basic
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod]
     public void TestNotUndoableField()
     {
       IDataPortal<DataBinding.ParentEntity> dataPortal = _testDIContext.CreateDataPortal<DataBinding.ParentEntity>();
 
-      TestResults.Reinitialise();
       Csla.Test.DataBinding.ParentEntity p = DataBinding.ParentEntity.NewParentEntity(dataPortal);
 
       p.NotUndoable = "something";
@@ -85,7 +90,6 @@ namespace Csla.Test.Basic
     {
       IDataPortal<CommandObject> dataPortal = _testDIContext.CreateDataPortal<CommandObject>();
 
-      TestResults.Reinitialise();
       CommandObject obj = dataPortal.Create();
       obj = dataPortal.Execute(obj);
       Assert.AreEqual("Executed", obj.AProperty);
@@ -94,7 +98,6 @@ namespace Csla.Test.Basic
     [TestMethod]
     public void CreateGenRoot()
     {
-      TestResults.Reinitialise();
       GenRoot root;
       root = NewGenRoot();
       Assert.IsNotNull(root);
@@ -108,7 +111,6 @@ namespace Csla.Test.Basic
     [TestMethod]
     public void InheritanceUndo()
     {
-      TestResults.Reinitialise();
       GenRoot root;
       root = NewGenRoot();
       root.BeginEdit();
@@ -125,7 +127,6 @@ namespace Csla.Test.Basic
     [TestMethod]
     public void CreateRoot()
     {
-      TestResults.Reinitialise();
       Root root;
       root = NewRoot();
       Assert.IsNotNull(root);
@@ -141,7 +142,6 @@ namespace Csla.Test.Basic
     {
       IDataPortal<Child> childDataPortal = _testDIContext.CreateDataPortal<Child>();
 
-      TestResults.Reinitialise();
       Root root = NewRoot();
       root.Children.Add(childDataPortal, "1");
       Assert.AreEqual(1, root.Children.Count);
@@ -153,7 +153,6 @@ namespace Csla.Test.Basic
     {
       IDataPortal<Child> childDataPortal = _testDIContext.CreateDataPortal<Child>();
 
-      TestResults.Reinitialise();
       Root root = NewRoot();
       root.Children.Add(childDataPortal, "1");
       root.Children.Remove(root.Children[0]);
@@ -165,7 +164,6 @@ namespace Csla.Test.Basic
     {
       IDataPortal<Child> childDataPortal = _testDIContext.CreateDataPortal<Child>();
 
-      TestResults.Reinitialise();
       Root root = NewRoot();
       root.Children.Add(childDataPortal, "1");
       root.BeginEdit();
@@ -183,7 +181,6 @@ namespace Csla.Test.Basic
     {
       IDataPortal<Child> childDataPortal = _testDIContext.CreateDataPortal<Child>();
 
-      TestResults.Reinitialise();
       Root root = NewRoot();
       root.Children.Add(childDataPortal, "1");
       Child child = root.Children[0];
@@ -197,7 +194,6 @@ namespace Csla.Test.Basic
     {
       IDataPortal<Child> childDataPortal = _testDIContext.CreateDataPortal<Child>();
 
-      TestResults.Reinitialise();
       Root root = NewRoot();
       root.Children.Add(childDataPortal, "1");
       Child child = root.Children[0];
@@ -236,7 +232,6 @@ namespace Csla.Test.Basic
     {
       IDataPortal<Child> childDataPortal = _testDIContext.CreateDataPortal<Child>();
 
-      TestResults.Reinitialise();
       Root root = NewRoot();
       root.Children.Add(childDataPortal, "A");
       root.Children.Add(childDataPortal, "B");
@@ -251,7 +246,6 @@ namespace Csla.Test.Basic
     {
       IDataPortal<Child> childDataPortal = _testDIContext.CreateDataPortal<Child>();
 
-      TestResults.Reinitialise();
       Root root = NewRoot();
       root.BeginEdit();
       root.Children.Add(childDataPortal, "A");
@@ -270,7 +264,6 @@ namespace Csla.Test.Basic
     {
       IDataPortal<Child> childDataPortal = _testDIContext.CreateDataPortal<Child>();
 
-      TestResults.Reinitialise();
       Root root = NewRoot();
       root.BeginEdit();
       root.Children.Add(childDataPortal, "A");
@@ -297,7 +290,6 @@ namespace Csla.Test.Basic
     [TestMethod]
     public void BasicEquality()
     {
-      TestResults.Reinitialise();
       Root r1 = NewRoot();
       r1.Data = "abc";
       Assert.AreEqual(true, r1.Equals(r1), "objects should be equal on instance compare");
@@ -319,7 +311,6 @@ namespace Csla.Test.Basic
     {
       IDataPortal<Child> childDataPortal = _testDIContext.CreateDataPortal<Child>();
 
-      TestResults.Reinitialise();
       Root root = NewRoot();
       root.Children.Add(childDataPortal, "abc");
       root.Children.Add(childDataPortal, "xyz");
@@ -350,7 +341,6 @@ namespace Csla.Test.Basic
     {
       IDataPortal<Child> childDataPortal = _testDIContext.CreateDataPortal<Child>();
 
-      TestResults.Reinitialise();
       Root root = NewRoot();
       root.Children.Add(childDataPortal, "1");
       root.Children.Add(childDataPortal, "2");
@@ -375,7 +365,6 @@ namespace Csla.Test.Basic
     {
       IDataPortal<Child> childDataPortal = _testDIContext.CreateDataPortal<Child>();
 
-      TestResults.Reinitialise();
       Root root = NewRoot();
       root.Children.Add(childDataPortal, "1");
       root.Children.Add(childDataPortal, "2");
@@ -423,12 +412,6 @@ namespace Csla.Test.Basic
       Assert.IsFalse(changed, "Should not raise ListChanged event");
       Assert.IsTrue(obj.RaiseListChangedEvents);
       Assert.AreEqual(child, obj[0]);
-    }
-
-    [TestCleanup]
-    public void ClearContextsAfterEachTest()
-    {
-      TestResults.Reinitialise();
     }
 
     private Root NewRoot()

--- a/Source/Csla.test/BusyStatus/BusyStatusTests.cs
+++ b/Source/Csla.test/BusyStatus/BusyStatusTests.cs
@@ -42,13 +42,17 @@ namespace cslalighttest.BusyStatus
       _noCloneOnUpdateDIContext = TestDIContextFactory.CreateContext(opt => opt.DataPortal(cfg => cfg.AutoCloneOnUpdate(false)));
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod]
     public async Task TestBusy()
     {
       IDataPortal<ItemWithAsynchRule> dataPortal = _noCloneOnUpdateDIContext.CreateDataPortal<ItemWithAsynchRule>();
 
-      TestResults.Reinitialise();
-      
       UnitTestContext context = GetContext();
       var item = await dataPortal.FetchAsync("an id");
       item.RuleField = "some value";
@@ -63,8 +67,6 @@ namespace cslalighttest.BusyStatus
     {
       IDataPortal<ItemWithAsynchRuleList> dataPortal = _noCloneOnUpdateDIContext.CreateDataPortal<ItemWithAsynchRuleList>();
 
-      TestResults.Reinitialise();
-      
       UnitTestContext context = GetContext();
       ItemWithAsynchRuleList items = ItemWithAsynchRuleList.GetListWithItems(dataPortal);
       items[0].RuleField = "some value";
@@ -79,8 +81,6 @@ namespace cslalighttest.BusyStatus
     {
       IDataPortal<ItemWithAsynchRule> dataPortal = _testDIContext.CreateDataPortal<ItemWithAsynchRule>();
 
-      TestResults.Reinitialise();
-      
       UnitTestContext context = GetContext();
       var item = await dataPortal.FetchAsync("an id");
       item.RuleField = "some value";
@@ -107,8 +107,6 @@ namespace cslalighttest.BusyStatus
     {
       IDataPortal<ItemWithAsynchRuleList> dataPortal = _noCloneOnUpdateDIContext.CreateDataPortal<ItemWithAsynchRuleList>();
 
-      TestResults.Reinitialise();
-      
       UnitTestContext context = GetContext();
       ItemWithAsynchRuleList items = ItemWithAsynchRuleList.GetListWithItems(dataPortal);
       items[0].RuleField = "some value";
@@ -135,8 +133,6 @@ namespace cslalighttest.BusyStatus
     {
       IDataPortal<ItemWithAsynchRule> dataPortal = _testDIContext.CreateDataPortal<ItemWithAsynchRule>();
 
-      TestResults.Reinitialise();
-      
       UnitTestContext context = GetContext();
       var item = await dataPortal.FetchAsync("an id");
       item.ValidationComplete += (o2, e2) =>
@@ -156,8 +152,6 @@ namespace cslalighttest.BusyStatus
     {
       IDataPortal<ItemWithAsynchRuleList> dataPortal = _noCloneOnUpdateDIContext.CreateDataPortal<ItemWithAsynchRuleList>();
 
-      TestResults.Reinitialise();
-      
       UnitTestContext context = GetContext();
       ItemWithAsynchRuleList items = ItemWithAsynchRuleList.GetListWithItems(dataPortal);
       items[0].ValidationComplete += (o2, e2) =>
@@ -176,8 +170,6 @@ namespace cslalighttest.BusyStatus
     public void ListTestSaveWhileNotBusy()
     {
       IDataPortal<ItemWithAsynchRuleList> dataPortal = _noCloneOnUpdateDIContext.CreateDataPortal<ItemWithAsynchRuleList>();
-
-      TestResults.Reinitialise();
 
       UnitTestContext context = GetContext();
       ItemWithAsynchRuleList items = ItemWithAsynchRuleList.GetListWithItems(dataPortal);
@@ -202,8 +194,6 @@ namespace cslalighttest.BusyStatus
     {
       IDataPortal<ItemWithAsynchRule> dataPortal = _testDIContext.CreateDataPortal<ItemWithAsynchRule>();
 
-      TestResults.Reinitialise();
-      
       UnitTestContext context = GetContext();
       var item = await dataPortal.FetchAsync("an id");
       item.RuleField = "some value";
@@ -219,8 +209,6 @@ namespace cslalighttest.BusyStatus
     {
       IDataPortal<ItemWithAsynchRuleList> dataPortal = _noCloneOnUpdateDIContext.CreateDataPortal<ItemWithAsynchRuleList>();
 
-      TestResults.Reinitialise();
-      
       UnitTestContext context = GetContext();
       ItemWithAsynchRuleList items = ItemWithAsynchRuleList.GetListWithItems(dataPortal);
 
@@ -249,8 +237,6 @@ namespace cslalighttest.BusyStatus
     {
       IDataPortal<ItemWithAsynchRule> dataPortal = _noCloneOnUpdateDIContext.CreateDataPortal<ItemWithAsynchRule>();
 
-      TestResults.Reinitialise();
-      
       UnitTestContext context = GetContext();
       var item = await dataPortal.FetchAsync("an id");
       item.ValidationComplete += (o2, e2) =>
@@ -272,8 +258,6 @@ namespace cslalighttest.BusyStatus
     {
       IDataPortal<ItemWithAsynchRuleList> dataPortal = _noCloneOnUpdateDIContext.CreateDataPortal<ItemWithAsynchRuleList>();
 
-      TestResults.Reinitialise();
-      
       UnitTestContext context = GetContext();
       ItemWithAsynchRuleList items = ItemWithAsynchRuleList.GetListWithItems(dataPortal);
 
@@ -301,8 +285,6 @@ namespace cslalighttest.BusyStatus
     {
       IDataPortal<ItemWithAsynchRule> dataPortal = _noCloneOnUpdateDIContext.CreateDataPortal<ItemWithAsynchRule>();
 
-      TestResults.Reinitialise();
-      
       UnitTestContext context = GetContext();
       var item = await dataPortal.FetchAsync("an id");
       item.OperationResult = "something";
@@ -320,8 +302,6 @@ namespace cslalighttest.BusyStatus
     {
       IDataPortal<ItemWithAsynchRuleList> dataPortal = _noCloneOnUpdateDIContext.CreateDataPortal<ItemWithAsynchRuleList>();
 
-      TestResults.Reinitialise();
-      
       UnitTestContext context = GetContext();
       ItemWithAsynchRuleList items = ItemWithAsynchRuleList.GetListWithItems(dataPortal);
 

--- a/Source/Csla.test/Csla.Tests.csproj
+++ b/Source/Csla.test/Csla.Tests.csproj
@@ -74,13 +74,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.StartsWith(&quot;net4&quot;))">
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="!$(TargetFramework.StartsWith(&quot;net4&quot;))">
     <PackageReference Include="System.ComponentModel.Annotations" Version="6.0.0-preview.4.21253.7" />
   </ItemGroup>
 

--- a/Source/Csla.test/DPException/DataPortalExceptionTests.cs
+++ b/Source/Csla.test/DPException/DataPortalExceptionTests.cs
@@ -38,13 +38,18 @@ namespace Csla.Test.DPException
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
 #if DEBUG
     [TestMethod()]
 
     public void CheckInnerExceptionsOnSave()
     {
       IDataPortal<DataPortal.TransactionalRoot> dataPortal = _testDIContext.CreateDataPortal<DataPortal.TransactionalRoot>();
-      TestResults.Reinitialise();
 
       DataPortal.TransactionalRoot root = DataPortal.TransactionalRoot.NewTransactionalRoot(dataPortal);
       root.FirstName = "Billy";
@@ -95,7 +100,6 @@ namespace Csla.Test.DPException
     public void CheckInnerExceptionsOnDelete()
     {
       IDataPortal<DataPortal.TransactionalRoot> dataPortal = _testDIContext.CreateDataPortal<DataPortal.TransactionalRoot>();
-      TestResults.Reinitialise();
 
       string baseException = string.Empty;
       string baseInnerException = string.Empty;
@@ -127,7 +131,6 @@ namespace Csla.Test.DPException
     public void CheckInnerExceptionsOnFetch()
     {
       IDataPortal<DataPortal.TransactionalRoot> dataPortal = _testDIContext.CreateDataPortal<DataPortal.TransactionalRoot>();
-      TestResults.Reinitialise();
 
       string baseException = string.Empty;
       string baseInnerException = string.Empty;

--- a/Source/Csla.test/DataPortal/ArrayTests.cs
+++ b/Source/Csla.test/DataPortal/ArrayTests.cs
@@ -20,6 +20,12 @@ namespace Csla.Test.DataPortal
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod]
     public void Test_DataPortal_Array()
     {
@@ -53,7 +59,6 @@ namespace Csla.Test.DataPortal
     public void Test_DataPortal_Int_Null()
     {
       IDataPortal<ArrayDataPortalClass> dataPortal = _testDIContext.CreateDataPortal<ArrayDataPortalClass>();
-      TestResults.Reinitialise();
 
       try
       {
@@ -73,7 +78,6 @@ namespace Csla.Test.DataPortal
     public void Test_DataPortal_String_Null()
     {
       IDataPortal<ArrayDataPortalClass> dataPortal = _testDIContext.CreateDataPortal<ArrayDataPortalClass>();
-      TestResults.Reinitialise();
 
       try
       {
@@ -93,7 +97,6 @@ namespace Csla.Test.DataPortal
     {
       IChildDataPortal<ArrayDataPortalClass> childDataPortal = _testDIContext.CreateChildDataPortal<ArrayDataPortalClass>();
 
-      TestResults.Reinitialise();
       _ = ArrayDataPortalClass.GetChild(childDataPortal, new int[] { 1, 2, 3 });
       Assert.AreEqual("FetchChild(int[] values)", TestResults.GetResult("Method"));
 
@@ -107,7 +110,6 @@ namespace Csla.Test.DataPortal
     {
       IChildDataPortal<ArrayDataPortalClass> childDataPortal = _testDIContext.CreateChildDataPortal<ArrayDataPortalClass>();
 
-      TestResults.Reinitialise();
       _ = ArrayDataPortalClass.GetChildParams(childDataPortal, 1, 2, 3);
       Assert.AreEqual("FetchChild(int[] values)", TestResults.GetResult("Method"));
 

--- a/Source/Csla.test/DataPortal/AsynchDataPortalTest.cs
+++ b/Source/Csla.test/DataPortal/AsynchDataPortalTest.cs
@@ -50,6 +50,7 @@ namespace Csla.Test.DataPortal
     [TestInitialize]
     public void Setup()
     {
+      TestResults.Reinitialise();
       CurrentCulture = Thread.CurrentThread.CurrentCulture;
       CurrentUICulture = Thread.CurrentThread.CurrentUICulture;
     }
@@ -170,7 +171,7 @@ namespace Csla.Test.DataPortal
     public async Task FetchAsync_WithCriteria()
     {
       IDataPortal<Single2> dataPortal = _testDIContext.CreateDataPortal<Single2>();
-
+      
       var result = await dataPortal.FetchAsync(123);
       Assert.IsNotNull(result);
       Assert.AreEqual(123, result.Id);

--- a/Source/Csla.test/DataPortal/DataPortalTests.cs
+++ b/Source/Csla.test/DataPortal/DataPortalTests.cs
@@ -38,6 +38,12 @@ namespace Csla.Test.DataPortal
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     private static string CONNECTION_STRING = WellKnownValues.DataPortalTestDatabase;
     public void ClearDataBase()
     {
@@ -146,7 +152,6 @@ namespace Csla.Test.DataPortal
       IDataPortal<StronglyTypedDP> dataPortal = _testDIContext.CreateDataPortal<StronglyTypedDP>();
 
       //test strongly-typed DataPortal_Fetch method
-      TestResults.Reinitialise();
       Csla.Test.DataPortal.StronglyTypedDP root = Csla.Test.DataPortal.StronglyTypedDP.GetStronglyTypedDP(456, dataPortal);
 
       Assert.AreEqual("Fetched", TestResults.GetResult("StronglyTypedDP"));
@@ -212,7 +217,6 @@ namespace Csla.Test.DataPortal
 
       try
       {
-        TestResults.Reinitialise();
         DpRoot root = dataPortal.Create(new DpRoot.Criteria());
 
         root.Data = "saved";
@@ -235,8 +239,6 @@ namespace Csla.Test.DataPortal
     [TestMethod]
     public void DataPortalBrokerTests()
     {
-      TestResults.Reinitialise();
-
       var dps = _testDIContext.ServiceProvider.GetRequiredService<Server.DataPortalSelector>();
       var oldServer = Csla.Server.DataPortalBroker.DataPortalServer = new CustomDataPortalServer(dps);
 
@@ -288,7 +290,6 @@ namespace Csla.Test.DataPortal
     {
       IDataPortal<ParentEntity> dataPortal = _testDIContext.CreateDataPortal<ParentEntity>();
 
-      TestResults.Reinitialise();
       ParentEntity parent = ParentEntity.NewParentEntity(dataPortal);
       parent.Data = "something";
 

--- a/Source/Csla.test/DataPortal/InterceptorTests.cs
+++ b/Source/Csla.test/DataPortal/InterceptorTests.cs
@@ -35,11 +35,15 @@ namespace Csla.Test.DataPortal
         )));
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod]
     public void CreateWithIntercept()
     {
-      TestResults.Reinitialise();
-
       var obj = CreateInitializeRoot("abc");
       Assert.AreEqual("Initialize", TestResults.GetResult("Intercept1+InitializeRoot"), "Initialize should have run");
       Assert.AreEqual("Complete", TestResults.GetResult("Intercept2+InitializeRoot"), "Complete should have run");
@@ -51,8 +55,6 @@ namespace Csla.Test.DataPortal
     [TestMethod]
     public void FetchWithIntercept()
     {
-      TestResults.Reinitialise();
-
       var obj = GetInitializeRoot("abc");
       Assert.AreEqual("Initialize", TestResults.GetResult("Intercept1+InitializeRoot"), "Initialize should have run");
       Assert.AreEqual("Complete", TestResults.GetResult("Intercept2+InitializeRoot"), "Complete should have run");
@@ -63,8 +65,6 @@ namespace Csla.Test.DataPortal
     [TestMethod]
     public void FetchListWithIntercept()
     {
-      TestResults.Reinitialise();
-
       var obj = GetInitializeListRoot();
       Assert.AreEqual("Initialize", TestResults.GetResult("Intercept1+InitializeListRoot"), "Initialize should have run");
       Assert.AreEqual("Complete", TestResults.GetResult("Intercept2+InitializeListRoot"), "Complete should have run");
@@ -78,8 +78,6 @@ namespace Csla.Test.DataPortal
     [TestMethod]
     public void InterceptException()
     {
-      TestResults.Reinitialise();
-
       try
       {
         var obj = GetInitializeRoot("boom");
@@ -94,8 +92,6 @@ namespace Csla.Test.DataPortal
     [TestMethod]
     public void UpdateWithIntercept()
     {
-      TestResults.Reinitialise();
-
       var obj = GetInitializeRoot("abc");
       TestResults.Reinitialise();
 
@@ -113,8 +109,6 @@ namespace Csla.Test.DataPortal
     [TestMethod]
     public void UpdateListWithIntercept()
     {
-      TestResults.Reinitialise();
-
       var obj = GetInitializeListRoot();
       TestResults.Reinitialise();
 
@@ -134,8 +128,6 @@ namespace Csla.Test.DataPortal
     public void ExecuteCommandWithIntercept()
     {
       IDataPortal<InterceptorCommand> dataPortal = _testDIContext.CreateDataPortal<InterceptorCommand>();
-
-      TestResults.Reinitialise();
 
       var obj = dataPortal.Create();
       TestResults.Reinitialise();

--- a/Source/Csla.test/DataPortal/LegacySplitTest.cs
+++ b/Source/Csla.test/DataPortal/LegacySplitTest.cs
@@ -23,95 +23,101 @@ using TestMethod = NUnit.Framework.TestAttribute;
 
 namespace Csla.Test.DataPortalTest
 {
-    [TestClass]
-    public class LegacySplitTest
+  [TestClass]
+  public class LegacySplitTest
+  {
+    private static TestDIContext _testDIContext;
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext context)
     {
-        private static TestDIContext _testDIContext;
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
-        {
-            _testDIContext = TestDIContextFactory.CreateDefaultContext();
-        }
-
-        [TestMethod]
-        public void TestDpCreate()
-        {
-            LegacySplit test = NewLegacySplit();
-            Assert.AreEqual("Created", TestResults.GetResult("LegacySplit"));
-        }
-
-        [TestMethod]
-        public void TestDpFetch()
-        {
-            LegacySplit test = GetLegacySplit(5);
-            Assert.AreEqual("Fetched", TestResults.GetResult("LegacySplit"));
-        }
-
-        [TestMethod]
-        public void TestDpInsert()
-        {
-            LegacySplit test = NewLegacySplit();
-            test.Save();
-            Assert.AreEqual("Inserted", TestResults.GetResult("LegacySplit"));
-        }
-
-        [TestMethod]
-        public void TestDpUpdate()
-        {
-            LegacySplit test = null;
-            try
-            {
-                test = NewLegacySplit();
-                test = test.Save();
-                test.Id = 5;
-            }
-            catch { Assert.Inconclusive(); }
-            test.Save();
-            Assert.AreEqual("Updated", TestResults.GetResult("LegacySplit"));
-        }
-
-        [TestMethod]
-        public void TestDpDelete()
-        {
-            DeleteLegacySplit(5);
-            Assert.AreEqual("Deleted", TestResults.GetResult("LegacySplit"));
-        }
-
-        [TestMethod]
-        public void TestDpDeleteSelf()
-        {
-            LegacySplit test = null;
-            try
-            {
-                test = NewLegacySplit();
-                test = test.Save();
-                test.Delete();
-            }
-            catch { Assert.Inconclusive(); }
-            test.Save();
-            Assert.AreEqual("SelfDeleted", TestResults.GetResult("LegacySplit"));
-        }
-
-        private LegacySplit NewLegacySplit()
-        {
-            IDataPortal<LegacySplit> dataPortal = _testDIContext.CreateDataPortal<LegacySplit>();
-
-            return dataPortal.Create();
-        }
-
-        private LegacySplit GetLegacySplit(int id)
-        {
-            IDataPortal<LegacySplit> dataPortal = _testDIContext.CreateDataPortal<LegacySplit>();
-
-            return dataPortal.Fetch(new LegacySplitBase<LegacySplit>.Criteria(id));
-        }
-
-        private void DeleteLegacySplit(int id)
-        {
-            IDataPortal<LegacySplit> dataPortal = _testDIContext.CreateDataPortal<LegacySplit>();
-
-            dataPortal.Delete(new LegacySplitBase<LegacySplit>.Criteria(id));
-        }
+      _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
+
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
+    [TestMethod]
+    public void TestDpCreate()
+    {
+      LegacySplit test = NewLegacySplit();
+      Assert.AreEqual("Created", TestResults.GetResult("LegacySplit"));
+    }
+
+    [TestMethod]
+    public void TestDpFetch()
+    {
+      LegacySplit test = GetLegacySplit(5);
+      Assert.AreEqual("Fetched", TestResults.GetResult("LegacySplit"));
+    }
+
+    [TestMethod]
+    public void TestDpInsert()
+    {
+      LegacySplit test = NewLegacySplit();
+      test.Save();
+      Assert.AreEqual("Inserted", TestResults.GetResult("LegacySplit"));
+    }
+
+    [TestMethod]
+    public void TestDpUpdate()
+    {
+      LegacySplit test = null;
+      try
+      {
+        test = NewLegacySplit();
+        test = test.Save();
+        test.Id = 5;
+      }
+      catch { Assert.Inconclusive(); }
+      test.Save();
+      Assert.AreEqual("Updated", TestResults.GetResult("LegacySplit"));
+    }
+
+    [TestMethod]
+    public void TestDpDelete()
+    {
+      DeleteLegacySplit(5);
+      Assert.AreEqual("Deleted", TestResults.GetResult("LegacySplit"));
+    }
+
+    [TestMethod]
+    public void TestDpDeleteSelf()
+    {
+      LegacySplit test = null;
+      try
+      {
+        test = NewLegacySplit();
+        test = test.Save();
+        test.Delete();
+      }
+      catch { Assert.Inconclusive(); }
+      test.Save();
+      Assert.AreEqual("SelfDeleted", TestResults.GetResult("LegacySplit"));
+    }
+
+    private LegacySplit NewLegacySplit()
+    {
+      IDataPortal<LegacySplit> dataPortal = _testDIContext.CreateDataPortal<LegacySplit>();
+
+      return dataPortal.Create();
+    }
+
+    private LegacySplit GetLegacySplit(int id)
+    {
+      IDataPortal<LegacySplit> dataPortal = _testDIContext.CreateDataPortal<LegacySplit>();
+
+      return dataPortal.Fetch(new LegacySplitBase<LegacySplit>.Criteria(id));
+    }
+
+    private void DeleteLegacySplit(int id)
+    {
+      IDataPortal<LegacySplit> dataPortal = _testDIContext.CreateDataPortal<LegacySplit>();
+
+      dataPortal.Delete(new LegacySplitBase<LegacySplit>.Criteria(id));
+    }
+  }
 }

--- a/Source/Csla.test/DataPortal/LegacyTest.cs
+++ b/Source/Csla.test/DataPortal/LegacyTest.cs
@@ -23,95 +23,101 @@ using TestMethod = NUnit.Framework.TestAttribute;
 
 namespace Csla.Test.DataPortalTest
 {
-    [TestClass]
-    public class LegacyTest
+  [TestClass]
+  public class LegacyTest
+  {
+    private static TestDIContext _testDIContext;
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext context)
     {
-        private static TestDIContext _testDIContext;
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
-        {
-            _testDIContext = TestDIContextFactory.CreateDefaultContext();
-        }
-
-        [TestMethod]
-        public void TestDpCreate()
-        {
-            Legacy test = NewLegacy();
-            Assert.AreEqual("Created", TestResults.GetResult("Legacy"));
-        }
-        [TestMethod]
-        public void TestDpFetch()
-        {
-            Legacy test = GetLegacy(5);
-            Assert.AreEqual("Fetched", TestResults.GetResult("Legacy"));
-        }
-        [TestMethod]
-        public void TestDpInsert()
-        {
-            Legacy test = null;
-            try
-            {
-                test = NewLegacy();
-            }
-            catch { Assert.Inconclusive(); }
-            test.Save();
-            Assert.AreEqual("Inserted", TestResults.GetResult("Legacy"));
-        }
-        [TestMethod]
-        public void TestDpUpdate()
-        {
-            Legacy test = null;
-            try
-            {
-                test = NewLegacy();
-                test = test.Save();
-                test.Id = 5;
-            }
-            catch { Assert.Inconclusive(); }
-            test.Save();
-            Assert.AreEqual("Updated", TestResults.GetResult("Legacy"));
-        }
-        [TestMethod]
-        public void TestDpDelete()
-        {
-            DeleteLegacy(5);
-            Assert.AreEqual("Deleted", TestResults.GetResult("Legacy"));
-        }
-        [TestMethod]
-        public void TestDpDeleteSelf()
-        {
-            Legacy test = null;
-            try
-            {
-                test = NewLegacy();
-                test = test.Save();
-                test.Delete();
-            }
-            catch { Assert.Inconclusive(); }
-            test.Save();
-            Assert.AreEqual("SelfDeleted", TestResults.GetResult("Legacy"));
-        }
-        
-        private Legacy NewLegacy()
-        {
-            IDataPortal<Legacy> dataPortal = _testDIContext.CreateDataPortal<Legacy>();
-
-            return dataPortal.Create();
-        }
-
-        private Legacy GetLegacy(int id)
-        {
-            IDataPortal<Legacy> dataPortal = _testDIContext.CreateDataPortal<Legacy>();
-
-            return dataPortal.Fetch(new Legacy.Criteria(id));
-        }
-
-        private void DeleteLegacy(int id)
-        {
-            IDataPortal<Legacy> dataPortal = _testDIContext.CreateDataPortal<Legacy>();
-
-            dataPortal.Delete(new Legacy.Criteria(id));
-        }
+      _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
+
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
+    [TestMethod]
+    public void TestDpCreate()
+    {
+      Legacy test = NewLegacy();
+      Assert.AreEqual("Created", TestResults.GetResult("Legacy"));
+    }
+    [TestMethod]
+    public void TestDpFetch()
+    {
+      Legacy test = GetLegacy(5);
+      Assert.AreEqual("Fetched", TestResults.GetResult("Legacy"));
+    }
+    [TestMethod]
+    public void TestDpInsert()
+    {
+      Legacy test = null;
+      try
+      {
+        test = NewLegacy();
+      }
+      catch { Assert.Inconclusive(); }
+      test.Save();
+      Assert.AreEqual("Inserted", TestResults.GetResult("Legacy"));
+    }
+    [TestMethod]
+    public void TestDpUpdate()
+    {
+      Legacy test = null;
+      try
+      {
+        test = NewLegacy();
+        test = test.Save();
+        test.Id = 5;
+      }
+      catch { Assert.Inconclusive(); }
+      test.Save();
+      Assert.AreEqual("Updated", TestResults.GetResult("Legacy"));
+    }
+    [TestMethod]
+    public void TestDpDelete()
+    {
+      DeleteLegacy(5);
+      Assert.AreEqual("Deleted", TestResults.GetResult("Legacy"));
+    }
+    [TestMethod]
+    public void TestDpDeleteSelf()
+    {
+      Legacy test = null;
+      try
+      {
+        test = NewLegacy();
+        test = test.Save();
+        test.Delete();
+      }
+      catch { Assert.Inconclusive(); }
+      test.Save();
+      Assert.AreEqual("SelfDeleted", TestResults.GetResult("Legacy"));
+    }
+
+    private Legacy NewLegacy()
+    {
+      IDataPortal<Legacy> dataPortal = _testDIContext.CreateDataPortal<Legacy>();
+
+      return dataPortal.Create();
+    }
+
+    private Legacy GetLegacy(int id)
+    {
+      IDataPortal<Legacy> dataPortal = _testDIContext.CreateDataPortal<Legacy>();
+
+      return dataPortal.Fetch(new Legacy.Criteria(id));
+    }
+
+    private void DeleteLegacy(int id)
+    {
+      IDataPortal<Legacy> dataPortal = _testDIContext.CreateDataPortal<Legacy>();
+
+      dataPortal.Delete(new Legacy.Criteria(id));
+    }
+  }
 }

--- a/Source/Csla.test/DataPortal/SingleOverloadTest.cs
+++ b/Source/Csla.test/DataPortal/SingleOverloadTest.cs
@@ -23,49 +23,55 @@ using TestMethod = NUnit.Framework.TestAttribute;
 
 namespace Csla.Test.DataPortalTest
 {
-    [TestClass]
-    public class SingleOverloadTest
+  [TestClass]
+  public class SingleOverloadTest
+  {
+    private static TestDIContext _testDIContext;
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext context)
     {
-        private static TestDIContext _testDIContext;
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
-        {
-            _testDIContext = TestDIContextFactory.CreateDefaultContext();
-        }
-
-        [TestMethod]
-        public void TestDpCreate()
-        {
-            IDataPortal<SingleOverload> dataPortal = _testDIContext.CreateDataPortal<SingleOverload>();
-
-            SingleOverload test = SingleOverload.NewObject(dataPortal);
-            Assert.AreEqual("Created0", TestResults.GetResult("SingleOverload"));
-        }
-        [TestMethod]
-        public void TestDpCreateWithCriteria()
-        {
-            IDataPortal<SingleOverload> dataPortal = _testDIContext.CreateDataPortal<SingleOverload>();
-
-            SingleOverload test = SingleOverload.NewObjectWithCriteria(dataPortal);
-            Assert.AreEqual("Created1", TestResults.GetResult("SingleOverload"));
-        }
-        [TestMethod]
-        public void TestDpFetch()
-        {
-            IDataPortal<SingleOverload> dataPortal = _testDIContext.CreateDataPortal<SingleOverload>();
-
-            SingleOverload test = SingleOverload.GetObject(5, dataPortal);
-            Assert.AreEqual("Fetched", TestResults.GetResult("SingleOverload"));
-        }
-        [TestMethod]
-        public void TestDpDelete()
-        {
-            IDataPortal<SingleOverload> dataPortal = _testDIContext.CreateDataPortal<SingleOverload>();
-
-            SingleOverload.DeleteObject(5, dataPortal);
-            Assert.AreEqual("Deleted", TestResults.GetResult("SingleOverload"));
-        }
-
+      _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
+
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
+    [TestMethod]
+    public void TestDpCreate()
+    {
+      IDataPortal<SingleOverload> dataPortal = _testDIContext.CreateDataPortal<SingleOverload>();
+
+      SingleOverload test = SingleOverload.NewObject(dataPortal);
+      Assert.AreEqual("Created0", TestResults.GetResult("SingleOverload"));
+    }
+    [TestMethod]
+    public void TestDpCreateWithCriteria()
+    {
+      IDataPortal<SingleOverload> dataPortal = _testDIContext.CreateDataPortal<SingleOverload>();
+
+      SingleOverload test = SingleOverload.NewObjectWithCriteria(dataPortal);
+      Assert.AreEqual("Created1", TestResults.GetResult("SingleOverload"));
+    }
+    [TestMethod]
+    public void TestDpFetch()
+    {
+      IDataPortal<SingleOverload> dataPortal = _testDIContext.CreateDataPortal<SingleOverload>();
+
+      SingleOverload test = SingleOverload.GetObject(5, dataPortal);
+      Assert.AreEqual("Fetched", TestResults.GetResult("SingleOverload"));
+    }
+    [TestMethod]
+    public void TestDpDelete()
+    {
+      IDataPortal<SingleOverload> dataPortal = _testDIContext.CreateDataPortal<SingleOverload>();
+
+      SingleOverload.DeleteObject(5, dataPortal);
+      Assert.AreEqual("Deleted", TestResults.GetResult("SingleOverload"));
+    }
+
+  }
 }

--- a/Source/Csla.test/DataPortal/SingleTest.cs
+++ b/Source/Csla.test/DataPortal/SingleTest.cs
@@ -23,95 +23,101 @@ using TestMethod = NUnit.Framework.TestAttribute;
 
 namespace Csla.Test.DataPortalTest
 {
-    [TestClass]
-    public class SingleTest
+  [TestClass]
+  public class SingleTest
+  {
+    private static TestDIContext _testDIContext;
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext context)
     {
-      private static TestDIContext _testDIContext;
+      _testDIContext = TestDIContextFactory.CreateDefaultContext();
+    }
 
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
-        {
-            _testDIContext = TestDIContextFactory.CreateDefaultContext();
-        }
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
 
-        [TestMethod]
-        public void TestDpCreate()
-        {
-            Single test = NewSingle();
-            Assert.AreEqual("Created", TestResults.GetResult("Single"));
-        }
-        [TestMethod]
-        public void TestDpFetch()
-        {
-            Single test = GetSingle(5);
-            Assert.AreEqual("Fetched", TestResults.GetResult("Single"));
-        }
-        [TestMethod]
-        public void TestDpInsert()
-        {
-            Single test = null;
-            try
-            {
-                test = NewSingle();
-            }
-            catch { Assert.Inconclusive(); }
-            test.Save();
-            Assert.AreEqual("Inserted", TestResults.GetResult("Single"));
-        }
-        [TestMethod]
-        public void TestDpUpdate()
-        {
-            Single test = null;
-            try
-            {
-                test = NewSingle();
-                test = test.Save();
-                test.Id = 5;
-            }
-            catch { Assert.Inconclusive(); }
-            test.Save();
-            Assert.AreEqual("Updated", TestResults.GetResult("Single"));
-        }
-        [TestMethod]
-        public void TestDpDelete()
-        {
-            DeleteSingle(5);
-            Assert.AreEqual("Deleted", TestResults.GetResult("Single"));
-        }
-        [TestMethod]
-        public void TestDpDeleteSelf()
-        {
-            Single test = null;
-            try
-            {
-                test = NewSingle();
-                test = test.Save();
-                test.Delete();
-            }
-            catch { Assert.Inconclusive(); }
-            test.Save();
-            Assert.AreEqual("SelfDeleted", TestResults.GetResult("Single"));
-        }
+    [TestMethod]
+    public void TestDpCreate()
+    {
+      Single test = NewSingle();
+      Assert.AreEqual("Created", TestResults.GetResult("Single"));
+    }
+    [TestMethod]
+    public void TestDpFetch()
+    {
+      Single test = GetSingle(5);
+      Assert.AreEqual("Fetched", TestResults.GetResult("Single"));
+    }
+    [TestMethod]
+    public void TestDpInsert()
+    {
+      Single test = null;
+      try
+      {
+        test = NewSingle();
+      }
+      catch { Assert.Inconclusive(); }
+      test.Save();
+      Assert.AreEqual("Inserted", TestResults.GetResult("Single"));
+    }
+    [TestMethod]
+    public void TestDpUpdate()
+    {
+      Single test = null;
+      try
+      {
+        test = NewSingle();
+        test = test.Save();
+        test.Id = 5;
+      }
+      catch { Assert.Inconclusive(); }
+      test.Save();
+      Assert.AreEqual("Updated", TestResults.GetResult("Single"));
+    }
+    [TestMethod]
+    public void TestDpDelete()
+    {
+      DeleteSingle(5);
+      Assert.AreEqual("Deleted", TestResults.GetResult("Single"));
+    }
+    [TestMethod]
+    public void TestDpDeleteSelf()
+    {
+      Single test = null;
+      try
+      {
+        test = NewSingle();
+        test = test.Save();
+        test.Delete();
+      }
+      catch { Assert.Inconclusive(); }
+      test.Save();
+      Assert.AreEqual("SelfDeleted", TestResults.GetResult("Single"));
+    }
 
-        private Single NewSingle()
-        {
-            IDataPortal<Single> dataPortal = _testDIContext.CreateDataPortal<Single>();
+    private Single NewSingle()
+    {
+      IDataPortal<Single> dataPortal = _testDIContext.CreateDataPortal<Single>();
 
-            return dataPortal.Create();
-        }
+      return dataPortal.Create();
+    }
 
-        private Single GetSingle(int id)
-        {
-            IDataPortal<Single> dataPortal = _testDIContext.CreateDataPortal<Single>();
+    private Single GetSingle(int id)
+    {
+      IDataPortal<Single> dataPortal = _testDIContext.CreateDataPortal<Single>();
 
-            return dataPortal.Fetch(id);
-        }
+      return dataPortal.Fetch(id);
+    }
 
-        private void DeleteSingle(int id)
-        {
-            IDataPortal<Single> dataPortal = _testDIContext.CreateDataPortal<Single>();
+    private void DeleteSingle(int id)
+    {
+      IDataPortal<Single> dataPortal = _testDIContext.CreateDataPortal<Single>();
 
-            dataPortal.Delete(id);
-        }
+      dataPortal.Delete(id);
+    }
   }
 }

--- a/Source/Csla.test/DataPortal/SplitOverloadTest.cs
+++ b/Source/Csla.test/DataPortal/SplitOverloadTest.cs
@@ -23,49 +23,55 @@ using TestMethod = NUnit.Framework.TestAttribute;
 
 namespace Csla.Test.DataPortalTest
 {
-    [TestClass]
-    public class SplitOverloadTest
+  [TestClass]
+  public class SplitOverloadTest
+  {
+    private static TestDIContext _testDIContext;
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext context)
     {
-        private static TestDIContext _testDIContext;
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
-        {
-            _testDIContext = TestDIContextFactory.CreateDefaultContext();
-        }
-
-        [TestMethod]
-        public void TestDpCreate()
-        {
-            IDataPortal<SplitOverload> dataPortal = _testDIContext.CreateDataPortal<SplitOverload>();
-
-            SplitOverload test = SplitOverload.NewObject(dataPortal);
-            Assert.AreEqual("Created", TestResults.GetResult("SplitOverload"));
-        }
-        [TestMethod]
-        public void TestDpCreateWithCriteria()
-        {
-            IDataPortal<SplitOverload> dataPortal = _testDIContext.CreateDataPortal<SplitOverload>();
-
-            SplitOverload test = SplitOverload.NewObjectWithCriteria(dataPortal);
-            Assert.AreEqual("Created1", TestResults.GetResult("SplitOverload"));
-        }
-        [TestMethod]
-        public void TestDpFetch()
-        {
-            IDataPortal<SplitOverload> dataPortal = _testDIContext.CreateDataPortal<SplitOverload>();
-      
-            SplitOverload test = SplitOverload.GetObject(5, dataPortal);
-            Assert.AreEqual("Fetched", TestResults.GetResult("SplitOverload"));
-        }
-        [TestMethod]
-        public void TestDpDelete()
-        {
-            IDataPortal<SplitOverload> dataPortal = _testDIContext.CreateDataPortal<SplitOverload>();
-      
-            SplitOverload.DeleteObject(5, dataPortal);
-            Assert.AreEqual("Deleted", TestResults.GetResult("SplitOverload"));
-        }
-
+      _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
+
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
+    [TestMethod]
+    public void TestDpCreate()
+    {
+      IDataPortal<SplitOverload> dataPortal = _testDIContext.CreateDataPortal<SplitOverload>();
+
+      SplitOverload test = SplitOverload.NewObject(dataPortal);
+      Assert.AreEqual("Created", TestResults.GetResult("SplitOverload"));
+    }
+    [TestMethod]
+    public void TestDpCreateWithCriteria()
+    {
+      IDataPortal<SplitOverload> dataPortal = _testDIContext.CreateDataPortal<SplitOverload>();
+
+      SplitOverload test = SplitOverload.NewObjectWithCriteria(dataPortal);
+      Assert.AreEqual("Created1", TestResults.GetResult("SplitOverload"));
+    }
+    [TestMethod]
+    public void TestDpFetch()
+    {
+      IDataPortal<SplitOverload> dataPortal = _testDIContext.CreateDataPortal<SplitOverload>();
+
+      SplitOverload test = SplitOverload.GetObject(5, dataPortal);
+      Assert.AreEqual("Fetched", TestResults.GetResult("SplitOverload"));
+    }
+    [TestMethod]
+    public void TestDpDelete()
+    {
+      IDataPortal<SplitOverload> dataPortal = _testDIContext.CreateDataPortal<SplitOverload>();
+
+      SplitOverload.DeleteObject(5, dataPortal);
+      Assert.AreEqual("Deleted", TestResults.GetResult("SplitOverload"));
+    }
+
+  }
 }

--- a/Source/Csla.test/DataPortal/SplitTest.cs
+++ b/Source/Csla.test/DataPortal/SplitTest.cs
@@ -23,87 +23,93 @@ using TestMethod = NUnit.Framework.TestAttribute;
 
 namespace Csla.Test.DataPortalTest
 {
-    [TestClass]
-    public class SplitTest
+  [TestClass]
+  public class SplitTest
+  {
+    private static TestDIContext _testDIContext;
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext context)
     {
-        private static TestDIContext _testDIContext;
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
-        {
-            _testDIContext = TestDIContextFactory.CreateDefaultContext();
-        }
-
-        [TestMethod]
-        public void TestDpCreate()
-        {
-            IDataPortal<Split> dataPortal = _testDIContext.CreateDataPortal<Split>();
-
-            Split test = Split.NewObject(dataPortal);
-            Assert.AreEqual("Created", TestResults.GetResult("Split"));
-        }
-        [TestMethod]
-        public void TestDpFetch()
-        {
-            IDataPortal<Split> dataPortal = _testDIContext.CreateDataPortal<Split>();
-
-            Split test = Split.GetObject(5, dataPortal);
-            Assert.AreEqual("Fetched", TestResults.GetResult("Split"));
-        }
-        [TestMethod]
-        public void TestDpInsert()
-        {
-            IDataPortal<Split> dataPortal = _testDIContext.CreateDataPortal<Split>();
-
-            Split test = null;
-            try
-            {
-                test = Split.NewObject(dataPortal);
-            }
-            catch { Assert.Inconclusive(); }
-            test.Save();
-            Assert.AreEqual("Inserted", TestResults.GetResult("Split"));
-        }
-        [TestMethod]
-        public void TestDpUpdate()
-        {
-            IDataPortal<Split> dataPortal = _testDIContext.CreateDataPortal<Split>();
-
-            Split test = null;
-            try
-            {
-                test = Split.NewObject(dataPortal);
-                test = test.Save();
-                test.Id = 5;
-            }
-            catch { Assert.Inconclusive(); }
-            test.Save();
-            Assert.AreEqual("Updated", TestResults.GetResult("Split"));
-        }
-        [TestMethod]
-        public void TestDpDelete()
-        {
-            IDataPortal<Split> dataPortal = _testDIContext.CreateDataPortal<Split>();
-
-            Split.DeleteObject(5, dataPortal);
-            Assert.AreEqual("Deleted", TestResults.GetResult("Split"));
-        }
-        [TestMethod]
-        public void TestDpDeleteSelf()
-        {
-            IDataPortal<Split> dataPortal = _testDIContext.CreateDataPortal<Split>();
-
-            Split test = null;
-            try
-            {
-                test = Split.NewObject(dataPortal);
-                test = test.Save();
-                test.Delete();
-            }
-            catch { Assert.Inconclusive(); }
-            test.Save();
-            Assert.AreEqual("SelfDeleted", TestResults.GetResult("Split"));
-        }
-
+      _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
+
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
+    [TestMethod]
+    public void TestDpCreate()
+    {
+      IDataPortal<Split> dataPortal = _testDIContext.CreateDataPortal<Split>();
+
+      Split test = Split.NewObject(dataPortal);
+      Assert.AreEqual("Created", TestResults.GetResult("Split"));
+    }
+    [TestMethod]
+    public void TestDpFetch()
+    {
+      IDataPortal<Split> dataPortal = _testDIContext.CreateDataPortal<Split>();
+
+      Split test = Split.GetObject(5, dataPortal);
+      Assert.AreEqual("Fetched", TestResults.GetResult("Split"));
+    }
+    [TestMethod]
+    public void TestDpInsert()
+    {
+      IDataPortal<Split> dataPortal = _testDIContext.CreateDataPortal<Split>();
+
+      Split test = null;
+      try
+      {
+        test = Split.NewObject(dataPortal);
+      }
+      catch { Assert.Inconclusive(); }
+      test.Save();
+      Assert.AreEqual("Inserted", TestResults.GetResult("Split"));
+    }
+    [TestMethod]
+    public void TestDpUpdate()
+    {
+      IDataPortal<Split> dataPortal = _testDIContext.CreateDataPortal<Split>();
+
+      Split test = null;
+      try
+      {
+        test = Split.NewObject(dataPortal);
+        test = test.Save();
+        test.Id = 5;
+      }
+      catch { Assert.Inconclusive(); }
+      test.Save();
+      Assert.AreEqual("Updated", TestResults.GetResult("Split"));
+    }
+    [TestMethod]
+    public void TestDpDelete()
+    {
+      IDataPortal<Split> dataPortal = _testDIContext.CreateDataPortal<Split>();
+
+      Split.DeleteObject(5, dataPortal);
+      Assert.AreEqual("Deleted", TestResults.GetResult("Split"));
+    }
+    [TestMethod]
+    public void TestDpDeleteSelf()
+    {
+      IDataPortal<Split> dataPortal = _testDIContext.CreateDataPortal<Split>();
+
+      Split test = null;
+      try
+      {
+        test = Split.NewObject(dataPortal);
+        test = test.Save();
+        test.Delete();
+      }
+      catch { Assert.Inconclusive(); }
+      test.Save();
+      Assert.AreEqual("SelfDeleted", TestResults.GetResult("Split"));
+    }
+
+  }
 }

--- a/Source/Csla.test/DataPortalChild/DataPortalChildTests.cs
+++ b/Source/Csla.test/DataPortalChild/DataPortalChildTests.cs
@@ -34,6 +34,12 @@ namespace Csla.Test.DataPortalChild
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod]
     public void CreateAndSaveChild()
     {

--- a/Source/Csla.test/EditableRootList/EditableRootListTests.cs
+++ b/Source/Csla.test/EditableRootList/EditableRootListTests.cs
@@ -33,6 +33,12 @@ namespace Csla.Test.EditableRootList
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod]
     public void AddItem()
     {
@@ -49,7 +55,6 @@ namespace Csla.Test.EditableRootList
     {
       IDataPortal<ERlist> dataPortal = _testDIContext.CreateDataPortal<ERlist>();
 
-      TestResults.Reinitialise();
       _isListSaved = false;
       ERlist list = dataPortal.Create();
       ERitem item = list.AddNew();
@@ -69,7 +74,6 @@ namespace Csla.Test.EditableRootList
       IDataPortal<ERlist> dataPortal = _testDIContext.CreateDataPortal<ERlist>();
       IDataPortal<ERitem> itemDataPortal = _testDIContext.CreateDataPortal<ERitem>();
 
-      TestResults.Reinitialise();
       _isListSaved = false;
 
       ERlist list = dataPortal.Create();
@@ -105,7 +109,6 @@ namespace Csla.Test.EditableRootList
     public void InsertItem()
     {
       IDataPortal<ERlist> dataPortal = _testDIContext.CreateDataPortal<ERlist>();
-      TestResults.Reinitialise();
 
       _isListSaved = false;
 
@@ -129,7 +132,6 @@ namespace Csla.Test.EditableRootList
     {
       IDataPortal<ERlist> dataPortal = _testDIContext.CreateDataPortal<ERlist>();
       IDataPortal<ERitem> itemDataPortal = _testDIContext.CreateDataPortal<ERitem>();
-      TestResults.Reinitialise();
 
       _isListSaved = false;
 

--- a/Source/Csla.test/FieldManager/Async/ChildUpdateTests.cs
+++ b/Source/Csla.test/FieldManager/Async/ChildUpdateTests.cs
@@ -32,6 +32,12 @@ namespace Csla.Test.FieldManager.Async
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod]
     public async Task CreateAndSaveChildAsync()
     {

--- a/Source/Csla.test/FieldManager/ChildUpdateTests.cs
+++ b/Source/Csla.test/FieldManager/ChildUpdateTests.cs
@@ -31,6 +31,12 @@ namespace Csla.Test.FieldManager
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod]
     public void FetchAndSaveChild()
     {

--- a/Source/Csla.test/GraphMerge/GraphMergerTests.cs
+++ b/Source/Csla.test/GraphMerge/GraphMergerTests.cs
@@ -36,6 +36,12 @@ namespace Csla.Test.GraphMerge
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod]
     public void MergeInsert()
     {

--- a/Source/Csla.test/GraphMerge/IdentityTests.cs
+++ b/Source/Csla.test/GraphMerge/IdentityTests.cs
@@ -36,6 +36,12 @@ namespace Csla.Test.GraphMerge
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod]
     public void IdentityInitializedBusinessBase()
     {

--- a/Source/Csla.test/IO/DPMethodOverloadTests.cs
+++ b/Source/Csla.test/IO/DPMethodOverloadTests.cs
@@ -34,13 +34,17 @@ namespace Csla.Test.IO
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod]
     [TestCategory("SkipWhenLiveUnitTesting")]
     public void CreateNoCriteria()
     {
       IDataPortal<TestBizObj> dataPortal = _testDIContext.CreateDataPortal<TestBizObj>();
-
-      TestResults.Reinitialise();
 
       TestBizObj obj;
 
@@ -55,8 +59,6 @@ namespace Csla.Test.IO
     {
       IDataPortal<TestBizObj> dataPortal = _testDIContext.CreateDataPortal<TestBizObj>();
 
-      TestResults.Reinitialise();
-
       TestBizObj obj;
 
       obj = TestBizObj.NewCriteria(dataPortal);
@@ -69,8 +71,6 @@ namespace Csla.Test.IO
     public void CreateWithOtherCriteria()
     {
       IDataPortal<TestBizObj> dataPortal = _testDIContext.CreateDataPortal<TestBizObj>();
-
-      TestResults.Reinitialise();
 
       TestBizObj obj;
 
@@ -85,8 +85,6 @@ namespace Csla.Test.IO
     {
       IDataPortal<TestBizObj> dataPortal = _testDIContext.CreateDataPortal<TestBizObj>();
 
-      TestResults.Reinitialise();
-
       TestBizObj obj;
 
       obj = TestBizObj.GetNullCriteria(dataPortal);
@@ -99,8 +97,6 @@ namespace Csla.Test.IO
     public void FetchNoCriteria()
     {
       IDataPortal<TestBizObj> dataPortal = _testDIContext.CreateDataPortal<TestBizObj>();
-
-      TestResults.Reinitialise();
 
       TestBizObj obj;
 
@@ -115,8 +111,6 @@ namespace Csla.Test.IO
     {
       IDataPortal<TestBizObj> dataPortal = _testDIContext.CreateDataPortal<TestBizObj>();
 
-      TestResults.Reinitialise();
-
       TestBizObj obj;
 
       obj = TestBizObj.GetCriteria(dataPortal);
@@ -129,8 +123,6 @@ namespace Csla.Test.IO
     public void FetchWithOtherCriteria()
     {
       IDataPortal<TestBizObj> dataPortal = _testDIContext.CreateDataPortal<TestBizObj>();
-
-      TestResults.Reinitialise();
 
       TestBizObj obj;
 

--- a/Source/Csla.test/IO/IOTests.cs
+++ b/Source/Csla.test/IO/IOTests.cs
@@ -22,155 +22,149 @@ using TestMethod = NUnit.Framework.TestAttribute;
 
 namespace Csla.Test.IO
 {
-    [TestClass]
-    public class IOTests
+  [TestClass]
+  public class IOTests
+  {
+    private static TestDIContext _testDIContext;
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext context)
     {
-        private static TestDIContext _testDIContext;
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
-        {
-            _testDIContext = TestDIContextFactory.CreateDefaultContext();
-        }
-
-        [TestMethod]
-        [TestCategory("SkipWhenLiveUnitTesting")]
-        public void SaveNewRoot()
-        {
-            TestResults.Reinitialise();
-            Csla.Test.Basic.Root root = NewRoot();
-
-            root.Data = "saved";
-            Assert.AreEqual("saved", root.Data);
-            Assert.AreEqual(true, root.IsDirty);
-            Assert.AreEqual(true, root.IsValid);
-
-            TestResults.Reinitialise();
-            root = root.Save();
-
-            Assert.IsNotNull(root);
-            //fails because no call is being made to DataPortal_Insert in Root.DataPortal_Update if IsDeleted == false and IsNew == true
-            Assert.AreEqual("Inserted", TestResults.GetResult("Root"));  
-            Assert.AreEqual("saved", root.Data);
-            Assert.AreEqual(false, root.IsNew, "IsNew");
-            Assert.AreEqual(false, root.IsDeleted, "IsDeleted");
-            Assert.AreEqual(false, root.IsDirty, "IsDirty");
-        }
-
-        [TestMethod]
-        [TestCategory("SkipWhenLiveUnitTesting")]
-        public void SaveOldRoot()
-        {
-            TestResults.Reinitialise();
-            Csla.Test.Basic.Root root = GetRoot("old");
-
-            root.Data = "saved";
-            Assert.AreEqual("saved", root.Data);
-            Assert.AreEqual(true, root.IsDirty, "IsDirty");
-            Assert.AreEqual(true, root.IsValid, "IsValid");
-
-            TestResults.Reinitialise();
-            root = root.Save();
-
-            Assert.IsNotNull(root);
-            Assert.AreEqual("Updated", TestResults.GetResult("Root"));
-            Assert.AreEqual("saved", root.Data);
-            Assert.AreEqual(false, root.IsNew, "IsNew");
-            Assert.AreEqual(false, root.IsDeleted, "IsDeleted");
-            Assert.AreEqual(false, root.IsDirty, "IsDirty");
-        }
-
-        [TestMethod]
-        [TestCategory("SkipWhenLiveUnitTesting")]
-        public void LoadRoot()
-        {
-            TestResults.Reinitialise();
-            Csla.Test.Basic.Root root = GetRoot("loaded");
-            Assert.IsNotNull(root);
-            Assert.AreEqual("Fetched", TestResults.GetResult("Root"));
-            Assert.AreEqual("loaded", root.Data);
-            Assert.AreEqual(false, root.IsNew);
-            Assert.AreEqual(false, root.IsDeleted);
-            Assert.AreEqual(false, root.IsDirty);
-            Assert.AreEqual(true, root.IsValid);
-        }
-
-        [TestMethod]
-        [TestCategory("SkipWhenLiveUnitTesting")]
-        public void DeleteNewRoot()
-        {
-            TestResults.Reinitialise();
-            Csla.Test.Basic.Root root = NewRoot();
-
-            TestResults.Reinitialise();
-            root.Delete();
-            Assert.AreEqual(true, root.IsNew);
-            Assert.AreEqual(true, root.IsDeleted);
-            Assert.AreEqual(true, root.IsDirty);
-
-            root = root.Save();
-            Assert.IsNotNull(root);
-            Assert.AreEqual("", TestResults.GetResult("Root"));
-            Assert.AreEqual(true, root.IsNew);
-            Assert.AreEqual(false, root.IsDeleted);
-            Assert.AreEqual(true, root.IsDirty);
-        }
-
-        [TestMethod]
-        [TestCategory("SkipWhenLiveUnitTesting")]
-        public void DeleteOldRoot()
-        {
-            TestResults.Reinitialise();
-            Csla.Test.Basic.Root root = GetRoot("old");
-
-            TestResults.Reinitialise();
-            root.Delete();
-            Assert.AreEqual(false, root.IsNew);
-            Assert.AreEqual(true, root.IsDeleted);
-            Assert.AreEqual(true, root.IsDirty);
-
-            root = root.Save();
-            Assert.IsNotNull(root);
-            Assert.AreEqual("Deleted self", TestResults.GetResult("Root"));
-            Assert.AreEqual(true, root.IsNew);
-            Assert.AreEqual(false, root.IsDeleted);
-            Assert.AreEqual(true, root.IsDirty);
-        }
-
-        [TestMethod]
-        [TestCategory("SkipWhenLiveUnitTesting")]
-        public void DeleteRootImmediate()
-        {
-            TestResults.Reinitialise();
-            DeleteRoot("test");
-            Assert.AreEqual("Deleted", TestResults.GetResult("Root"));
-        }
-
-        [TestCleanup]
-        public void ClearContextsAfterEachTest()
-        {
-            TestResults.Reinitialise();
-        }
-
-        private Basic.Root NewRoot()
-        {
-            IDataPortal<Basic.Root> dataPortal = _testDIContext.CreateDataPortal<Basic.Root>();
-
-            return dataPortal.Create(new Basic.Root.Criteria());
-        }
-
-        private Basic.Root GetRoot(string data)
-        {
-            IDataPortal<Basic.Root> dataPortal = _testDIContext.CreateDataPortal<Basic.Root>();
-
-            return dataPortal.Fetch(new Basic.Root.Criteria(data));
-        }
-
-        private void DeleteRoot(string data)
-        {
-          IDataPortal<Basic.Root> dataPortal = _testDIContext.CreateDataPortal<Basic.Root>();
-
-          dataPortal.Delete(new Basic.Root.Criteria(data));
-        }
+      _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
+
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
+    [TestMethod]
+    [TestCategory("SkipWhenLiveUnitTesting")]
+    public void SaveNewRoot()
+    {
+      Csla.Test.Basic.Root root = NewRoot();
+
+      root.Data = "saved";
+      Assert.AreEqual("saved", root.Data);
+      Assert.AreEqual(true, root.IsDirty);
+      Assert.AreEqual(true, root.IsValid);
+
+      TestResults.Reinitialise();
+      root = root.Save();
+
+      Assert.IsNotNull(root);
+      //fails because no call is being made to DataPortal_Insert in Root.DataPortal_Update if IsDeleted == false and IsNew == true
+      Assert.AreEqual("Inserted", TestResults.GetResult("Root"));
+      Assert.AreEqual("saved", root.Data);
+      Assert.AreEqual(false, root.IsNew, "IsNew");
+      Assert.AreEqual(false, root.IsDeleted, "IsDeleted");
+      Assert.AreEqual(false, root.IsDirty, "IsDirty");
+    }
+
+    [TestMethod]
+    [TestCategory("SkipWhenLiveUnitTesting")]
+    public void SaveOldRoot()
+    {
+      Csla.Test.Basic.Root root = GetRoot("old");
+
+      root.Data = "saved";
+      Assert.AreEqual("saved", root.Data);
+      Assert.AreEqual(true, root.IsDirty, "IsDirty");
+      Assert.AreEqual(true, root.IsValid, "IsValid");
+
+      TestResults.Reinitialise();
+      root = root.Save();
+
+      Assert.IsNotNull(root);
+      Assert.AreEqual("Updated", TestResults.GetResult("Root"));
+      Assert.AreEqual("saved", root.Data);
+      Assert.AreEqual(false, root.IsNew, "IsNew");
+      Assert.AreEqual(false, root.IsDeleted, "IsDeleted");
+      Assert.AreEqual(false, root.IsDirty, "IsDirty");
+    }
+
+    [TestMethod]
+    [TestCategory("SkipWhenLiveUnitTesting")]
+    public void LoadRoot()
+    {
+      Csla.Test.Basic.Root root = GetRoot("loaded");
+      Assert.IsNotNull(root);
+      Assert.AreEqual("Fetched", TestResults.GetResult("Root"));
+      Assert.AreEqual("loaded", root.Data);
+      Assert.AreEqual(false, root.IsNew);
+      Assert.AreEqual(false, root.IsDeleted);
+      Assert.AreEqual(false, root.IsDirty);
+      Assert.AreEqual(true, root.IsValid);
+    }
+
+    [TestMethod]
+    [TestCategory("SkipWhenLiveUnitTesting")]
+    public void DeleteNewRoot()
+    {
+      Csla.Test.Basic.Root root = NewRoot();
+
+      TestResults.Reinitialise();
+      root.Delete();
+      Assert.AreEqual(true, root.IsNew);
+      Assert.AreEqual(true, root.IsDeleted);
+      Assert.AreEqual(true, root.IsDirty);
+
+      root = root.Save();
+      Assert.IsNotNull(root);
+      Assert.AreEqual("", TestResults.GetResult("Root"));
+      Assert.AreEqual(true, root.IsNew);
+      Assert.AreEqual(false, root.IsDeleted);
+      Assert.AreEqual(true, root.IsDirty);
+    }
+
+    [TestMethod]
+    [TestCategory("SkipWhenLiveUnitTesting")]
+    public void DeleteOldRoot()
+    {
+      Csla.Test.Basic.Root root = GetRoot("old");
+
+      TestResults.Reinitialise();
+      root.Delete();
+      Assert.AreEqual(false, root.IsNew);
+      Assert.AreEqual(true, root.IsDeleted);
+      Assert.AreEqual(true, root.IsDirty);
+
+      root = root.Save();
+      Assert.IsNotNull(root);
+      Assert.AreEqual("Deleted self", TestResults.GetResult("Root"));
+      Assert.AreEqual(true, root.IsNew);
+      Assert.AreEqual(false, root.IsDeleted);
+      Assert.AreEqual(true, root.IsDirty);
+    }
+
+    [TestMethod]
+    [TestCategory("SkipWhenLiveUnitTesting")]
+    public void DeleteRootImmediate()
+    {
+      DeleteRoot("test");
+      Assert.AreEqual("Deleted", TestResults.GetResult("Root"));
+    }
+
+    private Basic.Root NewRoot()
+    {
+      IDataPortal<Basic.Root> dataPortal = _testDIContext.CreateDataPortal<Basic.Root>();
+
+      return dataPortal.Create(new Basic.Root.Criteria());
+    }
+
+    private Basic.Root GetRoot(string data)
+    {
+      IDataPortal<Basic.Root> dataPortal = _testDIContext.CreateDataPortal<Basic.Root>();
+
+      return dataPortal.Fetch(new Basic.Root.Criteria(data));
+    }
+
+    private void DeleteRoot(string data)
+    {
+      IDataPortal<Basic.Root> dataPortal = _testDIContext.CreateDataPortal<Basic.Root>();
+
+      dataPortal.Delete(new Basic.Root.Criteria(data));
+    }
+  }
 }

--- a/Source/Csla.test/LazyLoad/LazyLoadTests.cs
+++ b/Source/Csla.test/LazyLoad/LazyLoadTests.cs
@@ -34,6 +34,12 @@ namespace Csla.Test.LazyLoad
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod]
     public void NullApplyEdit()
     {

--- a/Source/Csla.test/Linq/LinqObservableCollectionTest.cs
+++ b/Source/Csla.test/Linq/LinqObservableCollectionTest.cs
@@ -43,6 +43,12 @@ namespace Csla.Test.Linq
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
 #if !WINDOWS_PHONE
     [TestMethod]
     public void Blb2Loc_WhereOnly()

--- a/Source/Csla.test/LogicalExecutionLocation/LogicalExecutionLocationTests.cs
+++ b/Source/Csla.test/LogicalExecutionLocation/LogicalExecutionLocationTests.cs
@@ -33,6 +33,12 @@ namespace Csla.Test.LogicalExecutionLocation
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod]
     public void TestLogicalExecutionLocation()
     {

--- a/Source/Csla.test/Nullable/NullableTests.cs
+++ b/Source/Csla.test/Nullable/NullableTests.cs
@@ -23,92 +23,94 @@ using TestMethod = NUnit.Framework.TestAttribute;
 
 namespace Csla.Test.Nullable
 {
-    [TestClass()]
-    public class NullableTests
+  [TestClass()]
+  public class NullableTests
+  {
+    private static TestDIContext _testDIContext;
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext context)
     {
-        private static TestDIContext _testDIContext;
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
-        {
-            _testDIContext = TestDIContextFactory.CreateDefaultContext();
-        }
-
-        [TestMethod()]
-        [TestCategory("SkipWhenLiveUnitTesting")]
-        public void TestNullableProperty()
-        {
-            IDataPortal<NullableObject> dataPortal = _testDIContext.CreateDataPortal<NullableObject>();
-
-            TestResults.Reinitialise();
-            NullableObject nullRoot = NullableObject.NewNullableObject(dataPortal);
-            nullRoot.NullableInteger = null;
-            nullRoot.Name = null;
-            Assert.AreEqual(null, nullRoot.Name);
-            Assert.AreEqual(null, nullRoot.NullableInteger);
-        }
-
-        [TestMethod()]
-        [TestCategory("SkipWhenLiveUnitTesting")]
-        public void TestNullableField()
-        {
-            IDataPortal<NullableObject> dataPortal = _testDIContext.CreateDataPortal<NullableObject>();
-
-            TestResults.Reinitialise();
-            NullableObject nullRoot = NullableObject.NewNullableObject(dataPortal);
-            nullRoot._nullableIntMember = null;
-            Assert.AreEqual(null, nullRoot._nullableIntMember);
-        }
-
-        [TestMethod()]
-        [TestCategory("SkipWhenLiveUnitTesting")]
-        public void TestNullableAfterClone()
-        {
-            IDataPortal<NullableObject> dataPortal = _testDIContext.CreateDataPortal<NullableObject>();
-
-            TestResults.Reinitialise();
-            NullableObject nullRoot = NullableObject.NewNullableObject(dataPortal);
-            nullRoot._nullableIntMember = null;
-            nullRoot.NullableInteger = null;
-            NullableObject nullRoot2 = nullRoot.Clone();
-            Assert.AreEqual(null, nullRoot2._nullableIntMember);
-            Assert.AreEqual(null, nullRoot2.NullableInteger);
-        }
-
-        [TestMethod()]
-        [TestCategory("SkipWhenLiveUnitTesting")]
-        public void TestNullableAfterEditCycle()
-        {
-            IDataPortal<NullableObject> dataPortal = _testDIContext.CreateDataPortal<NullableObject>();
-
-            TestResults.Reinitialise();
-            NullableObject nullRoot = NullableObject.NewNullableObject(dataPortal);
-            nullRoot.NullableInteger = null;
-            nullRoot._nullableIntMember = null;
-
-            nullRoot.BeginEdit();
-            nullRoot.NullableInteger = 45;
-            nullRoot._nullableIntMember = 32;
-            nullRoot.ApplyEdit();
-
-            Assert.AreEqual(45, nullRoot.NullableInteger);
-            Assert.AreEqual(32, nullRoot._nullableIntMember);
-
-            nullRoot.BeginEdit();
-            nullRoot.NullableInteger = null;
-            nullRoot._nullableIntMember = null;
-            nullRoot.ApplyEdit();
-
-            Assert.AreEqual(null, nullRoot.NullableInteger);
-            Assert.AreEqual(null, nullRoot._nullableIntMember);
-
-            nullRoot.BeginEdit();
-            nullRoot.NullableInteger = 444;
-            nullRoot._nullableIntMember = 222;
-            nullRoot.CancelEdit();
-
-            Assert.AreEqual(null, nullRoot.NullableInteger);
-            Assert.AreEqual(null, nullRoot._nullableIntMember);
-        }
+      _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
+
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
+    [TestMethod()]
+    [TestCategory("SkipWhenLiveUnitTesting")]
+    public void TestNullableProperty()
+    {
+      IDataPortal<NullableObject> dataPortal = _testDIContext.CreateDataPortal<NullableObject>();
+
+      NullableObject nullRoot = NullableObject.NewNullableObject(dataPortal);
+      nullRoot.NullableInteger = null;
+      nullRoot.Name = null;
+      Assert.AreEqual(null, nullRoot.Name);
+      Assert.AreEqual(null, nullRoot.NullableInteger);
+    }
+
+    [TestMethod()]
+    [TestCategory("SkipWhenLiveUnitTesting")]
+    public void TestNullableField()
+    {
+      IDataPortal<NullableObject> dataPortal = _testDIContext.CreateDataPortal<NullableObject>();
+
+      NullableObject nullRoot = NullableObject.NewNullableObject(dataPortal);
+      nullRoot._nullableIntMember = null;
+      Assert.AreEqual(null, nullRoot._nullableIntMember);
+    }
+
+    [TestMethod()]
+    [TestCategory("SkipWhenLiveUnitTesting")]
+    public void TestNullableAfterClone()
+    {
+      IDataPortal<NullableObject> dataPortal = _testDIContext.CreateDataPortal<NullableObject>();
+
+      NullableObject nullRoot = NullableObject.NewNullableObject(dataPortal);
+      nullRoot._nullableIntMember = null;
+      nullRoot.NullableInteger = null;
+      NullableObject nullRoot2 = nullRoot.Clone();
+      Assert.AreEqual(null, nullRoot2._nullableIntMember);
+      Assert.AreEqual(null, nullRoot2.NullableInteger);
+    }
+
+    [TestMethod()]
+    [TestCategory("SkipWhenLiveUnitTesting")]
+    public void TestNullableAfterEditCycle()
+    {
+      IDataPortal<NullableObject> dataPortal = _testDIContext.CreateDataPortal<NullableObject>();
+
+      NullableObject nullRoot = NullableObject.NewNullableObject(dataPortal);
+      nullRoot.NullableInteger = null;
+      nullRoot._nullableIntMember = null;
+
+      nullRoot.BeginEdit();
+      nullRoot.NullableInteger = 45;
+      nullRoot._nullableIntMember = 32;
+      nullRoot.ApplyEdit();
+
+      Assert.AreEqual(45, nullRoot.NullableInteger);
+      Assert.AreEqual(32, nullRoot._nullableIntMember);
+
+      nullRoot.BeginEdit();
+      nullRoot.NullableInteger = null;
+      nullRoot._nullableIntMember = null;
+      nullRoot.ApplyEdit();
+
+      Assert.AreEqual(null, nullRoot.NullableInteger);
+      Assert.AreEqual(null, nullRoot._nullableIntMember);
+
+      nullRoot.BeginEdit();
+      nullRoot.NullableInteger = 444;
+      nullRoot._nullableIntMember = 222;
+      nullRoot.CancelEdit();
+
+      Assert.AreEqual(null, nullRoot.NullableInteger);
+      Assert.AreEqual(null, nullRoot._nullableIntMember);
+    }
+  }
 }

--- a/Source/Csla.test/ObjectFactory/ObjectFactoryTests.cs
+++ b/Source/Csla.test/ObjectFactory/ObjectFactoryTests.cs
@@ -40,6 +40,12 @@ namespace Csla.Test.ObjectFactory
         ));
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     /// <summary>
     /// Always make sure to cleanup after each test 
     /// </summary>
@@ -49,7 +55,6 @@ namespace Csla.Test.ObjectFactory
       // TODO: Is any of this cleanup still required? Probably not
       //Csla.ApplicationContext.DataPortalProxy = "Local";
       //Csla.DataPortal.ResetProxyType();
-      TestResults.Reinitialise();
     }
 
     [TestMethod]
@@ -258,8 +263,6 @@ namespace Csla.Test.ObjectFactory
     {
       IDataPortal<Root> dataPortal = _testDIContext.CreateDataPortal<Root>();
 
-      TestResults.Reinitialise();
-
       dataPortal.Delete("abc");
 
       Assert.AreEqual("Delete", TestResults.GetResult("ObjectFactory"), "Data should match");
@@ -286,8 +289,6 @@ namespace Csla.Test.ObjectFactory
       TestDIContext testDIContext = TestDIContextFactory.CreateDefaultContext();
       IDataPortal<CommandObject> dataPortal = testDIContext.CreateDataPortal<CommandObject>();
 
-      TestResults.Reinitialise();
-
       var test = CommandObject.Execute(dataPortal);
       // return value is set in Execute method in CommandObjectFactory
       Assert.IsTrue(test);
@@ -302,8 +303,6 @@ namespace Csla.Test.ObjectFactory
 
       try
       {
-        TestResults.Reinitialise();
-
         var test = CommandObjectMissingFactoryMethod.Execute(dataPortal);
       }
       catch (DataPortalException ex)

--- a/Source/Csla.test/PropertyGetSet/EditableGetSetRuleValidationTests.cs
+++ b/Source/Csla.test/PropertyGetSet/EditableGetSetRuleValidationTests.cs
@@ -44,6 +44,12 @@ namespace Csla.Test.PropertyGetSet
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     #region Tests
 
     [TestMethod]

--- a/Source/Csla.test/PropertyGetSet/PropertyGetSetTests.cs
+++ b/Source/Csla.test/PropertyGetSet/PropertyGetSetTests.cs
@@ -44,6 +44,7 @@ namespace Csla.Test.PropertyGetSet
     [TestInitialize]
     public void Initialize()
     {
+      TestResults.Reinitialise();
       _mode = Csla.ApplicationContext.PropertyChangedMode;
       Csla.ApplicationContext.PropertyChangedMode = ApplicationContext.PropertyChangedModes.Windows;
       _changedName = "";

--- a/Source/Csla.test/PropertyInfo/PropertyInfoTests.cs
+++ b/Source/Csla.test/PropertyInfo/PropertyInfoTests.cs
@@ -31,6 +31,12 @@ namespace Csla.Test.PropertyInfo
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod]
     public void TestName()
     {

--- a/Source/Csla.test/RollBack/RollBackTests.cs
+++ b/Source/Csla.test/RollBack/RollBackTests.cs
@@ -33,13 +33,18 @@ namespace Csla.Test.RollBack
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod]
     [TestCategory("SkipWhenLiveUnitTesting")]
     public void NoFail()
     {
       IDataPortal<RollbackRoot> dataPortal = _testDIContext.CreateDataPortal<RollbackRoot>();
 
-      TestResults.Reinitialise();
       RollbackRoot root = Csla.Test.RollBack.RollbackRoot.NewRoot(dataPortal);
 
       root.BeginEdit();
@@ -69,7 +74,6 @@ namespace Csla.Test.RollBack
     {
       IDataPortal<RollbackRoot> dataPortal = _testDIContext.CreateDataPortal<RollbackRoot>();
 
-      TestResults.Reinitialise();
       RollbackRoot root = Csla.Test.RollBack.RollbackRoot.NewRoot(dataPortal);
 
       root.BeginEdit();
@@ -108,7 +112,6 @@ namespace Csla.Test.RollBack
     {
       IDataPortal<RollbackRoot> dataPortal = _testDIContext.CreateDataPortal<RollbackRoot>();
 
-      TestResults.Reinitialise();
       RollbackRoot root = Csla.Test.RollBack.RollbackRoot.NewRoot(dataPortal);
       Assert.AreEqual(true, root.IsDirty, "isdirty is true");
       Assert.AreEqual("<new>", root.Data, "data is '<new>'");

--- a/Source/Csla.test/Serialization/SerializationTests.cs
+++ b/Source/Csla.test/Serialization/SerializationTests.cs
@@ -72,6 +72,12 @@ namespace Csla.Test.Serialization
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod]
     public void SerializeDataPortalException()
     {
@@ -95,7 +101,6 @@ namespace Csla.Test.Serialization
     {
       IDataPortal<SerializationRoot> dataPortal = _testDIContext.CreateDataPortal<SerializationRoot>();
 
-      TestResults.Reinitialise();
       UnitTestContext context = GetContext();
       SerializationRoot root = SerializationRoot.NewSerializationRoot(dataPortal);
       nonSerializableEventHandler handler = new nonSerializableEventHandler();
@@ -122,7 +127,6 @@ namespace Csla.Test.Serialization
     {
       IDataPortal<SerializationRoot> dataPortal = _testDIContext.CreateDataPortal<SerializationRoot>();
 
-      TestResults.Reinitialise();
       UnitTestContext context = GetContext();
       SerializationRoot root = dataPortal.Create();
 
@@ -140,7 +144,6 @@ namespace Csla.Test.Serialization
     {
       IDataPortal<SerializationRoot> dataPortal = _testDIContext.CreateDataPortal<SerializationRoot>();
 
-      TestResults.Reinitialise();
       UnitTestContext context = GetContext();
 
       SerializationRoot root = SerializationRoot.NewSerializationRoot(dataPortal);

--- a/Source/Csla.test/SortedBindingList/SortedBindingListTests.cs
+++ b/Source/Csla.test/SortedBindingList/SortedBindingListTests.cs
@@ -34,6 +34,12 @@ namespace Csla.Test.SortedBindingList
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod()]
     public void AscendingSort()
     {

--- a/Source/Csla.test/ValidationRules/AsyncRuleTests.cs
+++ b/Source/Csla.test/ValidationRules/AsyncRuleTests.cs
@@ -40,6 +40,12 @@ namespace Csla.Test.ValidationRules
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod]
     public void TestAsyncRulesValid()
     {
@@ -83,8 +89,6 @@ namespace Csla.Test.ValidationRules
     public void InvalidAsyncRule()
     {
       IDataPortal<HasInvalidAsyncRule> dataPortal = _testDIContext.CreateDataPortal<HasInvalidAsyncRule>();
-
-      TestResults.Reinitialise();
 
       UnitTestContext context = GetContext();
       var root = dataPortal.Create();

--- a/Source/Csla.test/ValidationRules/CascadeTests.cs
+++ b/Source/Csla.test/ValidationRules/CascadeTests.cs
@@ -17,6 +17,12 @@ namespace Csla.Test.ValidationRules
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod]
     public void BusinessRules_MustCascade_WhenCascadeOnDirtyPropertiesIsTrue()
     {

--- a/Source/Csla.test/ValidationRules/DataAnnotationsTests.cs
+++ b/Source/Csla.test/ValidationRules/DataAnnotationsTests.cs
@@ -27,6 +27,12 @@ namespace Csla.Test.ValidationRules
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod]
     public void BrokenRulesCollection_ValidTestObject_ReturnsZeroBrokenRules()
     {

--- a/Source/Csla.test/ValidationRules/RuleBaseClassesTests.cs
+++ b/Source/Csla.test/ValidationRules/RuleBaseClassesTests.cs
@@ -45,6 +45,12 @@ namespace Csla.Test.ValidationRules
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod()]
     public void LookupRuleDefaultCanXYZValues()
     {

--- a/Source/Csla.test/ValidationRules/RuleURITests.cs
+++ b/Source/Csla.test/ValidationRules/RuleURITests.cs
@@ -33,6 +33,12 @@ namespace Csla.Test.ValidationRules
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod]
     public void RuleURIWithGenericObjectRule()
     {

--- a/Source/Csla.test/ValidationRules/SeverityTests.cs
+++ b/Source/Csla.test/ValidationRules/SeverityTests.cs
@@ -34,6 +34,12 @@ namespace Csla.Test.ValidationRules
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod]
     public void AllThree()
     {

--- a/Source/Csla.test/ValidationRules/ShortCircuitTests.cs
+++ b/Source/Csla.test/ValidationRules/ShortCircuitTests.cs
@@ -34,6 +34,12 @@ namespace Csla.Test.ValidationRules
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod]
     public void ShortCircuitOnNew()
     {

--- a/Source/Csla.test/ValidationRules/ValidationTests.cs
+++ b/Source/Csla.test/ValidationRules/ValidationTests.cs
@@ -41,12 +41,17 @@ namespace Csla.Test.ValidationRules
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
     [TestMethod()]
     public async Task TestValidationRulesWithPrivateMember()
     {
       //works now because we are calling ValidationRules.CheckRules() in DataPortal_Create
       UnitTestContext context = GetContext();
-      TestResults.Reinitialise();
       var root = await CreateHasRulesManagerAsync();
       context.Assert.AreEqual("<new>", root.Name);
       context.Assert.AreEqual(true, root.IsValid, "should be valid on create");
@@ -77,7 +82,6 @@ namespace Csla.Test.ValidationRules
     public async Task TestValidationRulesWithPublicProperty()
     {
       //should work since ValidationRules.CheckRules() is called in DataPortal_Create
-      TestResults.Reinitialise();
       var root = await CreateHasRulesManager2Async("<new>");
       Assert.AreEqual("<new>", root.Name);
       Assert.AreEqual(true, root.IsValid, "should be valid on create");
@@ -107,7 +111,6 @@ namespace Csla.Test.ValidationRules
     public async Task TestValidationAfterEditCycle()
     {
       //should work since ValidationRules.CheckRules() is called in DataPortal_Create
-      TestResults.Reinitialise();
       UnitTestContext context = GetContext();
       var root = await CreateHasRulesManagerAsync();
       context.Assert.AreEqual("<new>", root.Name);
@@ -188,7 +191,6 @@ namespace Csla.Test.ValidationRules
       //this test uses HasRulesManager2, which assigns criteria._name to its public
       //property in DataPortal_Create.  If it used HasRulesManager, it would fail
       //the first assert, but pass the others
-      TestResults.Reinitialise();
       var root = await CreateHasRulesManager2Async("test");
       Assert.AreEqual(true, root.IsValid);
       root.BeginEdit();
@@ -207,7 +209,6 @@ namespace Csla.Test.ValidationRules
 
     public async Task BreakRequiredRule()
     {
-      TestResults.Reinitialise();
       var root = await CreateHasRulesManagerAsync();
       root.Name = "";
       Assert.AreEqual(false, root.IsValid, "should not be valid");
@@ -219,7 +220,6 @@ namespace Csla.Test.ValidationRules
 
     public async Task BreakLengthRule()
     {
-      TestResults.Reinitialise();
       UnitTestContext context = GetContext();
       var root = await CreateHasRulesManagerAsync();
       root.Name = "12345678901";
@@ -239,7 +239,6 @@ namespace Csla.Test.ValidationRules
 
     public async Task BreakLengthRuleAndClone()
     {
-      TestResults.Reinitialise();
       UnitTestContext context = GetContext();
       var root = await CreateHasRulesManagerAsync();
       root.Name = "12345678901";
@@ -264,7 +263,6 @@ namespace Csla.Test.ValidationRules
     [TestMethod()]
     public void RegExSSN()
     {
-      TestResults.Reinitialise();
       UnitTestContext context = GetContext();
 
       HasRegEx root = CreateWithoutCriteria<HasRegEx>();
@@ -301,7 +299,6 @@ namespace Csla.Test.ValidationRules
     [TestMethod]
     public async Task VerifyUndoableStateStackOnClone()
     {
-      TestResults.Reinitialise();
       using (UnitTestContext context = GetContext())
       {
         var root = await CreateHasRulesManager2Async();
@@ -323,7 +320,6 @@ namespace Csla.Test.ValidationRules
     [TestMethod()]
     public async Task ListChangedEventTrigger()
     {
-      TestResults.Reinitialise();
       UnitTestContext context = GetContext();
       var root = await CreateWithoutCriteriaAsync<HasChildren>();
       context.Assert.AreEqual(false, root.IsValid);


### PR DESCRIPTION
Stabilisation of tests during checks of remaining issues.

Not associated with any open task.

All tests now look to be working correctly - failures all seem to identify potential bugs or unexpected changes in behaviour - or a few are areas where I don't know how to upgrade them to CSLA 6 - whether they are even relevant any more. These have comments and TODOs to explain the problem with the test.

Failing tests now need review from @rockfordlhotka to understand whether they do indeed highlight valid concerns/bugs.