### PR TITLE
Normalize LocalProxy by subclassing DataPortalProxy #2861

### DIFF
--- a/Source/Csla/DataPortalClient/DataPortalProxy.cs
+++ b/Source/Csla/DataPortalClient/DataPortalProxy.cs
@@ -329,7 +329,7 @@ namespace Csla.DataPortalClient
 
     /// <summary>
     /// Method called once only after returning to the <see cref="ApplicationContext.LogicalExecutionLocations.Client"/> after a DataPortal call.
-    /// It does not get called when subsequent chained DataPortal calls get called on the server side.
+    /// It does not get called during chained DataPortal operations initiated on the server side.
     /// </summary>
     /// <param name="result">The <see cref="DataPortalResult"/> based upon <see cref="DataPortalResponse"/> that came back from server</param>
     protected virtual void ReturnedToClientSideAndPreparedResult(DataPortalResult result, Type objectType, DataPortalOperations operationType)

--- a/Source/Csla/DataPortalClient/DataPortalProxy.cs
+++ b/Source/Csla/DataPortalClient/DataPortalProxy.cs
@@ -100,6 +100,10 @@ namespace Csla.DataPortalClient
       {
         result = new DataPortalResult(ApplicationContext, null, ex);
       }
+
+      if (ApplicationContext.LogicalExecutionLocation == ApplicationContext.LogicalExecutionLocations.Client)
+        ReturnedToClientSideAndPreparedResult(result, objectType, DataPortalOperations.Create);
+
       if (result.Error != null)
         throw result.Error;
       return result;
@@ -154,6 +158,10 @@ namespace Csla.DataPortalClient
       {
         result = new DataPortalResult(ApplicationContext, null, ex);
       }
+
+      if (ApplicationContext.LogicalExecutionLocation == ApplicationContext.LogicalExecutionLocations.Client)
+        ReturnedToClientSideAndPreparedResult(result, objectType, DataPortalOperations.Fetch);
+
       if (result.Error != null)
         throw result.Error;
       return result;
@@ -202,6 +210,10 @@ namespace Csla.DataPortalClient
       {
         result = new DataPortalResult(ApplicationContext, null, ex);
       }
+
+      if (ApplicationContext.LogicalExecutionLocation == ApplicationContext.LogicalExecutionLocations.Client)
+        ReturnedToClientSideAndPreparedResult(result, obj.GetType(), DataPortalOperations.Update);
+
       if (result.Error != null)
         throw result.Error;
       return result;
@@ -256,6 +268,10 @@ namespace Csla.DataPortalClient
       {
         result = new DataPortalResult(ApplicationContext, null, ex);
       }
+
+      if (ApplicationContext.LogicalExecutionLocation == ApplicationContext.LogicalExecutionLocations.Client)
+        ReturnedToClientSideAndPreparedResult(result, objectType, DataPortalOperations.Delete);
+
       if (result.Error != null)
         throw result.Error;
       return result;
@@ -309,6 +325,16 @@ namespace Csla.DataPortalClient
       if (list.Length > 0)
         result = ((DataPortalServerRoutingTagAttribute)list[0]).RoutingTag;
       return result;
+    }
+
+    /// <summary>
+    /// Method called once only after returning to the <see cref="ApplicationContext.LogicalExecutionLocations.Client"/> after a DataPortal call.
+    /// It does not get called when subsequent chained DataPortal calls get called on the server side.
+    /// </summary>
+    /// <param name="result">The <see cref="DataPortalResult"/> based upon <see cref="DataPortalResponse"/> that came back from server</param>
+    protected virtual void ReturnedToClientSideAndPreparedResult(DataPortalResult result, Type objectType, DataPortalOperations operationType)
+    {
+
     }
 
     #region Criteria

--- a/Source/Csla/DataPortalClient/DataPortalProxy.cs
+++ b/Source/Csla/DataPortalClient/DataPortalProxy.cs
@@ -101,8 +101,11 @@ namespace Csla.DataPortalClient
         result = new DataPortalResult(ApplicationContext, null, ex);
       }
 
-      if (ApplicationContext.LogicalExecutionLocation == ApplicationContext.LogicalExecutionLocations.Client)
-        ReturnedToClientSideAndPreparedResult(result, objectType, DataPortalOperations.Create);
+      var operation = DataPortalOperations.Create;
+      OnServerComplete(result, objectType, operation);
+
+      if (ExecutionIsNotOnLogicalOrPhysicalServer)
+        OnServerCompleteClient(result, objectType, operation);
 
       if (result.Error != null)
         throw result.Error;
@@ -159,8 +162,11 @@ namespace Csla.DataPortalClient
         result = new DataPortalResult(ApplicationContext, null, ex);
       }
 
