### PR TITLE
Fixes INotifyDataErrorInfo.GetErrors 

### DIFF
--- a/Source/Csla/Core/BusinessBase.cs
+++ b/Source/Csla/Core/BusinessBase.cs
@@ -1336,7 +1336,7 @@ namespace Csla.Core
 
     IEnumerable INotifyDataErrorInfo.GetErrors(string propertyName)
     {
-      return BusinessRules.GetBrokenRules().Where(r => r.Property == propertyName).Select(r => r.Description);
+      return BusinessRules.GetBrokenRules().Where(r => r.Property == propertyName && r.Severity == RuleSeverity.Error).Select(r => r.Description);
     }
 
     bool INotifyDataErrorInfo.HasErrors => !IsSelfValid;


### PR DESCRIPTION
INotifyDataErrorInfo.GetErrors return BrokenRules when it's valid object.
Closes https://github.com/MarimerLLC/csla/issues/3746