### PR TITLE
Use WaitForIdle() method in simple data portal to wait for rule execution

### DIFF
--- a/Source/Csla.test/BusinessListBase/Child.cs
+++ b/Source/Csla.test/BusinessListBase/Child.cs
@@ -9,7 +9,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Csla;
+using Csla.Rules;
 using Csla.Serialization;
 
 namespace Csla.Test.BusinessListBase
@@ -22,6 +24,19 @@ namespace Csla.Test.BusinessListBase
     {
       get { return GetProperty(DataProperty); }
       set { SetProperty(DataProperty, value); }
+    }
+
+
+    private static PropertyInfo<string> AsyncRuleTextProperty = RegisterProperty<string>(nameof(AsyncRuleText));
+    public string AsyncRuleText {
+      get { return GetProperty(AsyncRuleTextProperty); }
+      set { SetProperty<string>(AsyncRuleTextProperty, value);}
+    }
+
+    protected override void AddBusinessRules() {
+      base.AddBusinessRules();
+
+      BusinessRules.AddRule(new OneSecondAsyncRule(AsyncRuleTextProperty));
     }
 
     [CreateChild]
@@ -38,5 +53,17 @@ namespace Csla.Test.BusinessListBase
     [DeleteSelfChild]
     private void Child_DeleteSelf()
     { }
+
+
+    private sealed class OneSecondAsyncRule : BusinessRuleAsync {
+      public OneSecondAsyncRule(Core.IPropertyInfo primaryProperty) : base(primaryProperty)
+      {
+        InputProperties.Add(primaryProperty);
+      }
+
+      protected override async Task ExecuteAsync(IRuleContext context) {
+        await Task.Delay(TimeSpan.FromSeconds(1));
+      }
+    }
   }
 }

--- a/Source/Csla.test/BusinessListBase/Child.cs
+++ b/Source/Csla.test/BusinessListBase/Child.cs
@@ -28,19 +28,22 @@ namespace Csla.Test.BusinessListBase
 
 
     private static PropertyInfo<string> AsyncRuleTextProperty = RegisterProperty<string>(nameof(AsyncRuleText));
-    public string AsyncRuleText {
+    public string AsyncRuleText 
+    {
       get { return GetProperty(AsyncRuleTextProperty); }
       set { SetProperty<string>(AsyncRuleTextProperty, value);}
     }
 
-    protected override void AddBusinessRules() {
+    protected override void AddBusinessRules() 
+    {
       base.AddBusinessRules();
 
       BusinessRules.AddRule(new OneSecondAsyncRule(AsyncRuleTextProperty));
     }
 
     [CreateChild]
-    private void CreateChild() { }
+    private void CreateChild() 
+    { }
 
     [InsertChild]
     private void Child_Insert()
@@ -55,13 +58,15 @@ namespace Csla.Test.BusinessListBase
     { }
 
 
-    private sealed class OneSecondAsyncRule : BusinessRuleAsync {
+    private sealed class OneSecondAsyncRule : BusinessRuleAsync 
+    {
       public OneSecondAsyncRule(Core.IPropertyInfo primaryProperty) : base(primaryProperty)
       {
         InputProperties.Add(primaryProperty);
       }
 
-      protected override async Task ExecuteAsync(IRuleContext context) {
+      protected override async Task ExecuteAsync(IRuleContext context) 
+      {
         await Task.Delay(TimeSpan.FromSeconds(1));
       }
     }

--- a/Source/Csla.test/BusyStatus/BusyStatusTests.cs
+++ b/Source/Csla.test/BusyStatus/BusyStatusTests.cs
@@ -14,6 +14,7 @@ using Csla.Testing.Business.BusyStatus;
 using System.Threading.Tasks;
 using Csla.TestHelpers;
 using Csla.Test;
+using FluentAssertions;
 
 #if NUNIT
 using NUnit.Framework;
@@ -322,9 +323,22 @@ namespace cslalighttest.BusyStatus
       UnitTestContext context = GetContext();
       var item = await dataPortal.FetchAsync("an id");
       item.RuleField = "some value";
-      await item.WaitForIdle(TimeSpan.FromSeconds(60)); // Timeout should _never_ happen
+      
+      await item.WaitForIdle(TimeSpan.FromSeconds(5)); // Timeout should _never_ happen
 
-      Assert.IsFalse(item.IsBusy, $"{nameof(ItemWithAsynchRule.IsBusy)} is still true even though we waited with {nameof(ItemWithAsynchRule.WaitForIdle)}.");
+      item.IsBusy.Should().BeFalse(because: $"{nameof(ItemWithAsynchRule.IsBusy)} is still true even though we waited with {nameof(ItemWithAsynchRule.WaitForIdle)}.");
+    }
+
+    [TestMethod]
+    public async Task WaitForIdle_WhenReachingTheTimeoutATimeoutExceptionIsThrown() {
+
+      IDataPortal<ItemWithAsynchRule> dataPortal = _noCloneOnUpdateDIContext.CreateDataPortal<ItemWithAsynchRule>();
+
+      UnitTestContext context = GetContext();
+      var item = await dataPortal.FetchAsync("an id");
+      item.RuleField = "some value";
+
+      await item.Invoking(i => i.WaitForIdle(TimeSpan.FromMilliseconds(500))).Should().ThrowAsync<TimeoutException>();
     }
   }
 }

--- a/Source/Csla.test/BusyStatus/BusyStatusTests.cs
+++ b/Source/Csla.test/BusyStatus/BusyStatusTests.cs
@@ -298,7 +298,6 @@ namespace cslalighttest.BusyStatus
       context.Complete();
     }
 
