### PR TITLE
Add ManageObjectLifetime to Blazor.ViewModel Issue #3286

### DIFF
--- a/Source/Csla.Blazor/ViewModel.cs
+++ b/Source/Csla.Blazor/ViewModel.cs
@@ -232,17 +232,10 @@ namespace Csla.Blazor
       try
       {
         UnhookChangedEvents(Model);
-        var savable = Model as Core.ISavable;
-        if (ManageObjectLifetime)
-        {
-          // clone the object if possible
-          if (Model is ICloneable cloneable)
-            savable = (Core.ISavable)cloneable.Clone();
 
-          //apply changes
-          if (savable is Core.ISupportUndo undoable)
+        if (ManageObjectLifetime && Model is Core.ISupportUndo undoable)
             undoable.ApplyEdit();
-        }
+
         IsBusy = true;
         Model = await DoSaveAsync();
         Saved?.Invoke();
@@ -271,13 +264,8 @@ namespace Csla.Blazor
     protected virtual async Task<T> DoSaveAsync()
     {
       if (Model is Core.ISavable savable)
-      {
-        var result = (T)await savable.SaveAsync();
-        if (Model is Core.IEditableBusinessObject editable)
-          new Core.GraphMerger(ApplicationContext).MergeGraph(editable, (Core.IEditableBusinessObject)result);
-        else
-          Model = result;
-      }
+        await savable.SaveAndMergeAsync();
+
       return Model;
     }
 

--- a/Source/Csla.Blazor/ViewModel.cs
+++ b/Source/Csla.Blazor/ViewModel.cs
@@ -51,6 +51,11 @@ namespace Csla.Blazor
     /// raises its PropertyChanged event
     /// </summary>
     public event PropertyChangedEventHandler ModelPropertyChanged;
+    /// <summary>
+    /// Event raised when the Model object
+    /// raises its ChildChanged event
+    /// </summary>
+    public event Action ChildChanged;
 
     /// <summary>
     /// Raises the ModelChanging event
@@ -60,11 +65,24 @@ namespace Csla.Blazor
     protected virtual void OnModelChanging(T oldValue, T newValue)
     {
       _info.Clear();
+      if (oldValue is IBusinessBase oldBusinessBase)
+        oldBusinessBase.ChildChanged -= (s, e) => OnChildChanged();
+      if (newValue is IBusinessBase newBusinessBase)
+        newBusinessBase.ChildChanged += (s, e) => OnChildChanged();
+
       if (oldValue is INotifyPropertyChanged oldObj)
         oldObj.PropertyChanged -= (s, e) => OnModelPropertyChanged(e.PropertyName);
       if (newValue is INotifyPropertyChanged newObj)
         newObj.PropertyChanged += (s, e) => OnModelPropertyChanged(e.PropertyName);
       ModelChanging?.Invoke(oldValue, newValue);
+    }
+
+    /// <summary>
+    /// Raises the ChildChanged event
+    /// </summary>
+    protected virtual void OnChildChanged()
+    {
+      ChildChanged?.Invoke();
     }
 
     /// <summary>

--- a/Source/Csla.Blazor/ViewModel.cs
+++ b/Source/Csla.Blazor/ViewModel.cs
@@ -264,8 +264,13 @@ namespace Csla.Blazor
     protected virtual async Task<T> DoSaveAsync()
     {
       if (Model is Core.ISavable savable)
-        await savable.SaveAndMergeAsync();
-
+      {
+        var result = (T)await savable.SaveAsync();
+        if (Model is Core.IEditableBusinessObject editable)
+          new Core.GraphMerger(ApplicationContext).MergeGraph(editable, (Core.IEditableBusinessObject)result);
+        else
+          Model = result;
+      }
       return Model;
     }
 

--- a/Source/Csla.Xaml.Shared/ViewModelBase.cs
+++ b/Source/Csla.Xaml.Shared/ViewModelBase.cs
@@ -503,7 +503,6 @@ namespace Csla.Xaml
     private bool ObjectPropertiesSet;
 
     /// <summary>
-    /// This method is only called from constructor to set default values immediately.
     /// Sets the properties at object level.
     /// </summary>
     private void SetPropertiesAtObjectLevel()

--- a/Source/Csla.Xaml.Shared/ViewModelBase.cs
+++ b/Source/Csla.Xaml.Shared/ViewModelBase.cs
@@ -98,7 +98,6 @@ namespace Csla.Xaml
     /// ViewManageObjectLifetime should automatically managed the
     /// lifetime of the ManageObjectLifetime.
     /// </summary>
-    [Browsable(false)]
     [Display(AutoGenerateField = false)]
     [ScaffoldColumn(false)]
     public bool ManageObjectLifetime
@@ -574,8 +573,13 @@ namespace Csla.Xaml
     protected virtual async Task<T> DoSaveAsync()
     {
       if (Model is ISavable savable)
-        await savable.SaveAndMergeAsync();
-
+      {
+        var result = (T)await savable.SaveAsync();
+        if (Model is IEditableBusinessObject editable)
+          new GraphMerger(ApplicationContext).MergeGraph(editable, (IEditableBusinessObject)result);
+        else
+          Model = result;
+      }
       return Model;
     }
 

--- a/Source/Csla.Xaml.Shared/ViewModelBase.cs
+++ b/Source/Csla.Xaml.Shared/ViewModelBase.cs
@@ -416,7 +416,7 @@ namespace Csla.Xaml
     {
       get
       {
-        SetPropertiesAtObjectLevel(); 
+        SetPropertiesAtObjectLevel();
         return _canCreateObject;
       }
       protected set
@@ -437,10 +437,10 @@ namespace Csla.Xaml
     /// </summary>
     public virtual bool CanGetObject
     {
-      get 
-      { 
-        SetPropertiesAtObjectLevel(); 
-        return _canGetObject; 
+      get
+      {
+        SetPropertiesAtObjectLevel();
+        return _canGetObject;
       }
       protected set
       {
@@ -461,10 +461,10 @@ namespace Csla.Xaml
     /// </summary>
     public virtual bool CanEditObject
     {
-      get 
-      { 
-        SetPropertiesAtObjectLevel(); 
-        return _canEditObject; 
+      get
+      {
+        SetPropertiesAtObjectLevel();
+        return _canEditObject;
       }
       protected set
       {
@@ -485,10 +485,10 @@ namespace Csla.Xaml
     /// </summary>
     public virtual bool CanDeleteObject
     {
-      get 
-      { 
-        SetPropertiesAtObjectLevel(); 
-        return _canDeleteObject; 
+      get
+      {
+        SetPropertiesAtObjectLevel();
+        return _canDeleteObject;
       }
       protected set
       {
@@ -552,26 +552,30 @@ namespace Csla.Xaml
       try
       {
         UnhookChangedEvents(Model);
-        var savable = Model as ISavable;
-        if (ManageObjectLifetime)
-        {
-          // clone the object if possible
-          if (Model is ICloneable cloneable)
-            savable = (ISavable)cloneable.Clone();
 
-          //apply changes
-          if (savable is ISupportUndo undoable)
-            undoable.ApplyEdit();
-        }
+        if (ManageObjectLifetime && Model is ISupportUndo undoable)
+          undoable.ApplyEdit();
 
         IsBusy = true;
-        Model = (T)await savable.SaveAsync();
+        Model = await DoSaveAsync();
       }
       finally
       {
         HookChangedEvents(Model);
         IsBusy = false;
       }
+      return Model;
+    }
+
+    /// <summary>
+    /// Override to provide custom Model save behavior.
+    /// </summary>
+    /// <returns></returns>
+    protected virtual async Task<T> DoSaveAsync()
+    {
+      if (Model is ISavable savable)
+        await savable.SaveAndMergeAsync();
+
       return Model;
     }
 

--- a/Source/Csla.Xaml.Shared/ViewModelBase.cs
+++ b/Source/Csla.Xaml.Shared/ViewModelBase.cs
@@ -503,7 +503,7 @@ namespace Csla.Xaml
     private bool ObjectPropertiesSet;
 
     /// <summary>
-    /// This method is only called from constuctor to set default values immediately.
+    /// This method is only called from constructor to set default values immediately.
     /// Sets the properties at object level.
     /// </summary>
     private void SetPropertiesAtObjectLevel()
@@ -557,8 +557,8 @@ namespace Csla.Xaml
         if (ManageObjectLifetime)
         {
           // clone the object if possible
-          if (Model is ICloneable clonable)
-            savable = (ISavable)clonable.Clone();
+          if (Model is ICloneable cloneable)
+            savable = (ISavable)cloneable.Clone();
 
           //apply changes
           if (savable is ISupportUndo undoable)


### PR DESCRIPTION
**Add ManageObjectLifetime to Blazor.ViewModel Issue #3286**

Using Xaml.Shared.ViewModelBase as the example, I added ModelChildChanged, ModelCollectionChanged, IsBusy, BusyChanged, ManageObjectLifetime, and DoCancel.

Making these changes led to additional questions that I have noted in the code using "// TODO:".  Rocky, please let me know how you wish to proceed.
