### PR TITLE
Fixes Blazor ViewModel Save doesn't call begin edit after save.

### DIFF
--- a/Source/Csla.Blazor.Test/Fakes/FakePersonEmailAddress.cs
+++ b/Source/Csla.Blazor.Test/Fakes/FakePersonEmailAddress.cs
@@ -5,6 +5,7 @@ using System.Text;
 
 namespace Csla.Blazor.Test.Fakes
 {
+  [Serializable]
   public class FakePersonEmailAddress : BusinessBase<FakePersonEmailAddress>
   {
     public static Csla.PropertyInfo<string> EmailAddressProperty = RegisterProperty<string>(nameof(EmailAddress));

--- a/Source/Csla.Blazor.Test/Fakes/FakePersonEmailAddresses.cs
+++ b/Source/Csla.Blazor.Test/Fakes/FakePersonEmailAddresses.cs
@@ -5,6 +5,7 @@ using Csla.Server;
 
 namespace Csla.Blazor.Test.Fakes
 {
+  [Serializable]
   public class FakePersonEmailAddresses : BusinessListBase<FakePersonEmailAddresses, FakePersonEmailAddress>
   {
   }

--- a/Source/Csla.Blazor.Test/ViewModelEditChildListSaveEditLevelTests.cs
+++ b/Source/Csla.Blazor.Test/ViewModelEditChildListSaveEditLevelTests.cs
@@ -1,0 +1,79 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Csla.Blazor.Test.Fakes;
+using Microsoft.AspNetCore.Components.Forms;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Csla.TestHelpers;
+using System.Threading.Tasks;
+using Csla.Core;
+
+namespace Csla.Blazor.Test
+{
+  [TestClass]
+  public class ViewModelEditChildListSaveEditLevelTests
+  {
+    private static TestDIContext _testDIContext;
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext context)
+    {
+      _testDIContext = TestDIContextFactory.CreateDefaultContext();
+    }
+    
+    [TestMethod]
+    public async Task SaveModelChildListChange_ValidateEditLevel()
+    {
+      // Arrange
+      FakePerson person = GetValidFakePerson();
+      //EditContext editContext = new EditContext(person);
+      //editContext.AddCslaValidation();
+      var iuo = person as IUndoableObject;
+      var appCntxt = TestDIContextExtensions.CreateTestApplicationContext(_testDIContext);
+      var vm = new ViewModel<FakePerson>(appCntxt);
+      vm.ManageObjectLifetime = true;
+      vm.Model = person;
+      
+      Assert.IsTrue(iuo.EditLevel > 0);
+      await vm.SaveAsync();
+      Assert.IsTrue(iuo.EditLevel == 1);
+
+      // Act
+      var eaddr = person.EmailAddresses.AddNew();
+      eaddr.EmailAddress = "test@test.ca";
+      Assert.IsTrue(iuo.EditLevel > 0);
+      await vm.SaveAsync();
+
+      // Assert
+      Assert.IsTrue(iuo.EditLevel == 1);
+
+    }
+
+    #region Helper Methods
+
+    FakePerson GetValidFakePerson()
+    {
+      IDataPortal<FakePerson> dataPortal;
+      FakePerson person;
+
+      // Create an instance of a DataPortal that can be used for instantiating objects
+      dataPortal = _testDIContext.CreateDataPortal<FakePerson>();
+      person = dataPortal.Create();
+
+      person.FirstName = "John";
+      person.LastName = "Smith";
+      person.HomeTelephone = "01234 567890";
+
+      return person;
+    }
+
+    private string ConcatenateMessages(IEnumerable<string> messages)
+    {
+      return string.Join("; ", messages);
+    }
+
+    #endregion
+
+  }
+}

--- a/Source/Csla.Generators/cs/Csla.Generators.CSharp.Tests/Csla.Generators.CSharp.Tests.csproj
+++ b/Source/Csla.Generators/cs/Csla.Generators.CSharp.Tests/Csla.Generators.CSharp.Tests.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Csla.TestHelpers\Csla.TestHelpers.csproj" />
+    <ProjectReference Include="..\Csla.Generators.CSharp.TestObjects\Csla.Generators.CSharp.TestObjects.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #3668 

- Restored Save logic to save cloned Model when Manage Object Lifetime is true
- Added unit test