-
     [TestMethod]
     public void ListTestSaveWhileNotBusyNoActiveRuleNetOnly()
     {
@@ -314,6 +313,18 @@ namespace cslalighttest.BusyStatus
       context.Assert.AreEqual("DataPortal_Update", items[0].OperationResult);
       context.Assert.Success();
       context.Complete();
+    }
+
+    [TestMethod]
+    public async Task WaitForIdle_WhenBusyWillWaitUntilNotBusyAnymore() {
+      IDataPortal<ItemWithAsynchRule> dataPortal = _noCloneOnUpdateDIContext.CreateDataPortal<ItemWithAsynchRule>();
+
+      UnitTestContext context = GetContext();
+      var item = await dataPortal.FetchAsync("an id");
+      item.RuleField = "some value";
+      await item.WaitForIdle(TimeSpan.FromSeconds(60)); // Timeout should _never_ happen
+
+      Assert.IsFalse(item.IsBusy, $"{nameof(ItemWithAsynchRule.IsBusy)} is still true even though we waited with {nameof(ItemWithAsynchRule.WaitForIdle)}.");
     }
   }
 }

--- a/Source/Csla.test/BusyStatus/BusyStatusTests.cs
+++ b/Source/Csla.test/BusyStatus/BusyStatusTests.cs
@@ -317,7 +317,8 @@ namespace cslalighttest.BusyStatus
     }
 
     [TestMethod]
