### PR TITLE
DefaultTransactionAsyncFlowOption is now used within TransactionalAttribute

### DIFF
--- a/Source/Csla/Configuration/Fluent/DataOptions.cs
+++ b/Source/Csla/Configuration/Fluent/DataOptions.cs
@@ -34,11 +34,21 @@ namespace Csla.Configuration
       set => defaultTransactionTimeoutInSeconds = value;
     }
 
-    internal static TransactionIsolationLevel defaultTransactionIsolationLevel = TransactionIsolationLevel.Unspecified;
-    internal static int defaultTransactionTimeoutInSeconds = 30;
+    /// <summary>
+    /// Sets the default transaction async flow option
+    /// used to create new TransactionScope objects.
+    /// </summary>
+    public TransactionScopeAsyncFlowOption DefaultTransactionAsyncFlowOption {
+      get => defaultTransactionScopeAsyncFlowOption;
+      set => defaultTransactionScopeAsyncFlowOption = value;
+    }
+
+    private static TransactionIsolationLevel defaultTransactionIsolationLevel = TransactionIsolationLevel.Unspecified;
+    private static int defaultTransactionTimeoutInSeconds = 30;
+    private static TransactionScopeAsyncFlowOption defaultTransactionScopeAsyncFlowOption = TransactionScopeAsyncFlowOption.Suppress;
 
     /// <summary>
-    /// Gets or sets the default transaction isolation level.
+    /// Gets the default transaction isolation level.
     /// </summary>
     /// <value>
     /// The default transaction isolation level.
@@ -46,7 +56,7 @@ namespace Csla.Configuration
     internal static TransactionIsolationLevel GetDefaultTransactionIsolationLevel() => defaultTransactionIsolationLevel;
 
     /// <summary>
-    /// Gets or sets the default transaction timeout in seconds.
+    /// Gets default transaction timeout in seconds.
     /// </summary>
     /// <value>
     /// The default transaction timeout in seconds.
@@ -54,10 +64,10 @@ namespace Csla.Configuration
     internal static int GetDefaultTransactionTimeoutInSeconds() => defaultTransactionTimeoutInSeconds;
 
     /// <summary>
-    /// Sets the default transaction async flow option
-    /// used to create new TransactionScope objects.
+    /// Gets the default transaction scope async flow option.
     /// </summary>
-    public TransactionScopeAsyncFlowOption DefaultTransactionAsyncFlowOption { get; set; } = System.Transactions.TransactionScopeAsyncFlowOption.Suppress;
+    /// <returns>The default transaction scope async flow option.</returns>
+    internal static TransactionScopeAsyncFlowOption GetDefaultTransactionScopeAsyncFlowOption() => defaultTransactionScopeAsyncFlowOption;
 
 #if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
     /// <summary>

--- a/Source/Csla/TransactionalAttribute.cs
+++ b/Source/Csla/TransactionalAttribute.cs
@@ -56,18 +56,8 @@ namespace Csla
     /// Specifies the transactional context within which the
     /// method should run.</param>
     public TransactionalAttribute(TransactionalTypes transactionType)
+      : this(transactionType, Configuration.DataOptions.GetDefaultTransactionIsolationLevel())
     {
-      TransactionType = transactionType;
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
-      if (transactionType == TransactionalTypes.TransactionScope)
-#else
-      if (transactionType == TransactionalTypes.TransactionScope || 
-        transactionType == TransactionalTypes.EnterpriseServices)
-#endif
-      {
-        TransactionIsolationLevel = Configuration.DataOptions.GetDefaultTransactionIsolationLevel();
-        TimeoutInSeconds = Configuration.DataOptions.GetDefaultTransactionTimeoutInSeconds();
-      }
     }
 
     /// <summary>
@@ -82,46 +72,9 @@ namespace Csla
     /// Default can be specified in .config file via CslaTransactionIsolationLevel setting
     /// If none specified, Serializable level is used
     /// </param>
-    /// <param name="timeoutInSeconds">
-    /// Timeout for transaction, in seconds
-    /// </param>
-    public TransactionalAttribute(
-      TransactionalTypes transactionType,
-      TransactionIsolationLevel transactionIsolationLevel,
-      int timeoutInSeconds)
+    public TransactionalAttribute(TransactionalTypes transactionType, TransactionIsolationLevel transactionIsolationLevel)
+      : this(transactionType, transactionIsolationLevel, Configuration.DataOptions.GetDefaultTransactionTimeoutInSeconds())
     {
-      TransactionType = transactionType;
-      TransactionIsolationLevel = transactionIsolationLevel;
-      TimeoutInSeconds = timeoutInSeconds;
-    }
-
-    /// <summary>
-    /// Marks a method to run within the specified
-    /// type of transactional context.
-    /// </summary>
-    /// <param name="transactionType">
-    /// Specifies the transactional context within which the
-    /// method should run.</param>
-    /// <param name="transactionIsolationLevel">
-    /// Specifies override for transaction isolation level.
-    /// Default can be specified in .config file via CslaTransactionIsolationLevel setting
-    /// If none specified, Serializable level is used
-    /// </param>
-    public TransactionalAttribute(
-      TransactionalTypes transactionType,
-      TransactionIsolationLevel transactionIsolationLevel)
-    {
-      TransactionType = transactionType;
-      TransactionIsolationLevel = transactionIsolationLevel;
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
-      if (transactionType == TransactionalTypes.TransactionScope)
-#else
-      if (transactionType == TransactionalTypes.TransactionScope ||
-        transactionType == TransactionalTypes.EnterpriseServices)
-#endif
-      {
-        TimeoutInSeconds = Csla.Configuration.DataOptions.GetDefaultTransactionTimeoutInSeconds();
-      }
     }
 
     /// <summary>
