### PR TITLE
Fixes #1376 (AllowSynchronousIO = true now obsolete)

### DIFF
--- a/Source/Csla.TestHelpers/Csla.TestHelpers.csproj
+++ b/Source/Csla.TestHelpers/Csla.TestHelpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Csla\CslaKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
@@ -10,10 +10,12 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.3" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Csla\Csla.csproj" />
+    <ProjectReference Include="..\Csla.AspNetCore\Csla.AspNetCore.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Source/Csla.TestHelpers/Http/HttpTestServerFactory.cs
+++ b/Source/Csla.TestHelpers/Http/HttpTestServerFactory.cs
@@ -1,0 +1,43 @@
+﻿using Csla.Configuration;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Csla.TestHelpers.Http;
+public static class HttpTestServerFactory {
+
+  public static TestServer CreateHttpTestServer() {
+    return new TestServer(new WebHostBuilder()
+      .ConfigureServices((IServiceCollection services) => {
+        services.AddControllers();
+        services.AddHttpContextAccessor();
+        services.AddCsla(o => o.AddAspNetCore());
+      })
+      .Configure(app => {
+        app.UseRouting();
+        app.UseEndpoints(endpoints => endpoints.MapControllers());
+      })
+    );
+  }
+
+  public static (TestServer Server, ServiceProvider ClientServiceProvider) CreateHttpTestServerAndClientServiceProvider() {
+    var testServer = CreateHttpTestServer();
+
+    string controllerName = nameof(TestDataPortalController).Replace("Controller", "");
+    var clientServices = new ServiceCollection()
+      .AddCsla(
+      o => o.DataPortal(
+        portalOptions => portalOptions.ClientSideDataPortal(
+          a => a.UseHttpProxy(
+            proxy => proxy.DataPortalUrl = $"/api/{controllerName}"
+            )
+          )
+        )
+      );
+    clientServices.AddSingleton(testServer.CreateClient());
+    var clientServiceProvider = clientServices.BuildServiceProvider();
+
+    return (testServer, clientServiceProvider);
+  }
+}

--- a/Source/Csla.TestHelpers/Http/TestDataPortalController.cs
+++ b/Source/Csla.TestHelpers/Http/TestDataPortalController.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace Csla.TestHelpers.Http;
+
+[Route("api/[controller]")]
+[ApiController]
+public class TestDataPortalController(ApplicationContext applicationContext)
+    : Csla.Server.Hosts.HttpPortalController(applicationContext) {
+  [HttpGet]
+  public string Get() {
+    return "DataPortal running...";
+  }
+}

--- a/Source/Csla.test/Hosting/KestrelOrIISHostingTests.cs
+++ b/Source/Csla.test/Hosting/KestrelOrIISHostingTests.cs
@@ -1,0 +1,39 @@
+﻿using System.Threading.Tasks;
+using Csla.TestHelpers.Http;
+using Csla.Testing.Business.DataPortal;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Csla.Test.Hosting;
+
+[TestClass]
+public class KestrelOrIISHostingTests {
+
+  private static TestServer _server;
+  private static ServiceProvider _clientSideServiceProvider;
+
+  [ClassInitialize]
+  public static void Initialize(TestContext context) {
+    _ = context;
+
+    var (server, clientServiceProvider) = HttpTestServerFactory.CreateHttpTestServerAndClientServiceProvider();
+    _server = server;
+    _clientSideServiceProvider = clientServiceProvider;
+  }
+
+  [ClassCleanup]
+  public static async Task Cleanup() {
+    await _clientSideServiceProvider.DisposeAsync();
+    _server.Dispose();
+  }
+
+  [TestMethod]
+  public async Task WhenAllowSynchronousIOIsNotAllowedTheRequestShouldWorkAsExpected() {
+
+    _server.AllowSynchronousIO = false;
+
+    var portal = _clientSideServiceProvider.GetRequiredService<IDataPortal<TestBO>>();
+    _ = await portal.CreateAsync();
+  }
+}


### PR DESCRIPTION
Fixes #1376 

* Avoid sync IO through asyn reading into a memory stream which will be used by the (de)serializer
* Add integration test to verify that it works as expected

I added a basic `TestServer` to simulate HTTP calls in memory. I created a factory to make it possible to re-use it for future tests.

One thing is weird: The newly added test works when executed alone but when I execute all tests via the Test Runner the test goes red. I think there's maybe something static which interferes with running all tests in succession. For now I ignored that problem so here is the PR :-)
