### PR TITLE
Change principal flow to secure by default - CSLA 7

### DIFF
--- a/Source/Csla.Windows/ApplicationContextManager.cs
+++ b/Source/Csla.Windows/ApplicationContextManager.cs
@@ -33,7 +33,7 @@ namespace Csla.Windows
     {
       if (_principal == null)
       {
-        if (ApplicationContext.AuthenticationType != "Windows")
+        if (ApplicationContext.FlowSecurityPrincipalFromClient)
           SetUser(new System.Security.Claims.ClaimsPrincipal());
         else
 #pragma warning disable CA1416 // Validate platform compatibility

--- a/Source/Csla.Xaml.Shared/ApplicationContextManager.cs
+++ b/Source/Csla.Xaml.Shared/ApplicationContextManager.cs
@@ -45,12 +45,12 @@ namespace Csla.Xaml
       if (_principal == null)
       {
 #if NET6_0_OR_GREATER
-        if (OperatingSystem.IsWindows() && ApplicationContext.AuthenticationType == "Windows")
+        if (OperatingSystem.IsWindows() && !ApplicationContext.FlowSecurityPrincipalFromClient)
           SetUser(new WindowsPrincipal(WindowsIdentity.GetCurrent()));
         else
           SetUser(new System.Security.Claims.ClaimsPrincipal());
 #elif NETFRAMEWORK
-        if (ApplicationContext.AuthenticationType == "Windows")
+        if (!ApplicationContext.FlowSecurityPrincipalFromClient)
 #pragma warning disable CA1416 // Validate platform compatibility
           SetUser(new WindowsPrincipal(WindowsIdentity.GetCurrent()));
 #pragma warning restore CA1416 // Validate platform compatibility

--- a/Source/Csla.test/Csla.Tests.csproj
+++ b/Source/Csla.test/Csla.Tests.csproj
@@ -83,10 +83,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Fakes\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Update="Properties\Settings.Designer.cs">
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
       <AutoGen>True</AutoGen>

--- a/Source/Csla.test/DataPortal/PrincipalFlowTests.cs
+++ b/Source/Csla.test/DataPortal/PrincipalFlowTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Principal;
+using System.Text;
+using System.Threading.Tasks;
+using Csla.Configuration;
+using Csla.Security;
+using Csla.TestHelpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Csla.Test.DataPortal
+{
+  [TestClass]
+  public class PrincipalFlowTests
+  {
+    [TestMethod]
+    public void Fetch_FakeRemoteDataPortalWithDefaultFlow_DoesNotFlowPrincipal()
+    {
+      var principal = new CslaClaimsPrincipal(new GenericIdentity("rocky", "custom"));
+      var testDIContext = TestDIContextFactory.CreateContext(opts => opts
+        .DataPortal(dp => dp.UseFakeRemoteDataPortalProxy()), 
+        principal);
+
+      var dataPortal = testDIContext.CreateDataPortal<PrincipalInfo>();
+      var info = dataPortal.Fetch();
+
+      Assert.IsFalse(info.IsAuthenticated);
+      Assert.AreEqual(string.Empty, info.Name);
+    }
+
+    [TestMethod]
+    public void Fetch_FakeRemoteDataPortalWithFlowEnabled_FlowsPrincipal()
+    {
+      var principal = new CslaClaimsPrincipal(new GenericIdentity("rocky", "custom"));
+      var testDIContext = TestDIContextFactory.CreateContext(opts => opts
+        .DataPortal(dp => {
+          dp.UseFakeRemoteDataPortalProxy();
+          dp.EnableSecurityPrincipalFlowFromClient();
+        }), 
+        principal) ;
+
+      var dataPortal = testDIContext.CreateDataPortal<PrincipalInfo>();
+      var info = dataPortal.Fetch();
+
+      Assert.IsTrue(info.IsAuthenticated);
+      Assert.AreEqual(principal.Identity.Name, info.Name);
+    }
+  }
+}

--- a/Source/Csla.test/DataPortal/PrincipalInfo.cs
+++ b/Source/Csla.test/DataPortal/PrincipalInfo.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Csla.Test.DataPortal
+{
+  internal class PrincipalInfo : ReadOnlyBase<PrincipalInfo>
+  {
+    public static PropertyInfo<bool> IsAuthenticatedProperty = RegisterProperty<bool>(nameof(IsAuthenticated));
+    public static PropertyInfo<string> NameProperty = RegisterProperty<string>(nameof(Name));
+
+    public bool IsAuthenticated
+    {
+      get { return GetProperty(IsAuthenticatedProperty); }
+      private set { LoadProperty(IsAuthenticatedProperty, value); }
+    }
+
+    public string Name 
+    { 
+      get { return GetProperty(NameProperty); }
+      private set { LoadProperty(NameProperty, value); } 
+    }
+
+    [Fetch]
+    private void Fetch()
+    {
+      IsAuthenticated = ApplicationContext.Principal.Identity?.IsAuthenticated ?? false;
+      Name = ApplicationContext.Principal.Identity?.Name ?? string.Empty;
+    }
+  }
+}

--- a/Source/Csla.test/Fakes/Server/DataPortal/FakeDataPortalProxyExtensions.cs
+++ b/Source/Csla.test/Fakes/Server/DataPortal/FakeDataPortalProxyExtensions.cs
@@ -1,0 +1,28 @@
+﻿using Csla.Channels.Local;
+using Csla.DataPortalClient;
+using Csla.Test.Fakes.Server.DataPortal;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Csla.Configuration
+{
+  /// <summary>
+  /// Extension methods for the DataPortalClientOptions to make FakeRemoteDataPortalProxy easier to use
+  /// </summary>
+  internal static class FakeDataPortalProxyExtensions
+  {
+    /// <summary>
+    /// Configure data portal client to use fake remote data portal proxy.
+    /// </summary>
+    /// <param name="config">CslaDataPortalConfiguration object being extended</param>
+    public static DataPortalClientOptions UseFakeRemoteDataPortalProxy(this DataPortalClientOptions config)
+    {
+      config.Services.AddTransient(typeof(IDataPortalProxy),
+        sp =>
+        {
+          var implementingProxy = sp.GetRequiredService<LocalProxy>();
+          return new FakeRemoteDataPortalProxy(implementingProxy);
+        });
+      return config;
+    }
+  }
+}

--- a/Source/Csla.test/Fakes/Server/DataPortal/FakeRemoteDataPortalProxy.cs
+++ b/Source/Csla.test/Fakes/Server/DataPortal/FakeRemoteDataPortalProxy.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Csla.Channels.Local;
+using Csla.DataPortalClient;
+using Csla.Server;
+
+namespace Csla.Test.Fakes.Server.DataPortal
+{
+  /// <summary>
+  /// Fake proxy implementation that can be used to represent a remote proxy
+  /// for testing, without the need to step outside of the AppDomain
+  /// </summary>
+  internal class FakeRemoteDataPortalProxy : IDataPortalProxy
+  {
+    private readonly LocalProxy _implementingProxy;
+
+    public FakeRemoteDataPortalProxy(LocalProxy implementingProxy)
+    {
+      _implementingProxy = implementingProxy;
+    }
+
+    public bool IsServerRemote { get => true; }
+
+    public Task<DataPortalResult> Create(Type objectType, object criteria, DataPortalContext context, bool isSync) 
+      => _implementingProxy.Create(objectType, criteria, context, isSync);
+    
+    public Task<DataPortalResult> Delete(Type objectType, object criteria, DataPortalContext context, bool isSync)
+      => _implementingProxy.Delete(objectType, criteria, context, isSync);
+
+    public Task<DataPortalResult> Fetch(Type objectType, object criteria, DataPortalContext context, bool isSync)
+      => _implementingProxy.Fetch(objectType, criteria, context, isSync);
+
+    public Task<DataPortalResult> Update(object obj, DataPortalContext context, bool isSync)
+      => _implementingProxy.Update(obj, context, isSync);
+  }
+}

--- a/Source/Csla.test/Serialization/CslaClaimsPrincipalSerializationTests.cs
+++ b/Source/Csla.test/Serialization/CslaClaimsPrincipalSerializationTests.cs
@@ -15,6 +15,7 @@ using Csla.Serialization;
 using Csla.Test.ValidationRules;
 using UnitDriven;
 using Csla.TestHelpers;
+using Csla.Configuration;
 
 #if NUNIT
 using NUnit.Framework;
@@ -33,20 +34,13 @@ namespace Csla.Test.Serialization
   [TestClass()]
   public class CslaClaimsPrincipalSerializationTests
   {
-    private static TestDIContext _testDIContext;
-
-    [ClassInitialize]
-    public static void ClassInitialize(TestContext context)
-    {
-      _testDIContext = TestDIContextFactory.CreateDefaultContext();
-    }
-
     [TestMethod]
     public void SerializeCslaClaimsPrincipal()
     {
       var identity = new System.Security.Principal.GenericIdentity("rocky", "custom");
       var principal = new Csla.Security.CslaClaimsPrincipal(identity);
-      var applicationContext = _testDIContext.CreateTestApplicationContext();
+      var testDIContext = TestDIContextFactory.CreateContext(principal);
+      var applicationContext = testDIContext.CreateTestApplicationContext();
       var cloner = new Core.ObjectCloner(applicationContext);
       var clone = (Csla.Security.CslaClaimsPrincipal)cloner.Clone(principal);
       Assert.AreEqual(principal.Identity.Name, clone.Identity.Name);

--- a/Source/Csla/ApplicationContext.cs
+++ b/Source/Csla/ApplicationContext.cs
@@ -181,6 +181,17 @@ namespace Csla
     public static string AuthenticationType { get; internal set; } = "Csla";
 
     /// <summary>
+    /// Get whether we are to flow User Principal to the server
+    /// </summary>
+    /// <remarks>
+    /// This should generally be left at the default of false. Values on 
+    /// the client can be manipulated, and therefore allowing the principal 
+    /// to flow from client to server could result in an exploitable security 
+    /// weakness, including impersonation or elevation of privileges.
+    /// </remarks>
+    public static bool FlowSecurityPrincipalFromClient { get; internal set; } = false;
+
+    /// <summary>
     /// Gets a value indicating whether objects should be
     /// automatically cloned by the data portal Update()
     /// method when using a local data portal configuration.

--- a/Source/Csla/Configuration/Bind/CslaDataPortalConfigurationOptions.cs
+++ b/Source/Csla/Configuration/Bind/CslaDataPortalConfigurationOptions.cs
@@ -21,6 +21,18 @@ namespace Csla.Configuration
     public string AuthenticationType { get => ApplicationContext.AuthenticationType; set => ApplicationContext.AuthenticationType = value; }
 
     /// <summary>
+    /// Gets or sets whether the user's security principal flows from client to server.
+    /// </summary>
+    /// <remarks>
+    /// You should avoid enabling this flow wherever possible. Anything on 
+    /// the client can be manipulated, and using any data flowed from the 
+    /// client to make security decisions on the server could make your 
+    /// application vulnerable to impersonation exploits or elevation
+    /// of privilege attacks.
+    /// </remarks>
+    public bool EnableSecurityPrincipalFlowFromClient { get => ApplicationContext.FlowSecurityPrincipalFromClient; set => ApplicationContext.FlowSecurityPrincipalFromClient = value; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether objects should be
     /// automatically cloned by the data portal Update()method 
     /// when using a local data portal configuration.

--- a/Source/Csla/Configuration/Fluent/DataPortalClientOptions.cs
+++ b/Source/Csla/Configuration/Fluent/DataPortalClientOptions.cs
@@ -65,6 +65,23 @@ namespace Csla.Configuration
     }
 
     /// <summary>
+    /// Enable flow of user's security principal from client to server.
+    /// </summary>
+    /// <returns>This instance, to support method chaining</returns>
+    /// <remarks>
+    /// You should avoid enabling this flow wherever possible. Anything on 
+    /// the client can be manipulated, and using any data flowed from the 
+    /// client to make security decisions on the server could make your 
+    /// application vulnerable to impersonation exploits or elevation
+    /// of privilege attacks.
+    /// </remarks>
+    public DataPortalClientOptions EnableSecurityPrincipalFlowFromClient()
+    {
+      ApplicationContext.FlowSecurityPrincipalFromClient = true;
+      return this;
+    }
+
+    /// <summary>
     /// Sets a value indicating whether the
     /// server-side business object should be returned to
     /// the client as part of the DataPortalException.

--- a/Source/Csla/DataPortalClient/DataPortalProxy.cs
+++ b/Source/Csla/DataPortalClient/DataPortalProxy.cs
@@ -319,7 +319,7 @@ namespace Csla.DataPortalClient
       result.CriteriaData = null;
       result.ClientContext = SerializationFormatterFactory.GetFormatter(ApplicationContext).Serialize(ApplicationContext.ClientContext);
       result.Principal = SerializationFormatterFactory.GetFormatter(ApplicationContext)
-          .Serialize(ApplicationContext.AuthenticationType == "Windows" ? null : ApplicationContext.User);
+          .Serialize(ApplicationContext.FlowSecurityPrincipalFromClient ? ApplicationContext.User : null);
       result.ClientCulture = System.Globalization.CultureInfo.CurrentCulture.Name;
       result.ClientUICulture = System.Globalization.CultureInfo.CurrentUICulture.Name;
       return result;
@@ -331,7 +331,7 @@ namespace Csla.DataPortalClient
       result.ObjectData = null;
       result.ClientContext = SerializationFormatterFactory.GetFormatter(ApplicationContext).Serialize(ApplicationContext.ClientContext);
       result.Principal = SerializationFormatterFactory.GetFormatter(ApplicationContext)
-          .Serialize(ApplicationContext.AuthenticationType == "Windows" ? null : ApplicationContext.User);
+          .Serialize(ApplicationContext.FlowSecurityPrincipalFromClient ? ApplicationContext.User : null);
       result.ClientCulture = Thread.CurrentThread.CurrentCulture.Name;
       result.ClientUICulture = Thread.CurrentThread.CurrentUICulture.Name;
       return result;

--- a/Source/Csla/Server/DataPortal.cs
+++ b/Source/Csla/Server/DataPortal.cs
@@ -680,9 +680,9 @@ namespace Csla.Server
 
     private void SetPrincipal(DataPortalContext context)
     {
-      if (context.IsRemotePortal && ApplicationContext.AuthenticationType == "Windows")
+      if (context.IsRemotePortal && !ApplicationContext.FlowSecurityPrincipalFromClient)
       {
-        // When using integrated security, Principal must be null
+        // When using platform-supplied security, Principal must be null
         if (context.Principal != null)
         {
           Csla.Security.SecurityException ex =
@@ -690,12 +690,15 @@ namespace Csla.Server
           //ex.Action = System.Security.Permissions.SecurityAction.Deny;
           throw ex;
         }
-        // Set .NET to use integrated security
-        AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.WindowsPrincipal);
+        if (ApplicationContext.AuthenticationType == "Windows")
+        {
+          // Set .NET to use integrated security
+          AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.WindowsPrincipal);
+        }
       }
       else
       {
-        // We expect the some Principal object
+        // We expect some Principal object to be available
         if (context.Principal == null)
         {
           Csla.Security.SecurityException ex =
@@ -724,7 +727,7 @@ namespace Csla.Server
       // do nothing
       if (!context.IsRemotePortal) return;
       ApplicationContext.Clear();
-      if (ApplicationContext.AuthenticationType != "Windows")
+      if (ApplicationContext.FlowSecurityPrincipalFromClient)
         ApplicationContext.User = null;
     }
 

--- a/Source/Csla/Server/DataPortalContext.cs
+++ b/Source/Csla/Server/DataPortalContext.cs
@@ -138,9 +138,9 @@ namespace Csla.Server
 
     private IPrincipal GetPrincipal(ApplicationContext applicationContext, bool isRemotePortal)
     {
-      if (isRemotePortal && ApplicationContext.AuthenticationType == "Windows")
+      if (isRemotePortal && !ApplicationContext.FlowSecurityPrincipalFromClient)
       {
-        // Windows integrated security
+        // Platform-supplied security (including Windows and ASP.NET)
         return null;
       }
       else


### PR DESCRIPTION
Change the data portal's flow of the user's security principal from client to server to being off by default. However, the change includes the ability for developers to turn the flow back on if they need it and consider the risk this introduces as acceptable in their specific environment.

As discussed in #3043, this is a BREAKING CHANGE. The old behaviour was to flow the principal from client to server by default. However, the security principal can be manipulated on the client, and in most circumstances it is inappropriate to use unprotected data from the client in making security decisions. The new, more modern security behaviour introduced in this change - to be secure by default - is achieved by disabling the flow of this unprotected information. Disabling the flow reduces the possibility for security vulnerabilities because people are not attempting to use data that could have been changed - untrustworthy data - in their security decisions.

Developers should delegate to the platform on which the data portal is hosted for providing data that is used for making security decisions. For example, this can be done through integrated Windows authentication or ASP.NET Core authentication using cookies or tokens.

Fixes issue #3043