### PR TITLE
Added property IsCanReadPropertyAuthorizationCheckDisabled to disable auth check

### DIFF
--- a/Source/Csla.test/Authorization/ReadOnlyPerson.cs
+++ b/Source/Csla.test/Authorization/ReadOnlyPerson.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Text;
 using Csla.Serialization;
 using System.Diagnostics;
+using Csla.Rules;
 
 namespace Csla.Test.Authorization
 {
@@ -20,6 +21,9 @@ namespace Csla.Test.Authorization
   [Serializable()]
   public class ReadOnlyPerson : ReadOnlyBase<ReadOnlyPerson>
   {
+    private bool _authorizationCheckDisabled;
+    protected override bool IsCanReadPropertyAuthorizationCheckDisabled => _authorizationCheckDisabled;
+
     private ReadOnlyPerson() 
     {
       LoadProperty(FirstNameProperty, "John");
@@ -76,6 +80,9 @@ namespace Csla.Test.Authorization
       BusinessRules.AddRule(new Csla.Rules.CommonRules.IsInRole(Rules.AuthorizationActions.ReadProperty, FirstNameProperty, new List<string> { "Admin" }));
       BusinessRules.AddRule(new Csla.Rules.CommonRules.IsNotInRole(Rules.AuthorizationActions.ReadProperty, MiddleNameProperty, new List<string> { "Admin" }));
     }
+
+    internal void SetDisableCanReadAuthorizationChecks(bool isCanReadAuthorizationChecksDisabled) => _authorizationCheckDisabled = isCanReadAuthorizationChecksDisabled;
+
     //protected override void AddInstanceAuthorizationRules()
     //{
     //  base.AddInstanceAuthorizationRules();

--- a/Source/Csla.test/Authorization/ReadonlyAuthorizationTests.cs
+++ b/Source/Csla.test/Authorization/ReadonlyAuthorizationTests.cs
@@ -12,6 +12,8 @@ using Csla.Test.Security;
 using UnitDriven;
 using System.Diagnostics;
 using System.Security.Claims;
+using Csla.Core;
+using Csla.TestHelpers;
 
 #if NUNIT
 using NUnit.Framework;
@@ -32,12 +34,30 @@ namespace Csla.Test.Authorization
   [TestClass()]
   public class ReadonlyAuthorizationTests
   {
+    private static TestDIContext _testDIContext;
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext context) {
+      _ = context;
+      _testDIContext = TestDIContextFactory.CreateDefaultContext();
+    }
+
     private static ClaimsPrincipal GetPrincipal(params string[] roles)
     {
       var identity = new ClaimsIdentity();
       foreach (var item in roles)
         identity.AddClaim(new Claim(ClaimTypes.Role, item));
       return new ClaimsPrincipal(identity);
+    }
+
+    [TestMethod]
+    public void WhenReadOnlyBaseHasAuthorizationRuleChecksDisabledThePropertiesShouldBeReadableEvenThoughIDontHaveTheNeededRule() {
+      var person = ReadOnlyPerson.GetReadOnlyPerson();
+      ((IUseApplicationContext)person).ApplicationContext = _testDIContext.CreateTestApplicationContext();
+
+      person.SetDisableCanReadAuthorizationChecks(isCanReadAuthorizationChecksDisabled: true);
+
+      _ = person.FirstName; // When no exception happens this test is successful
     }
 
     //[TestMethod()]

--- a/Source/Csla/ReadOnlyBase.cs
+++ b/Source/Csla/ReadOnlyBase.cs
@@ -129,6 +129,12 @@ namespace Csla
 
     #region Authorization
 
+    /// <summary>
+    /// Gets or sets if <see cref="CanReadProperty(IPropertyInfo)"/> performs an authorization check or not. <br/>
+    /// <see langword="true"/> means read is <i>always</i> allowed. <see langword="false"/> means an authorization check is always performed.
+    /// </summary>
+    protected virtual bool IsCanReadPropertyAuthorizationCheckDisabled { get; } = false;
+
     [NotUndoable()]
     [NonSerialized()]
     private ConcurrentDictionary<string, bool> _readResultCache;
@@ -215,6 +221,10 @@ namespace Csla
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     public virtual bool CanReadProperty(Csla.Core.IPropertyInfo property)
     {
+      if (IsCanReadPropertyAuthorizationCheckDisabled) {
+        return true;
+      }
+
       bool result = true;
 
       VerifyAuthorizationCache();


### PR DESCRIPTION
Fixes #3430 

Adds a new overridable property `IsCanReadPropertyAuthorizationCheckDisabled` which can be set to `true` in a class to suppress authorization checks for read properties.