### PR TITLE
avoid incorrect as usage in PropertyStatus.popup_Loaded

### DIFF
--- a/Source/Csla.Xaml.Shared/PropertyStatus.cs
+++ b/Source/Csla.Xaml.Shared/PropertyStatus.cs
@@ -508,18 +508,19 @@ namespace Csla.Xaml
 
     void popup_Loaded(object sender, RoutedEventArgs e)
     {
-      (sender as Popup).Loaded -= popup_Loaded;
-      if (((sender as Popup).Child as UIElement).DesiredSize.Height > 0)
+      var popup = (Popup)sender;
+      popup.Loaded -= popup_Loaded;
+      if (popup.Child.DesiredSize.Height > 0)
       {
-        _lastPopupSize = ((sender as Popup).Child as UIElement).DesiredSize;
+        _lastPopupSize = popup.Child.DesiredSize;
       }
       if (_lastAppSize.Width < _lastPosition.X + _popupLastPosition.X + _lastPopupSize.Width)
       {
-        (sender as Popup).HorizontalOffset = _lastAppSize.Width - _lastPosition.X - _popupLastPosition.X - _lastPopupSize.Width;
+        popup.HorizontalOffset = _lastAppSize.Width - _lastPosition.X - _popupLastPosition.X - _lastPopupSize.Width;
       }
       if (_lastAppSize.Height < _lastPosition.Y + _popupLastPosition.Y + _lastPopupSize.Height)
       {
-        (sender as Popup).VerticalOffset = _lastAppSize.Height - _lastPosition.Y - _popupLastPosition.Y - _lastPopupSize.Height;
+        popup.VerticalOffset = _lastAppSize.Height - _lastPosition.Y - _popupLastPosition.Y - _lastPopupSize.Height;
       }
     }
 

--- a/Source/Csla.Xaml.Shared/PropertyStatus.cs
+++ b/Source/Csla.Xaml.Shared/PropertyStatus.cs
@@ -508,18 +508,19 @@ namespace Csla.Xaml
 
     void popup_Loaded(object sender, RoutedEventArgs e)
     {
-      (sender as Popup).Loaded -= popup_Loaded;
-      if ((sender as Popup).Child.DesiredSize.Height > 0)
+      var popup = (Popup)sender;
+      popup.Loaded -= popup_Loaded;
+      if (popup.Child.DesiredSize.Height > 0)
       {
-        _lastPopupSize = (sender as Popup).Child.DesiredSize;
+        _lastPopupSize = popup.Child.DesiredSize;
       }
       if (_lastAppSize.Width < _lastPosition.X + _popupLastPosition.X + _lastPopupSize.Width)
       {
-        (sender as Popup).HorizontalOffset = _lastAppSize.Width - _lastPosition.X - _popupLastPosition.X - _lastPopupSize.Width;
+        popup.HorizontalOffset = _lastAppSize.Width - _lastPosition.X - _popupLastPosition.X - _lastPopupSize.Width;
       }
       if (_lastAppSize.Height < _lastPosition.Y + _popupLastPosition.Y + _lastPopupSize.Height)
       {
-        (sender as Popup).VerticalOffset = _lastAppSize.Height - _lastPosition.Y - _popupLastPosition.Y - _lastPopupSize.Height;
+        popup.VerticalOffset = _lastAppSize.Height - _lastPosition.Y - _popupLastPosition.Y - _lastPopupSize.Height;
       }
     }
 


### PR DESCRIPTION
assumptions are the same. but better to have a cast exception than a null ref exception