### PR TITLE
cleanup CompressionWebClient

### DIFF
--- a/Source/Csla/DataPortalClient/HttpCompressionProxy.cs
+++ b/Source/Csla/DataPortalClient/HttpCompressionProxy.cs
@@ -65,19 +65,23 @@ namespace Csla.Channels.Http
     }
 
 #pragma warning disable SYSLIB0014
-    private class CompressionWebClient : WebClient
+    private class CompressionWebClient(int timeout) : WebClient
     {
-      private int Timeout { get; set; }
-
-      public CompressionWebClient(int timeout) => Timeout = timeout;
-
       protected override WebRequest GetWebRequest(Uri address)
       {
-        var req = base.GetWebRequest(address) as HttpWebRequest;
-        req.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
-        if (Timeout > 0)
-          req.Timeout = Timeout;
-        return req;
+        var webRequest = base.GetWebRequest(address)!;
+
+        if (webRequest is HttpWebRequest httpWebRequest)
+        {
+          httpWebRequest.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
+        }
+
+        if (timeout > 0)
+        {
+          webRequest.Timeout = timeout;
+        }
+
+        return webRequest;
       }
     }
 #pragma warning restore SYSLIB0014


### PR DESCRIPTION
 * use a primary constructor
 * GetWebRequest might not return a HttpWebRequest, so set AutomaticDecompression safely
 * assert the assumption that `base.GetWebRequest(address)` can be null by adding a ! `base.GetWebRequest(address)!`. We could null check here and throw a better exception??