### PR TITLE
Make unit tests "run all" able from within VS

### DIFF
--- a/Source/Csla.TestHelpers/TestResults.cs
+++ b/Source/Csla.TestHelpers/TestResults.cs
@@ -6,6 +6,8 @@
 // <summary>Static, dictionary-style container for test results</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics;
+
 namespace Csla.Test
 {
 
@@ -15,7 +17,17 @@ namespace Csla.Test
   /// </summary>
   public class TestResults
   {
-    private static readonly AsyncLocal<Dictionary<string, string>> _testResults = new();
+    private static AsyncLocal<Dictionary<string, string>> _testResults;
+
+    private static AsyncLocal<Dictionary<string, string>> TestResultsInternal
+    {
+      get
+      {
+        _testResults ??= new();
+        _testResults.Value ??= new();
+        return _testResults;
+      }
+    }
 
     /// <summary>
     /// Add an item to the test results, to indicate an outcome of a particular operation
@@ -24,7 +36,7 @@ namespace Csla.Test
     /// <param name="value">The outcome recorded against the operation</param>
     public static void Add(string key, string value)
     {
-      _testResults.Value.Add(key, value);
+      TestResultsInternal.Value.Add(key, value);
     }
 
     /// <summary>
@@ -34,7 +46,7 @@ namespace Csla.Test
     /// <param name="value">The outcome recorded against the operation</param>
     public static void AddOrOverwrite(string key, string value)
     {
-      _testResults.Value[key] = value;
+      TestResultsInternal.Value[key] = value;
     }
 
     /// <summary>
@@ -44,7 +56,8 @@ namespace Csla.Test
     /// <returns>The value recorded against the operation, or an empty string if no result is found</returns>
     public static string GetResult(string key)
     {
-      if (!_testResults.Value.TryGetValue(key, out var result)) return string.Empty;
+      if (!TestResultsInternal.Value.TryGetValue(key, out var result)) 
+        return string.Empty;
 
       return result;
     }
@@ -56,7 +69,7 @@ namespace Csla.Test
     /// <returns>Whether the key is present in the dictionary of results</returns>
     public static bool ContainsResult(string key)
     {
-      return _testResults.Value.ContainsKey(key);
+      return TestResultsInternal.Value.ContainsKey(key);
     }
 
     /// <summary>
@@ -64,8 +77,9 @@ namespace Csla.Test
     /// </summary>
     public static void Reinitialise()
     {
-      if (_testResults.Value is null) _testResults.Value = new Dictionary<string, string>();
-      _testResults.Value.Clear();
+      if (TestResultsInternal.Value is null)
+        TestResultsInternal.Value = new Dictionary<string, string>();
+      TestResultsInternal.Value.Clear();
     }
 
   }

--- a/Source/Csla.test/DataPortal/DataPortalTests.cs
+++ b/Source/Csla.test/DataPortal/DataPortalTests.cs
@@ -293,11 +293,22 @@ namespace Csla.Test.DataPortal
     [TestMethod]
     public async Task WhenCreatingANewObjectThePortalMustWaitAfterCreateUntilTheObjectIsNotBusyAnymore()
     {
-      var dataPortal = _testDIContext.CreateDataPortal<ObjectStillBusyAfterCreate>();
+      var cslaOptions = _testDIContext.ServiceProvider.GetRequiredService<CslaOptions>();
+      int oldTimeout = cslaOptions.DefaultWaitForIdleTimeoutInSeconds;
+      try
+      {
+        cslaOptions.DefaultWaitForIdleTimeoutInSeconds = 5;
 
-      var obj = await dataPortal.CreateAsync();
+        var dataPortal = _testDIContext.CreateDataPortal<ObjectStillBusyAfterCreate>();
 
-      obj.IsBusy.Should().BeFalse();
+        var obj = await dataPortal.CreateAsync();
+
+        obj.IsBusy.Should().BeFalse();
+      }
+      finally
+      {
+        cslaOptions.DefaultWaitForIdleTimeoutInSeconds = oldTimeout;
+      }
     }
 
     private void ClientPortal_DataPortalInvoke(DataPortalEventArgs obj)


### PR DESCRIPTION
I have _no clue_ why and how `AsyncLocal` correctly functions. But during running all tests in one run I saw a couple of null reference exceptions when trying to add stuff into the `TestResults` static field.
So I moved away from the pure field to an property which ensures all is always not null and now the tests run again. Again: I have no clue why `AsyncLocal` isn't doing it's thing always. Maybe someone can shed some light on it?

* Ensure the variables are properly initilaized. Tbh I don't know why they are not but now it's ensured.
* Timeout for one test increased due to timing stuff.