-      if (ApplicationContext.LogicalExecutionLocation == ApplicationContext.LogicalExecutionLocations.Client)
-        ReturnedToClientSideAndPreparedResult(result, objectType, DataPortalOperations.Fetch);
+      var operation = DataPortalOperations.Fetch;
+      OnServerComplete(result, objectType, operation);
+
+      if (ExecutionIsNotOnLogicalOrPhysicalServer)
+        OnServerCompleteClient(result, objectType, operation);
 
       if (result.Error != null)
         throw result.Error;
@@ -211,8 +217,11 @@ namespace Csla.DataPortalClient
         result = new DataPortalResult(ApplicationContext, null, ex);
       }
 
-      if (ApplicationContext.LogicalExecutionLocation == ApplicationContext.LogicalExecutionLocations.Client)
-        ReturnedToClientSideAndPreparedResult(result, obj.GetType(), DataPortalOperations.Update);
+      var operation = DataPortalOperations.Update;
+      OnServerComplete(result, obj.GetType(), operation);
+
+      if (ExecutionIsNotOnLogicalOrPhysicalServer)
+        OnServerCompleteClient(result, obj.GetType(), operation);
 
       if (result.Error != null)
         throw result.Error;
@@ -269,8 +278,11 @@ namespace Csla.DataPortalClient
         result = new DataPortalResult(ApplicationContext, null, ex);
       }
 
-      if (ApplicationContext.LogicalExecutionLocation == ApplicationContext.LogicalExecutionLocations.Client)
-        ReturnedToClientSideAndPreparedResult(result, objectType, DataPortalOperations.Delete);
+      var operation = DataPortalOperations.Delete;
+      OnServerComplete(result, objectType, operation);
+
+      if (ExecutionIsNotOnLogicalOrPhysicalServer)
+        OnServerCompleteClient(result, objectType, operation);
 
       if (result.Error != null)
         throw result.Error;
@@ -328,13 +340,35 @@ namespace Csla.DataPortalClient
     }
 
     /// <summary>
-    /// Method called once only after returning to the <see cref="ApplicationContext.LogicalExecutionLocations.Client"/> after a DataPortal call.
-    /// It does not get called during chained DataPortal operations initiated on the server side.
+    /// Called after completion of DataPortal operation regardless if operation was originated from the client or from chained calls on the server side.
     /// </summary>
-    /// <param name="result">The <see cref="DataPortalResult"/> based upon <see cref="DataPortalResponse"/> that came back from server</param>
-    protected virtual void ReturnedToClientSideAndPreparedResult(DataPortalResult result, Type objectType, DataPortalOperations operationType)
+    /// <param name="result">Result from DataPortal operation.</param>
+    /// <param name="objectType">Type of business object.</param>
+    /// <param name="operationType">The requested data portal operation type</param>
+    protected virtual void OnServerComplete(DataPortalResult result, Type objectType, DataPortalOperations operationType)
     {
 
+    }
+
+    /// <summary>
+    /// Called after completion of a DataPortal operation which was initiated from the <see cref="ApplicationContext.ExecutionLocations.Client"/> 
+    /// This is NOT called on completion of chained DataPortal operations initiated on the server side.
+    /// </summary>
+    /// <param name="result">Result from DataPortal operation.</param>
+    /// <param name="objectType">Type of business object.</param>
+    /// <param name="operationType">The requested data portal operation type</param>
+    protected virtual void OnServerCompleteClient(DataPortalResult result, Type objectType, DataPortalOperations operationType)
+    {
+
+    }
+
+    internal bool ExecutionIsNotOnLogicalOrPhysicalServer
+    {
+      get
+      {
+        return ApplicationContext.LogicalExecutionLocation != ApplicationContext.LogicalExecutionLocations.Server
+          && ApplicationContext.ExecutionLocation != ApplicationContext.ExecutionLocations.Server;
+      }
     }
 
     #region Criteria

--- a/Source/Csla/DataPortalClient/LocalProxy.cs
+++ b/Source/Csla/DataPortalClient/LocalProxy.cs
@@ -216,7 +216,7 @@ namespace Csla.Channels.Local
         await DisposeScope();
       }
 
-      if (ApplicationContext.LogicalExecutionLocation == ApplicationContext.LogicalExecutionLocations.Client)
+      if (CurrentApplicationContext.LogicalExecutionLocation == ApplicationContext.LogicalExecutionLocations.Client)
         ReturnedToClientSideAndPreparedResult(result, objectType, DataPortalOperations.Create);
 
       return result;
@@ -260,7 +260,7 @@ namespace Csla.Channels.Local
         await DisposeScope();
       }
 
-      if (ApplicationContext.LogicalExecutionLocation == ApplicationContext.LogicalExecutionLocations.Client)
+      if (CurrentApplicationContext.LogicalExecutionLocation == ApplicationContext.LogicalExecutionLocations.Client)
         ReturnedToClientSideAndPreparedResult(result, objectType, DataPortalOperations.Fetch);
 
       return result;
