### PR TITLE
Upgrade of BlazorExample and BlazorServerExample to CSLA 6.2.2

### DIFF
--- a/Samples/BlazorExample/BlazorExample/Client/BlazorExample.Client.csproj
+++ b/Samples/BlazorExample/BlazorExample/Client/BlazorExample.Client.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Csla.Blazor.WebAssembly" Version="6.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.5" PrivateAssets="all" />
+    <PackageReference Include="Csla.Blazor.WebAssembly" Version="6.2.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.11" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/BlazorExample/BlazorExample/DataAccess.EF/DataAccess.EF.csproj
+++ b/Samples/BlazorExample/BlazorExample/DataAccess.EF/DataAccess.EF.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Csla" Version="6.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.5">
+    <PackageReference Include="Csla" Version="6.2.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Samples/BlazorExample/BlazorExample/DataAccess.Mock/DataAccess.Mock.csproj
+++ b/Samples/BlazorExample/BlazorExample/DataAccess.Mock/DataAccess.Mock.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Csla" Version="6.1.0" />
+    <PackageReference Include="Csla" Version="6.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/BlazorExample/BlazorExample/DataAccess/DataAccess.csproj
+++ b/Samples/BlazorExample/BlazorExample/DataAccess/DataAccess.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Csla" Version="6.1.0" />
+    <PackageReference Include="Csla" Version="6.2.2" />
   </ItemGroup>
 
 </Project>

--- a/Samples/BlazorExample/BlazorExample/Server/BlazorExample.Server.csproj
+++ b/Samples/BlazorExample/BlazorExample/Server/BlazorExample.Server.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Csla.AspNetCore" Version="6.1.0" />
-    <PackageReference Include="Csla.Blazor" Version="6.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.5" />
+    <PackageReference Include="Csla.AspNetCore" Version="6.2.2" />
+    <PackageReference Include="Csla.Blazor" Version="6.2.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.11" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.1" />
   </ItemGroup>
 

--- a/Samples/BlazorExample/BlazorExample/Shared/BlazorExample.Shared.csproj
+++ b/Samples/BlazorExample/BlazorExample/Shared/BlazorExample.Shared.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Csla" Version="6.1.0" />
+    <PackageReference Include="Csla" Version="6.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/BlazorServerExample/BlazorServerExample.sln
+++ b/Samples/BlazorServerExample/BlazorServerExample.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataAccess", "..\BlazorExam
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataAccess.Mock", "..\BlazorExample\BlazorExample\DataAccess.Mock\DataAccess.Mock.csproj", "{6CD8336E-79B8-4162-A730-66349C660065}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataAccess.EF", "..\BlazorExample\BlazorExample\DataAccess.EF\DataAccess.EF.csproj", "{4BAA3D5D-9C17-4415-A584-EEAE087C40AF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{6CD8336E-79B8-4162-A730-66349C660065}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6CD8336E-79B8-4162-A730-66349C660065}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6CD8336E-79B8-4162-A730-66349C660065}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4BAA3D5D-9C17-4415-A584-EEAE087C40AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4BAA3D5D-9C17-4415-A584-EEAE087C40AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4BAA3D5D-9C17-4415-A584-EEAE087C40AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4BAA3D5D-9C17-4415-A584-EEAE087C40AF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Samples/BlazorServerExample/BlazorServerExample/BlazorServerExample.csproj
+++ b/Samples/BlazorServerExample/BlazorServerExample/BlazorServerExample.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Csla.AspNetCore" Version="6.0.0" />
-    <PackageReference Include="Csla.Blazor" Version="6.0.0" />
+    <PackageReference Include="Csla.AspNetCore" Version="6.2.2" />
+    <PackageReference Include="Csla.Blazor" Version="6.2.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgrade of BlazorExample and BlazorServerExample sample applications to use the latest released version of CSLA - 6.2.2.

This fixes the issue that causes the Blazor Server app not to compile. Fixes #3204