-    public async Task WaitForIdle_WhenBusyWillWaitUntilNotBusyAnymore() {
+    public async Task WaitForIdle_WhenBusyWillWaitUntilNotBusyAnymore() 
+    {
       IDataPortal<ItemWithAsynchRule> dataPortal = _noCloneOnUpdateDIContext.CreateDataPortal<ItemWithAsynchRule>();
 
       UnitTestContext context = GetContext();
@@ -330,7 +331,8 @@ namespace cslalighttest.BusyStatus
     }
 
     [TestMethod]
-    public async Task WaitForIdle_WhenReachingTheTimeoutATimeoutExceptionIsThrown() {
+    public async Task WaitForIdle_WhenReachingTheTimeoutATimeoutExceptionIsThrown() 
+    {
 
       IDataPortal<ItemWithAsynchRule> dataPortal = _noCloneOnUpdateDIContext.CreateDataPortal<ItemWithAsynchRule>();
 

--- a/Source/Csla.test/Csla.Tests.csproj
+++ b/Source/Csla.test/Csla.Tests.csproj
@@ -64,6 +64,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />

--- a/Source/Csla.test/DataPortal/DataPortalTests.cs
+++ b/Source/Csla.test/DataPortal/DataPortalTests.cs
@@ -374,22 +374,27 @@ namespace Csla.Test.DataPortal
     }
 
     [Create]
-    protected void Create() {
+    protected void Create() 
+    {
       RuleTrigger = Guid.NewGuid().ToString();
     }
 
-    protected override void AddBusinessRules() {
+    protected override void AddBusinessRules() 
+    {
       base.AddBusinessRules();
 
       BusinessRules.AddRule(new TwoSecondAsyncRule(RuleTriggerProperty));
     }
 
-    private sealed class TwoSecondAsyncRule : BusinessRuleAsync {
-      public TwoSecondAsyncRule(IPropertyInfo primaryProperty) : base(primaryProperty) {
+    private sealed class TwoSecondAsyncRule : BusinessRuleAsync 
+    {
+      public TwoSecondAsyncRule(IPropertyInfo primaryProperty) : base(primaryProperty) 
+      {
       }
 
       /// <inheritdoc />
-      protected override async Task ExecuteAsync(IRuleContext context) {
+      protected override async Task ExecuteAsync(IRuleContext context) 
+      {
         await Task.Delay(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
       }
     }

--- a/Source/Csla.test/DataPortal/DataPortalTests.cs
+++ b/Source/Csla.test/DataPortal/DataPortalTests.cs
@@ -13,6 +13,11 @@ using System.Data;
 using System.Data.SqlClient;
 using Csla.TestHelpers;
 using Microsoft.Extensions.DependencyInjection;
+using Csla.Configuration;
+using FluentAssertions;
+using System.Threading.Tasks;
+using Csla.Rules;
+using Csla.Core;
 
 #if NUNIT
 using NUnit.Framework;
@@ -174,18 +179,10 @@ namespace Csla.Test.DataPortal
     [TestMethod]
     public void EncapsulatedIsBusyFails()
     {
+      _testDIContext.ServiceProvider.GetRequiredService<CslaOptions>().DefaultWaitForIdleTimeoutInSeconds = 1;
       IDataPortal<EncapsulatedBusy> dataPortal = _testDIContext.CreateDataPortal<EncapsulatedBusy>();
 
-      try
-      {
-        var obj = dataPortal.Fetch();
-      }
-      catch (DataPortalException ex)
-      {
-        Assert.IsInstanceOfType(ex.InnerException, typeof(InvalidOperationException));
-        return;
-      }
-      Assert.Fail("Expected exception");
+      dataPortal.Invoking(dp => dp.Fetch()).Should().Throw<DataPortalException>().WithInnerException<TimeoutException>();
     }
 
     [TestMethod]
@@ -307,6 +304,16 @@ namespace Csla.Test.DataPortal
       Assert.AreEqual("Fetched", TestResults.GetResult("ParentEntity"));
     }
 
+    [TestMethod]
+    public async Task WhenCreatingANewObjectThePortalMustWaitAfterCreateUntilTheObjectIsNotBusyAnymore()
+    {
+      var dataPortal = _testDIContext.CreateDataPortal<ObjectStillBusyAfterCreate>();
+
+      var obj = await dataPortal.CreateAsync();
+
+      obj.IsBusy.Should().BeFalse();
+    }
+
     private void ClientPortal_DataPortalInvoke(DataPortalEventArgs obj)
     {
       TestResults.Add("dpinvoke", "true");
@@ -353,6 +360,38 @@ namespace Csla.Test.DataPortal
     private void DataPortal_Fetch()
     {
       MarkBusy();
+    }
+  }
+
+  [Serializable]
+  public class ObjectStillBusyAfterCreate : BusinessBase<ObjectStillBusyAfterCreate> 
+  {
+    public static PropertyInfo<string> RuleTriggerProperty = RegisterProperty<string>(nameof(RuleTrigger));
+    public string RuleTrigger 
+    { 
+      get => ReadProperty(RuleTriggerProperty); 
+      set => SetProperty(RuleTriggerProperty, value);
+    }
+
+    [Create]
+    protected void Create() {
+      RuleTrigger = Guid.NewGuid().ToString();
+    }
+
+    protected override void AddBusinessRules() {
+      base.AddBusinessRules();
+
+      BusinessRules.AddRule(new TwoSecondAsyncRule(RuleTriggerProperty));
+    }
+
+    private sealed class TwoSecondAsyncRule : BusinessRuleAsync {
+      public TwoSecondAsyncRule(IPropertyInfo primaryProperty) : base(primaryProperty) {
+      }
+
+      /// <inheritdoc />
+      protected override async Task ExecuteAsync(IRuleContext context) {
+        await Task.Delay(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+      }
     }
   }
 

--- a/Source/Csla/BusinessBase.cs
+++ b/Source/Csla/BusinessBase.cs
@@ -104,13 +104,7 @@ namespace Csla
     /// <returns></returns>
     public async Task WaitForIdle(TimeSpan timeout)
     {
-      var endTime = DateTime.Now + timeout;
-      while (IsBusy)
-      {
-        if (DateTime.Now > endTime)
-          throw new TimeoutException($"{this.GetType().FullName}.WaitForIdle");
-        await Task.Delay(1);
-      }
+      await BusyHelper.WaitForIdle(this, timeout);
     }
 
     /// <summary>

--- a/Source/Csla/BusinessBase.cs
+++ b/Source/Csla/BusinessBase.cs
@@ -93,7 +93,7 @@ namespace Csla
     public async Task WaitForIdle()
     {
       var cslaOptions = ApplicationContext.GetRequiredService<Csla.Configuration.CslaOptions>();
-      await WaitForIdle(TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds));
+      await WaitForIdle(TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds)).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -104,7 +104,7 @@ namespace Csla
     /// <returns></returns>
     public async Task WaitForIdle(TimeSpan timeout)
     {
-      await BusyHelper.WaitForIdle(this, timeout);
+      await BusyHelper.WaitForIdle(this, timeout).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Source/Csla/BusinessBindingListBase.cs
+++ b/Source/Csla/BusinessBindingListBase.cs
@@ -720,7 +720,7 @@ namespace Csla
     public async Task WaitForIdle()
     {
       var cslaOptions = ApplicationContext.GetRequiredService<Csla.Configuration.CslaOptions>();
-      await WaitForIdle(TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds));
+      await WaitForIdle(TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds)).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -731,7 +731,7 @@ namespace Csla
     /// <returns></returns>
     public async Task WaitForIdle(TimeSpan timeout)
     {
-      await BusyHelper.WaitForIdle(this, timeout);
+      await BusyHelper.WaitForIdle(this, timeout).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Source/Csla/BusinessBindingListBase.cs
+++ b/Source/Csla/BusinessBindingListBase.cs
@@ -731,13 +731,7 @@ namespace Csla
     /// <returns></returns>
     public async Task WaitForIdle(TimeSpan timeout)
     {
-      var endTime = DateTime.Now + timeout;
-      while (IsBusy)
-      {
-        if (DateTime.Now > endTime)
-          throw new TimeoutException($"{this.GetType().FullName}.WaitForIdle");
-        await Task.Delay(1);
-      }
+      await BusyHelper.WaitForIdle(this, timeout);
     }
 
     /// <summary>

--- a/Source/Csla/BusinessListBase.cs
+++ b/Source/Csla/BusinessListBase.cs
@@ -750,13 +750,7 @@ namespace Csla
     /// <returns></returns>
     public async Task WaitForIdle(TimeSpan timeout)
     {
-      var endTime = DateTime.Now + timeout;
-      while (IsBusy)
-      {
-        if (DateTime.Now > endTime)
-          throw new TimeoutException($"{this.GetType().FullName}.WaitForIdle");
-        await Task.Delay(1);
-      }
+      await BusyHelper.WaitForIdle(this, timeout);
     }
 
     /// <summary>

--- a/Source/Csla/BusinessListBase.cs
+++ b/Source/Csla/BusinessListBase.cs
@@ -739,7 +739,7 @@ namespace Csla
     public async Task WaitForIdle()
     {
       var cslaOptions = ApplicationContext.GetRequiredService<Csla.Configuration.CslaOptions>();
-      await WaitForIdle(TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds));
+      await WaitForIdle(TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds)).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -750,7 +750,7 @@ namespace Csla
     /// <returns></returns>
     public async Task WaitForIdle(TimeSpan timeout)
     {
-      await BusyHelper.WaitForIdle(this, timeout);
+      await BusyHelper.WaitForIdle(this, timeout).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Source/Csla/CommandBase.cs
+++ b/Source/Csla/CommandBase.cs
@@ -158,6 +158,8 @@ namespace Csla
 
     Task Csla.Server.IDataPortalTarget.CheckRulesAsync() => Task.CompletedTask;
 
+    Task Csla.Server.IDataPortalTarget.WaitForIdle(TimeSpan timeout) => Task.CompletedTask;
+
     void IDataPortalTarget.MarkAsChild()
     { }
 

--- a/Source/Csla/Core/BusinessBase.cs
+++ b/Source/Csla/Core/BusinessBase.cs
@@ -3431,7 +3431,9 @@ namespace Csla.Core
       BusinessRules.CheckRules();
     }
 
-    async Task Csla.Server.IDataPortalTarget.CheckRulesAsync() => await BusinessRules.CheckRulesAsync();
+    async Task Csla.Server.IDataPortalTarget.CheckRulesAsync() => await BusinessRules.CheckRulesAsync().ConfigureAwait(false);
+
+    async Task Csla.Server.IDataPortalTarget.WaitForIdle(TimeSpan timeout) => await BusyHelper.WaitForIdle(this, timeout).ConfigureAwait(false);
 
     void Csla.Server.IDataPortalTarget.MarkAsChild()
     {

--- a/Source/Csla/Core/BusyHelper.cs
+++ b/Source/Csla/Core/BusyHelper.cs
@@ -38,9 +38,8 @@ namespace Csla.Core {
         source.BusyChanged -= ObserverForIsBusyChange;
       }
 
-      void ObserverForIsBusyChange(object sender, BusyChangedEventArgs e) {
-        // e.PropertyName == string.Empty means CSLA itself raised the busy-changed event
-        if (!source.IsBusy && !e.Busy && (string.IsNullOrEmpty(e.PropertyName) || e.PropertyName == nameof(INotifyBusy.IsBusy))) {
+      void ObserverForIsBusyChange(object sender, BusyChangedEventArgs e) {        
+        if (!source.IsBusy && !e.Busy) {
           tcs.TrySetResult(null);
         }
       }

--- a/Source/Csla/Core/BusyHelper.cs
+++ b/Source/Csla/Core/BusyHelper.cs
@@ -28,7 +28,7 @@ namespace Csla.Core {
         }
 
         var timeoutTask = Task.Delay(timeout);
-        var finishedTask = await Task.WhenAny(tcs.Task, timeoutTask);
+        var finishedTask = await Task.WhenAny(tcs.Task, timeoutTask).ConfigureAwait(false);
 
         if (finishedTask == timeoutTask) {
           throw new TimeoutException($"{source.GetType().FullName}.{methodName} after {timeout}.");

--- a/Source/Csla/Core/BusyHelper.cs
+++ b/Source/Csla/Core/BusyHelper.cs
@@ -37,7 +37,7 @@ namespace Csla.Core {
 
         if (finishedTask == timeoutTask)
         {
-          throw new TimeoutException($"{source.GetType().FullName}.{methodName} after {timeout}.");
+          throw new TimeoutException($"{source.GetType().FullName}.{methodName} - {timeout}.");
         }
       }
       finally 

--- a/Source/Csla/Core/BusyHelper.cs
+++ b/Source/Csla/Core/BusyHelper.cs
@@ -1,0 +1,49 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="INotifyBusy.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>Interface defining an object that notifies when it</summary>
+//-----------------------------------------------------------------------
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace Csla.Core {
+  /// <summary>
+  /// Helper class for busy related functionality spread across different business type implementations.
+  /// </summary>
+  internal static class BusyHelper {
+    public static async Task WaitForIdle(INotifyBusy source, TimeSpan timeout, [CallerMemberName] string methodName = "") {
+      if (!source.IsBusy) {
+        return;
+      }
+
+      var tcs = new TaskCompletionSource<object>();
+      try {
+        source.BusyChanged += ObserverForIsBusyChange;
+
+        if (!source.IsBusy) {
+          return;
+        }
+
+        var timeoutTask = Task.Delay(timeout);
+        var finishedTask = await Task.WhenAny(tcs.Task, timeoutTask);
+
+        if (finishedTask == timeoutTask) {
+          throw new TimeoutException($"{source.GetType().FullName}.{methodName} after {timeout}.");
+        }
+      }
+      finally {
+        source.BusyChanged -= ObserverForIsBusyChange;
+      }
+
+      void ObserverForIsBusyChange(object sender, BusyChangedEventArgs e) {
+        // e.PropertyName == string.Empty means CSLA itself raised the busy-changed event
+        if (!source.IsBusy && !e.Busy && (string.IsNullOrEmpty(e.PropertyName) || e.PropertyName == nameof(INotifyBusy.IsBusy))) {
+          tcs.TrySetResult(null);
+        }
+      }
+    }
+  }
+}

--- a/Source/Csla/Core/BusyHelper.cs
+++ b/Source/Csla/Core/BusyHelper.cs
@@ -13,33 +13,42 @@ namespace Csla.Core {
   /// <summary>
   /// Helper class for busy related functionality spread across different business type implementations.
   /// </summary>
-  internal static class BusyHelper {
-    public static async Task WaitForIdle(INotifyBusy source, TimeSpan timeout, [CallerMemberName] string methodName = "") {
-      if (!source.IsBusy) {
+  internal static class BusyHelper 
+  {
+    public static async Task WaitForIdle(INotifyBusy source, TimeSpan timeout, [CallerMemberName] string methodName = "") 
+    {
+      if (!source.IsBusy) 
+      {
         return;
       }
 
       var tcs = new TaskCompletionSource<object>();
-      try {
+      try 
+      {
         source.BusyChanged += ObserverForIsBusyChange;
 
-        if (!source.IsBusy) {
+        if (!source.IsBusy) 
+        {
           return;
         }
 
         var timeoutTask = Task.Delay(timeout);
         var finishedTask = await Task.WhenAny(tcs.Task, timeoutTask).ConfigureAwait(false);
 
-        if (finishedTask == timeoutTask) {
+        if (finishedTask == timeoutTask)
+        {
           throw new TimeoutException($"{source.GetType().FullName}.{methodName} after {timeout}.");
         }
       }
-      finally {
+      finally 
+      {
         source.BusyChanged -= ObserverForIsBusyChange;
       }
 
-      void ObserverForIsBusyChange(object sender, BusyChangedEventArgs e) {        
-        if (!source.IsBusy && !e.Busy) {
+      void ObserverForIsBusyChange(object sender, BusyChangedEventArgs e)
+      {
+        if (!source.IsBusy && !e.Busy) 
+        {
           tcs.TrySetResult(null);
         }
       }

--- a/Source/Csla/DynamicBindingListBase.cs
+++ b/Source/Csla/DynamicBindingListBase.cs
@@ -571,13 +571,7 @@ namespace Csla
     /// <returns></returns>
     public async Task WaitForIdle(TimeSpan timeout)
     {
-      var endTime = DateTime.Now + timeout;
-      while (IsBusy)
-      {
-        if (DateTime.Now > endTime)
-          throw new TimeoutException($"{this.GetType().FullName}.WaitForIdle");
-        await Task.Delay(1);
-      }
+      await BusyHelper.WaitForIdle(this, timeout);
     }
 
     /// <summary>

--- a/Source/Csla/DynamicBindingListBase.cs
+++ b/Source/Csla/DynamicBindingListBase.cs
@@ -560,7 +560,7 @@ namespace Csla
     public async Task WaitForIdle()
     {
       var cslaOptions = ApplicationContext.GetRequiredService<Csla.Configuration.CslaOptions>();
-      await WaitForIdle(TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds));
+      await WaitForIdle(TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds)).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -571,7 +571,7 @@ namespace Csla
     /// <returns></returns>
     public async Task WaitForIdle(TimeSpan timeout)
     {
-      await BusyHelper.WaitForIdle(this, timeout);
+      await BusyHelper.WaitForIdle(this, timeout).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Source/Csla/DynamicListBase.cs
+++ b/Source/Csla/DynamicListBase.cs
@@ -454,13 +454,7 @@ namespace Csla
     /// <returns></returns>
     public async Task WaitForIdle(TimeSpan timeout)
     {
-      var endTime = DateTime.Now + timeout;
-      while (IsBusy)
-      {
-        if (DateTime.Now > endTime)
-          throw new TimeoutException($"{this.GetType().FullName}.WaitForIdle");
-        await Task.Delay(1);
-      }
+      await BusyHelper.WaitForIdle(this, timeout);
     }
 
     /// <summary>

--- a/Source/Csla/DynamicListBase.cs
+++ b/Source/Csla/DynamicListBase.cs
@@ -443,7 +443,7 @@ namespace Csla
     public async Task WaitForIdle()
     {
       var cslaOptions = ApplicationContext.GetRequiredService<Csla.Configuration.CslaOptions>();
-      await WaitForIdle(TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds));
+      await WaitForIdle(TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds)).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -454,7 +454,7 @@ namespace Csla
     /// <returns></returns>
     public async Task WaitForIdle(TimeSpan timeout)
     {
-      await BusyHelper.WaitForIdle(this, timeout);
+      await BusyHelper.WaitForIdle(this, timeout).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Source/Csla/NameValueListBase.cs
+++ b/Source/Csla/NameValueListBase.cs
@@ -331,6 +331,8 @@ namespace Csla
 
     Task Csla.Server.IDataPortalTarget.CheckRulesAsync() => Task.CompletedTask;
 
+    async Task Csla.Server.IDataPortalTarget.WaitForIdle(TimeSpan timeout) => await BusyHelper.WaitForIdle(this, timeout).ConfigureAwait(false);
+
     void Csla.Server.IDataPortalTarget.MarkAsChild()
     { }
 

--- a/Source/Csla/ReadOnlyBase.cs
+++ b/Source/Csla/ReadOnlyBase.cs
@@ -1510,13 +1510,7 @@ namespace Csla
     /// <returns></returns>
     public async Task WaitForIdle(TimeSpan timeout)
     {
-      var endTime = DateTime.Now + timeout;
-      while (IsBusy)
-      {
-        if (DateTime.Now > endTime)
-          throw new TimeoutException($"{this.GetType().FullName}.WaitForIdle");
-        await Task.Delay(1);
-      }
+      await BusyHelper.WaitForIdle(this, timeout);
     }
 
     [NonSerialized]

--- a/Source/Csla/ReadOnlyBase.cs
+++ b/Source/Csla/ReadOnlyBase.cs
@@ -1499,7 +1499,7 @@ namespace Csla
     public async Task WaitForIdle()
     {
       var cslaOptions = ApplicationContext.GetRequiredService<Csla.Configuration.CslaOptions>();
-      await WaitForIdle(TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds));
+      await WaitForIdle(TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds)).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -1510,7 +1510,7 @@ namespace Csla
     /// <returns></returns>
     public async Task WaitForIdle(TimeSpan timeout)
     {
-      await BusyHelper.WaitForIdle(this, timeout);
+      await BusyHelper.WaitForIdle(this, timeout).ConfigureAwait(false);
     }
 
     [NonSerialized]

--- a/Source/Csla/ReadOnlyBindingListBase.cs
+++ b/Source/Csla/ReadOnlyBindingListBase.cs
@@ -25,8 +25,8 @@ namespace Csla
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq.Expressions;
 using System.Threading.Tasks;
+using Csla.Core;
 using Csla.Properties;
 
 namespace Csla
@@ -213,6 +213,8 @@ namespace Csla
     { }
 
     Task Csla.Server.IDataPortalTarget.CheckRulesAsync() => Task.CompletedTask;
+
+    async Task Csla.Server.IDataPortalTarget.WaitForIdle(TimeSpan timeout) => await BusyHelper.WaitForIdle(this, timeout).ConfigureAwait(false);
 
     void Csla.Server.IDataPortalTarget.MarkAsChild()
     { }

--- a/Source/Csla/ReadOnlyListBase.cs
+++ b/Source/Csla/ReadOnlyListBase.cs
@@ -11,6 +11,7 @@ using System.Diagnostics.CodeAnalysis;
 using Csla.Properties;
 using System;
 using System.Threading.Tasks;
+using Csla.Core;
 
 namespace Csla
 {
@@ -207,6 +208,8 @@ namespace Csla
     { }
 
     Task Csla.Server.IDataPortalTarget.CheckRulesAsync() => Task.CompletedTask;
+
+    async Task Csla.Server.IDataPortalTarget.WaitForIdle(TimeSpan timeout) => await BusyHelper.WaitForIdle(this, timeout).ConfigureAwait(false);
 
     void Csla.Server.IDataPortalTarget.MarkAsChild()
     { }

--- a/Source/Csla/Server/IDataPortalTarget.cs
+++ b/Source/Csla/Server/IDataPortalTarget.cs
@@ -17,6 +17,7 @@ namespace Csla.Server
     void MarkOld();
     void CheckRules();
     Task CheckRulesAsync();
+    Task WaitForIdle(TimeSpan timeout);
     void DataPortal_OnDataPortalInvoke(DataPortalEventArgs e);
     void DataPortal_OnDataPortalInvokeComplete(DataPortalEventArgs e);
     void DataPortal_OnDataPortalException(DataPortalEventArgs e, Exception ex);

--- a/Source/Csla/Server/ObjectFactory.cs
+++ b/Source/Csla/Server/ObjectFactory.cs
@@ -73,7 +73,7 @@ namespace Csla.Server
     {
       var target = obj as IDataPortalTarget;
       if (target != null)
-        await target.CheckRulesAsync();
+        await target.CheckRulesAsync().ConfigureAwait(false);
       else
         MethodCaller.CallMethodIfImplemented(obj, "CheckRules", null);
     }
@@ -86,7 +86,7 @@ namespace Csla.Server
     protected async Task WaitForIdle(object obj) 
     {
       var cslaOptions = ApplicationContext.GetRequiredService<Csla.Configuration.CslaOptions>();
-      await WaitForIdle(obj, TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds));
+      await WaitForIdle(obj, TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds)).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Source/Csla/Server/ObjectFactory.cs
+++ b/Source/Csla/Server/ObjectFactory.cs
@@ -79,6 +79,39 @@ namespace Csla.Server
     }
 
     /// <summary>
+    /// Calls the WaitForIdle() method on the specified object with the default timeout, if possible.
+    /// </summary>
+    /// <param name="obj">Object on which to call the method.</param>
+    /// <returns>void</returns>
+    protected async Task WaitForIdle(object obj) 
+    {
+      var cslaOptions = ApplicationContext.GetRequiredService<Csla.Configuration.CslaOptions>();
+      await WaitForIdle(obj, TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds));
+    }
+
+    /// <summary>
+    /// Calls the WaitForIdle() method on the specified object with the given timeout, if possible.
+    /// </summary>
+    /// <param name="obj">Object on which to call the method.</param>
+    /// <param name="timeout">The timeout.</param>
+    /// <returns>void</returns>
+    protected async Task WaitForIdle(object obj, TimeSpan timeout) 
+    {
+      if (obj is IDataPortalTarget target) 
+      {
+        await target.WaitForIdle(timeout);
+      }
+      else if(obj is INotifyBusy notifyBusy) 
+      {
+        await BusyHelper.WaitForIdle(notifyBusy, timeout);
+      }
+      else 
+      {
+        MethodCaller.CallMethodIfImplemented(obj, nameof(IDataPortalTarget.WaitForIdle), timeout);
+      }
+    }
+
+    /// <summary>
     /// Calls the MarkOld method on the specified
     /// object, if possible.
     /// </summary>

--- a/Source/Csla/Server/ObjectFactory.cs
+++ b/Source/Csla/Server/ObjectFactory.cs
@@ -99,11 +99,11 @@ namespace Csla.Server
     {
       if (obj is IDataPortalTarget target) 
       {
-        await target.WaitForIdle(timeout);
+        await target.WaitForIdle(timeout).ConfigureAwait(false);
       }
       else if(obj is INotifyBusy notifyBusy) 
       {
-        await BusyHelper.WaitForIdle(notifyBusy, timeout);
+        await BusyHelper.WaitForIdle(notifyBusy, timeout).ConfigureAwait(false);
       }
       else 
       {

--- a/Source/Csla/Server/SimpleDataPortal.cs
+++ b/Source/Csla/Server/SimpleDataPortal.cs
@@ -59,8 +59,8 @@ namespace Csla.Server
         obj = ApplicationContext.CreateInstanceDI<DataPortalTarget>(ApplicationContext.CreateInstanceDI(objectType));
         obj.OnDataPortalInvoke(eventArgs);
         obj.MarkNew();
-        await obj.CreateAsync(criteria, isSync);
-        await obj.WaitForIdle();
+        await obj.CreateAsync(criteria, isSync).ConfigureAwait(false);
+        await obj.WaitForIdle().ConfigureAwait(false);
         obj.ThrowIfBusy();
         obj.OnDataPortalInvokeComplete(eventArgs);
         return new DataPortalResult(ApplicationContext, obj.Instance);
@@ -118,8 +118,8 @@ namespace Csla.Server
         Activator.InitializeInstance(obj.Instance);
         obj.OnDataPortalInvoke(eventArgs);
         obj.MarkOld();
-        await obj.FetchAsync(criteria, isSync);
-        await obj.WaitForIdle();
+        await obj.FetchAsync(criteria, isSync).ConfigureAwait(false);
+        await obj.WaitForIdle().ConfigureAwait(false);
         obj.ThrowIfBusy();
         obj.OnDataPortalInvokeComplete(eventArgs);
         return new DataPortalResult(ApplicationContext, obj.Instance);
@@ -161,8 +161,8 @@ namespace Csla.Server
         Activator.InitializeInstance(obj.Instance);
         obj.OnDataPortalInvoke(eventArgs);
         obj.MarkOld();
-        await obj.ExecuteAsync(criteria, isSync);
-        await obj.WaitForIdle();
+        await obj.ExecuteAsync(criteria, isSync).ConfigureAwait(false);
+        await obj.WaitForIdle().ConfigureAwait(false);
         obj.ThrowIfBusy();
         obj.OnDataPortalInvokeComplete(eventArgs);
         return new DataPortalResult(ApplicationContext, obj.Instance);
@@ -217,8 +217,8 @@ namespace Csla.Server
       {
         Activator.InitializeInstance(lb.Instance);
         lb.OnDataPortalInvoke(eventArgs);
-        await lb.UpdateAsync(isSync);
-        await lb.WaitForIdle();
+        await lb.UpdateAsync(isSync).ConfigureAwait(false);
+        await lb.WaitForIdle().ConfigureAwait(false);
         lb.ThrowIfBusy();
         lb.OnDataPortalInvokeComplete(eventArgs);
         return new DataPortalResult(ApplicationContext, lb.Instance);
@@ -256,8 +256,8 @@ namespace Csla.Server
       {
         Activator.InitializeInstance(obj.Instance);
         obj.OnDataPortalInvoke(eventArgs);
-        await obj.ExecuteAsync(isSync);
-        await obj.WaitForIdle();
+        await obj.ExecuteAsync(isSync).ConfigureAwait(false);
+        await obj.WaitForIdle().ConfigureAwait(false);
         obj.ThrowIfBusy();
         obj.OnDataPortalInvokeComplete(eventArgs);
         return new DataPortalResult(ApplicationContext, obj.Instance);
@@ -306,8 +306,8 @@ namespace Csla.Server
         obj = ApplicationContext.CreateInstanceDI<DataPortalTarget>(ApplicationContext.CreateInstanceDI(objectType));
         Activator.InitializeInstance(obj.Instance);
         obj.OnDataPortalInvoke(eventArgs);
-        await obj.DeleteAsync(criteria, isSync);
-        await obj.WaitForIdle();
+        await obj.DeleteAsync(criteria, isSync).ConfigureAwait(false);
+        await obj.WaitForIdle().ConfigureAwait(false);
         obj.ThrowIfBusy();
         obj.OnDataPortalInvokeComplete(eventArgs);
         return new DataPortalResult {  ApplicationContext = ApplicationContext };

--- a/Source/Csla/Server/SimpleDataPortal.cs
+++ b/Source/Csla/Server/SimpleDataPortal.cs
@@ -60,6 +60,7 @@ namespace Csla.Server
         obj.OnDataPortalInvoke(eventArgs);
         obj.MarkNew();
         await obj.CreateAsync(criteria, isSync);
+        await obj.WaitForIdle();
         obj.ThrowIfBusy();
         obj.OnDataPortalInvokeComplete(eventArgs);
         return new DataPortalResult(ApplicationContext, obj.Instance);
@@ -118,6 +119,7 @@ namespace Csla.Server
         obj.OnDataPortalInvoke(eventArgs);
         obj.MarkOld();
         await obj.FetchAsync(criteria, isSync);
+        await obj.WaitForIdle();
         obj.ThrowIfBusy();
         obj.OnDataPortalInvokeComplete(eventArgs);
         return new DataPortalResult(ApplicationContext, obj.Instance);
@@ -160,6 +162,7 @@ namespace Csla.Server
         obj.OnDataPortalInvoke(eventArgs);
         obj.MarkOld();
         await obj.ExecuteAsync(criteria, isSync);
+        await obj.WaitForIdle();
         obj.ThrowIfBusy();
         obj.OnDataPortalInvokeComplete(eventArgs);
         return new DataPortalResult(ApplicationContext, obj.Instance);
@@ -215,6 +218,7 @@ namespace Csla.Server
         Activator.InitializeInstance(lb.Instance);
         lb.OnDataPortalInvoke(eventArgs);
         await lb.UpdateAsync(isSync);
+        await lb.WaitForIdle();
         lb.ThrowIfBusy();
         lb.OnDataPortalInvokeComplete(eventArgs);
         return new DataPortalResult(ApplicationContext, lb.Instance);
@@ -253,6 +257,7 @@ namespace Csla.Server
         Activator.InitializeInstance(obj.Instance);
         obj.OnDataPortalInvoke(eventArgs);
         await obj.ExecuteAsync(isSync);
+        await obj.WaitForIdle();
         obj.ThrowIfBusy();
         obj.OnDataPortalInvokeComplete(eventArgs);
         return new DataPortalResult(ApplicationContext, obj.Instance);
@@ -302,6 +307,7 @@ namespace Csla.Server
         Activator.InitializeInstance(obj.Instance);
         obj.OnDataPortalInvoke(eventArgs);
         await obj.DeleteAsync(criteria, isSync);
+        await obj.WaitForIdle();
         obj.ThrowIfBusy();
         obj.OnDataPortalInvokeComplete(eventArgs);
         return new DataPortalResult {  ApplicationContext = ApplicationContext };


### PR DESCRIPTION
* `WaitForIdle(TimeSpan timeout)` added to  `IDataPortalTarget`
* `WaitForIdle` implementations consolidated into `BusyHelper` static class which depends on the `INotifyBusy` interface
* `.ConfigureAwait(false)` added

Closes #3755 