### PR TITLE
Add csharp_new_line_before_open_brace=all to editorconfig

### DIFF
--- a/Source/.editorconfig
+++ b/Source/.editorconfig
@@ -4,6 +4,7 @@ indent_style = space
 indent_size = 2
 
 [*.cs]
+csharp_new_line_before_open_brace = all
 csharp_new_line_before_catch = true
 csharp_new_line_before_else = true
 csharp_new_line_before_finally = true


### PR DESCRIPTION
Add `csharp_new_line_before_open_brace = all` [New-line options](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/csharp-formatting-options#new-line-options)

I personally use the style
```csharp
public void Foo() {
}
```
instead of (the now demanded by editorconfig)
```csharp
public void Foo()
{
}
```
so this change just means a bit less clean up work (for me) and other who have other personal coding styles.