@@ -140,22 +93,53 @@ namespace Csla
     /// Specifies the async flow option used to initialize
     /// the transaction.
     /// </param>
-    public TransactionalAttribute(
-      TransactionalTypes transactionType,
-      TransactionIsolationLevel transactionIsolationLevel,
-      TransactionScopeAsyncFlowOption asyncFlowOption)
+    public TransactionalAttribute(TransactionalTypes transactionType, TransactionIsolationLevel transactionIsolationLevel, TransactionScopeAsyncFlowOption asyncFlowOption)
+      : this(transactionType, transactionIsolationLevel, Configuration.DataOptions.GetDefaultTransactionTimeoutInSeconds(), asyncFlowOption) {
+    }
+
+    /// <summary>
+    /// Marks a method to run within the specified
+    /// type of transactional context.
+    /// </summary>
+    /// <param name="transactionType">
+    /// Specifies the transactional context within which the
+    /// method should run.</param>
+    /// <param name="transactionIsolationLevel">
+    /// Specifies override for transaction isolation level.
+    /// Default can be specified in .config file via CslaTransactionIsolationLevel setting
+    /// If none specified, Serializable level is used
+    /// </param>
+    /// <param name="timeoutInSeconds">
+    /// Timeout for transaction, in seconds
+    /// </param>
+    public TransactionalAttribute(TransactionalTypes transactionType, TransactionIsolationLevel transactionIsolationLevel, int timeoutInSeconds)
+      : this(transactionType, transactionIsolationLevel, timeoutInSeconds, Configuration.DataOptions.GetDefaultTransactionScopeAsyncFlowOption())
     {
+    }
+
+    /// <summary>
+    /// Marks a method to run within the specified
+    /// type of transactional context.
+    /// </summary>
+    /// <param name="transactionType">
+    /// Specifies the transactional context within which the
+    /// method should run.</param>
+    /// <param name="transactionIsolationLevel">
+    /// Specifies override for transaction isolation level.
+    /// Default can be specified in .config file via CslaTransactionIsolationLevel setting
+    /// If none specified, Serializable level is used
+    /// </param>
+    /// <param name="timeoutInSeconds">
+    /// Timeout for transaction, in seconds
+    /// </param>
+    /// <param name="asyncFlowOption">
+    /// Specifies the async flow option used to initialize
+    /// the transaction.
+    /// </param>
+    public TransactionalAttribute(TransactionalTypes transactionType, TransactionIsolationLevel transactionIsolationLevel, int timeoutInSeconds, TransactionScopeAsyncFlowOption asyncFlowOption) {
       TransactionType = transactionType;
       TransactionIsolationLevel = transactionIsolationLevel;
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
-      if (transactionType == TransactionalTypes.TransactionScope)
-#else
-      if (transactionType == TransactionalTypes.TransactionScope ||
-        transactionType == TransactionalTypes.EnterpriseServices)
-#endif
-      {
-        TimeoutInSeconds = Configuration.DataOptions.GetDefaultTransactionTimeoutInSeconds();
-      }
+      TimeoutInSeconds = timeoutInSeconds;
       AsyncFlowOption = asyncFlowOption;
     }
 
@@ -163,14 +147,14 @@ namespace Csla
     /// Gets the type of transaction requested by the
     /// business object method.
     /// </summary>
-    public TransactionalTypes TransactionType { get; private set; }
+    public TransactionalTypes TransactionType { get; }
 
     /// <summary>
     /// Specifies override for transaction isolation level.
     /// Default can be specified in .config file via CslaTransactionIsolationLevel setting
     /// If none specified, Serializable level is used
     /// </summary>
-    public TransactionIsolationLevel TransactionIsolationLevel { get; private set; }
+    public TransactionIsolationLevel TransactionIsolationLevel { get; }
 
     /// <summary>
     /// Timeout for transaction, in seconds
@@ -178,12 +162,11 @@ namespace Csla
     /// <value>
     /// The timeout for transaction, in seconds
     /// </value>
-    public int TimeoutInSeconds { get; private set; }
+    public int TimeoutInSeconds { get; }
 
     /// <summary>
     /// Gets the AsyncFlowOption for this transaction
     /// </summary>
-    public TransactionScopeAsyncFlowOption AsyncFlowOption { get; private set; } = 
-      TransactionScopeAsyncFlowOption.Suppress;
+    public TransactionScopeAsyncFlowOption AsyncFlowOption { get; }
   }
 }


### PR DESCRIPTION
Reorganized TransactionalAttribute ctors (from smallest to biggest ctor) and chaining ctors to have consistency.

To be discussed:
I removed a lot of if-else within the `TransactionalAttribute` because it somehwat doesn't make sense to me to not apply the defaults always. The framework decides whether the propertys and values are used or not. This makes the code more easier to read and less error prone.

Fixes #3206