@@ -303,7 +303,7 @@ namespace Csla.Channels.Local
         await DisposeScope();
       }
 
-      if (ApplicationContext.LogicalExecutionLocation == ApplicationContext.LogicalExecutionLocations.Client)
+      if (CurrentApplicationContext.LogicalExecutionLocation == ApplicationContext.LogicalExecutionLocations.Client)
         ReturnedToClientSideAndPreparedResult(result, obj.GetType(), DataPortalOperations.Update);
 
       return result;
@@ -347,7 +347,7 @@ namespace Csla.Channels.Local
         await DisposeScope();
       }
 
-      if (ApplicationContext.LogicalExecutionLocation == ApplicationContext.LogicalExecutionLocations.Client)
+      if (CurrentApplicationContext.LogicalExecutionLocation == ApplicationContext.LogicalExecutionLocations.Client)
         ReturnedToClientSideAndPreparedResult(result, objectType, DataPortalOperations.Delete);
 
       return result;

--- a/Source/Csla/DataPortalClient/LocalProxy.cs
+++ b/Source/Csla/DataPortalClient/LocalProxy.cs
@@ -216,8 +216,11 @@ namespace Csla.Channels.Local
         await DisposeScope();
       }
 
-      if (CurrentApplicationContext.LogicalExecutionLocation == ApplicationContext.LogicalExecutionLocations.Client)
-        ReturnedToClientSideAndPreparedResult(result, objectType, DataPortalOperations.Create);
+      var operation = DataPortalOperations.Create;
+      OnServerComplete(result, objectType, operation);
+
+      if (ExecutionIsNotOnLogicalOrPhysicalServer)
+        OnServerCompleteClient(result, objectType, operation);
 
       return result;
     }
@@ -260,8 +263,11 @@ namespace Csla.Channels.Local
         await DisposeScope();
       }
 
-      if (CurrentApplicationContext.LogicalExecutionLocation == ApplicationContext.LogicalExecutionLocations.Client)
-        ReturnedToClientSideAndPreparedResult(result, objectType, DataPortalOperations.Fetch);
+      var operation = DataPortalOperations.Fetch;
+      OnServerComplete(result, objectType, operation);
+
+      if (ExecutionIsNotOnLogicalOrPhysicalServer)
+        OnServerCompleteClient(result, objectType, operation);
 
       return result;
     }
@@ -303,8 +309,11 @@ namespace Csla.Channels.Local
         await DisposeScope();
       }
 
-      if (CurrentApplicationContext.LogicalExecutionLocation == ApplicationContext.LogicalExecutionLocations.Client)
-        ReturnedToClientSideAndPreparedResult(result, obj.GetType(), DataPortalOperations.Update);
+      var operation = DataPortalOperations.Update;
+      OnServerComplete(result, obj.GetType(), operation);
+
+      if (ExecutionIsNotOnLogicalOrPhysicalServer)
+        OnServerCompleteClient(result, obj.GetType(), operation);
 
       return result;
     }
@@ -347,8 +356,11 @@ namespace Csla.Channels.Local
         await DisposeScope();
       }
 
-      if (CurrentApplicationContext.LogicalExecutionLocation == ApplicationContext.LogicalExecutionLocations.Client)
-        ReturnedToClientSideAndPreparedResult(result, objectType, DataPortalOperations.Delete);
+      var operation = DataPortalOperations.Delete;
+      OnServerComplete(result, objectType, operation);
+
+      if (ExecutionIsNotOnLogicalOrPhysicalServer)
+        OnServerCompleteClient(result, objectType, operation);
 
       return result;
     }
@@ -361,7 +373,7 @@ namespace Csla.Channels.Local
     /// <param name="routingToken">Routing Tag for server</param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
     /// <returns>Serialised response from server</returns>
-    protected override async Task<byte[]> CallDataPortalServer(byte[] serialized, string operation, string routingToken, bool isSync)
+    protected override Task<byte[]> CallDataPortalServer(byte[] serialized, string operation, string routingToken, bool isSync)
     {
       throw new NotImplementedException();
     }
@@ -371,10 +383,7 @@ namespace Csla.Channels.Local
     /// a remote data portal server, or run the "server-side"
     /// data portal in the caller's process and AppDomain.
     /// </summary>
-    public bool IsServerRemote
-    {
-      get { return false; }
-    }
+    public override bool IsServerRemote => false;
 
     /// <summary>
     /// Method called once when execution returns to <see cref="ApplicationContext.LogicalExecutionLocations.Client"/> after a call to 


### PR DESCRIPTION
Fixes #2861 by making LocalProxy subclass DataPortalProxy so it is like the other 3 proxies; Also adds a virtual method called when switching appcontext back to client which allows dev to inherit from LocalProxy giving a hook to watch for salient things "coming back" to client from logical server;

Closes #3556
