### PR TITLE
Change usage from Dictionary to ConcurrentDictionary

### DIFF
--- a/Source/Csla/Core/FieldManager/PropertyInfoManager.cs
+++ b/Source/Csla/Core/FieldManager/PropertyInfoManager.cs
@@ -73,8 +73,8 @@ namespace Csla.Core.FieldManager
 #if NET5_0_OR_GREATER
       var list = cache.GetOrAdd(objectType, type => 
       {
-        var cacheInstance = AssemblyLoadContextManager.CreateCacheInstance(objectType, new PropertyInfoList(), OnAssemblyLoadContextUnload);
-        FieldDataManager.ForceStaticFieldInit(objectType);
+        var cacheInstance = AssemblyLoadContextManager.CreateCacheInstance(type, new PropertyInfoList(), OnAssemblyLoadContextUnload);
+        FieldDataManager.ForceStaticFieldInit(type);
         return cacheInstance;
       }).Item2;
 #else


### PR DESCRIPTION
This changes the usage from Dictionary to ConcurrentDictionary with less locking.

_BUT_ @rockfordlhotka 

Before this is merged there are things to consider if we should close the issue without addressing it:
The new implementation uses the API of the ConcurrentDictionary `GetOrAdd` this is _most_ of the time harmless.
But the "Add" factory can be _invoked_ multiple times. Due to the implementation of `GetOrAdd`. c.f. [GetOrAdd Docs](https://learn.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentdictionary-2.getoradd?view=net-8.0#system-collections-concurrent-concurrentdictionary-2-getoradd(-0-system-func((-0-1)))) see the remarks part.
That means we have to consider multiple invocations of
* `AssemblyLoadContextManager.CreateCacheInstance(objectType, new PropertyInfoList(), OnAssemblyLoadContextUnload)` in case of > NET5
* `FieldDataManager.ForceStaticFieldInit(type);` in all supported TFMs

Latter iterates over the object to force initialization which I think is acceptable to be invoked multiple times (I suspect here two or three times at most).
Former adds a delegate to the `Unloading` event in case of an unloadable assembly context. Which could be invoked multiple times too. I think this does not do any harm because the second invokation has nothing to do and will be a no-op.

During writing this: Is it possible we have a memory leak with the `Unloading` event subscription? I can't find any deregistration and so we keep the AssemblyLoadContext around?

Fixes #565