### PR TITLE
Fixes 3857: Remove protected setter from InputPropertes

### DIFF
--- a/Source/Csla.test/Fakes/Server/BusyStatus/ItemWithAsynchRule.cs
+++ b/Source/Csla.test/Fakes/Server/BusyStatus/ItemWithAsynchRule.cs
@@ -78,7 +78,7 @@ namespace Csla.Testing.Business.BusyStatus
         : base(primaryProperty)
       {
         IsAsync = true;
-        InputProperties = [primaryProperty];
+        InputProperties.Add(primaryProperty);
         base.RunMode = RunModes.DenyOnServerSidePortal | RunModes.DenyCheckRules;
       }
 

--- a/Source/Csla.test/ValidationRules/AsyncRuleRoot.cs
+++ b/Source/Csla.test/ValidationRules/AsyncRuleRoot.cs
@@ -61,7 +61,7 @@ namespace Csla.Test.ValidationRules
       {
         _nameProperty = nameProperty;
         AffectedProperties.Add(nameProperty);
-        InputProperties = [primaryProperty];
+        InputProperties.Add(primaryProperty);
 
         IsAsync = true;
       }

--- a/Source/Csla.test/ValidationRules/CascadeRoot.cs
+++ b/Source/Csla.test/ValidationRules/CascadeRoot.cs
@@ -230,7 +230,6 @@ namespace Csla.Test.ValidationRules
     {
       _primaryProperty = primaryProperty;
       _affectedProperty = affectedProperty;
-      if (InputProperties == null) InputProperties = new List<IPropertyInfo>();
       InputProperties.Add(primaryProperty);
       AffectedProperties.Add(affectedProperty);
     }
@@ -293,7 +292,6 @@ namespace Csla.Test.ValidationRules
     public CalcSumRule(IPropertyInfo primaryProperty, params IPropertyInfo[] inputProperties)
       : base(primaryProperty)
     {
-      InputProperties = new List<IPropertyInfo>();
       InputProperties.AddRange(inputProperties);
     }
 
@@ -322,7 +320,6 @@ namespace Csla.Test.ValidationRules
     {
       _primaryProperty = primaryProperty;
       _affectedProperty = affectedProperty;
-      if (InputProperties == null) InputProperties = new List<IPropertyInfo>();
       InputProperties.Add(primaryProperty);
       AffectedProperties.Add(affectedProperty);
 

--- a/Source/Csla.test/ValidationRules/HasAsyncRule.cs
+++ b/Source/Csla.test/ValidationRules/HasAsyncRule.cs
@@ -33,7 +33,7 @@ namespace Csla.Test.ValidationRules
         : base(primaryProperty)
       {
         IsAsync = true;
-        InputProperties = [primaryProperty];
+        InputProperties.Add(primaryProperty);
       }
 
       protected override void Execute(IRuleContext context)
@@ -76,7 +76,7 @@ namespace Csla.Test.ValidationRules
       {
         IsAsync = true;
         _innerRule = new Rule1(primaryProperty);
-        InputProperties = _innerRule.InputProperties;
+        InputProperties.AddRange(_innerRule.InputProperties);
       }
 
       protected override void Execute(IRuleContext context)
@@ -97,7 +97,7 @@ namespace Csla.Test.ValidationRules
       {
         IsAsync = true;
         _innerRule = new Rule1(primaryProperty);
-        InputProperties = _innerRule.InputProperties;
+        InputProperties.AddRange(_innerRule.InputProperties);
         ProvideTargetWhenAsync = true;
       }
 

--- a/Source/Csla.test/ValidationRules/HasInvalidAsyncRule.cs
+++ b/Source/Csla.test/ValidationRules/HasInvalidAsyncRule.cs
@@ -44,7 +44,7 @@ namespace Csla.Test.ValidationRules
         : base(primaryProperty)
       {
         IsAsync = true;
-        InputProperties = [primaryProperty];
+        InputProperties.Add(primaryProperty);
       }
 
       protected override void Execute(IRuleContext context)

--- a/Source/Csla.test/ValidationRules/RuleBaseClassesRoot.cs
+++ b/Source/Csla.test/ValidationRules/RuleBaseClassesRoot.cs
@@ -141,10 +141,6 @@ namespace Csla.Test.ValidationRules
     public CalcSum(IPropertyInfo primaryProperty, params IPropertyInfo[] inputProperties)
       : base(primaryProperty)
     {
-      if (InputProperties == null)
-      {
-        InputProperties = [];
-      }
       InputProperties.AddRange(inputProperties);
 
       CanRunOnServer = false;
@@ -213,7 +209,8 @@ namespace Csla.Test.ValidationRules
       : base(primaryProperty)
     {
       CompareTo = compareToProperty;
-      InputProperties = [primaryProperty, compareToProperty];
+      InputProperties.Add(primaryProperty);
+      InputProperties.Add(compareToProperty);
       AffectedProperties.Add(compareToProperty);
     }
 
@@ -241,7 +238,7 @@ namespace Csla.Test.ValidationRules
       : base(primaryProperty)
     {
       NameProperty = nameProperty;
-      InputProperties = [primaryProperty];
+      InputProperties.Add(primaryProperty);
       AffectedProperties.Add(NameProperty);
 
       CanRunOnServer = false;

--- a/Source/Csla.test/ValidationRules/ValidationTests.cs
+++ b/Source/Csla.test/ValidationRules/ValidationTests.cs
@@ -736,7 +736,8 @@ namespace Csla.Test.ValidationRules
     {
       SecondaryProperty = secondProperty;
       AffectedProperties.Add(SecondaryProperty);
-      InputProperties = [PrimaryProperty, SecondaryProperty];
+      InputProperties.Add(PrimaryProperty);
+      InputProperties.Add(SecondaryProperty);
     }
 
     protected override void Execute(Rules.IRuleContext context)
@@ -800,7 +801,7 @@ namespace Csla.Test.ValidationRules
       public ToUpper(IPropertyInfo primaryProperty)
         : base(primaryProperty)
       {
-        InputProperties = [primaryProperty];
+        InputProperties.Add(primaryProperty);
       }
 
       protected override void Execute(IRuleContext context)
@@ -837,7 +838,7 @@ namespace Csla.Test.ValidationRules
     public CheckLazyInputFieldExists(Csla.Core.IPropertyInfo primaryProperty)
       : base(primaryProperty)
     {
-      InputProperties = [primaryProperty];
+      InputProperties.Add(primaryProperty);
     }
 
     protected override void Execute(Rules.IRuleContext context)

--- a/Source/Csla/Rules/BusinessRuleBase.cs
+++ b/Source/Csla/Rules/BusinessRuleBase.cs
@@ -6,6 +6,7 @@
 // <summary>Base class used to create business and validation</summary>
 //-----------------------------------------------------------------------
 
+using Csla.Core;
 using Csla.Properties;
 
 namespace Csla.Rules
@@ -16,7 +17,7 @@ namespace Csla.Rules
   /// </summary>
   public abstract class BusinessRuleBase : IBusinessRuleBase
   {
-    private Csla.Core.IPropertyInfo _primaryProperty;
+    private IPropertyInfo _primaryProperty;
     private RunModes _runMode;
     private bool _provideTargetWhenAsync;
     private int _priority;
@@ -38,12 +39,12 @@ namespace Csla.Rules
     /// <summary>
     /// Gets or sets the primary property affected by this rule.
     /// </summary>
-    public virtual Csla.Core.IPropertyInfo PrimaryProperty
+    public virtual IPropertyInfo PrimaryProperty
     {
       get { return _primaryProperty; }
       set
       {
-        CanWriteProperty("PrimaryProperty");
+        CanWriteProperty(nameof(PrimaryProperty));
         _primaryProperty = value;
         this.RuleUri = new RuleUri(this, value);
         if (_primaryProperty != null)
@@ -56,13 +57,13 @@ namespace Csla.Rules
     /// properties are executed after rules for the primary
     /// property.
     /// </summary>
-    public List<Csla.Core.IPropertyInfo> AffectedProperties { get; }
+    public List<IPropertyInfo> AffectedProperties { get; }
 
     /// <summary>
     /// Gets a list of secondary property values to be supplied to the
     /// rule when it is executed.
     /// </summary>
-    public List<Csla.Core.IPropertyInfo> InputProperties { get; protected set; }
+    public List<IPropertyInfo> InputProperties { get; }
 
     /// <summary>
     /// Gets a value indicating whether the rule will run
@@ -80,7 +81,7 @@ namespace Csla.Rules
       get { return _provideTargetWhenAsync; }
       protected set
       {
-        CanWriteProperty("ProvideTargetWhenAsync");
+        CanWriteProperty(nameof(ProvideTargetWhenAsync));
         _provideTargetWhenAsync = value;
       }
     }
@@ -100,7 +101,7 @@ namespace Csla.Rules
       get { return _ruleUri; }
       set
       {
-        CanWriteProperty("RuleUri");
+        CanWriteProperty(nameof(RuleUri));
         _ruleUri = value;
       }
     }
@@ -113,7 +114,7 @@ namespace Csla.Rules
       get { return _priority; }
       set
       {
-        CanWriteProperty("Priority");
+        CanWriteProperty(nameof(Priority));
         _priority = value;
       }
     }
@@ -127,7 +128,7 @@ namespace Csla.Rules
       get { return _runMode; }
       set
       {
-        CanWriteProperty("RunMode");
+        CanWriteProperty(nameof(RunMode));
         _runMode = value;
       }
     }
@@ -138,8 +139,8 @@ namespace Csla.Rules
     /// <param name="argument"></param>
     protected void CanWriteProperty(string argument)
     {
-      if (PropertiesLocked) throw
-        new ArgumentException($"{Resources.PropertySetNotAllowed} ({argument})", argument);
+      if (PropertiesLocked) 
+        throw new ArgumentException($"{Resources.PropertySetNotAllowed} ({argument})", argument);
     }
 
     /// <summary>
@@ -147,10 +148,10 @@ namespace Csla.Rules
     /// to a specfic property.
     /// </summary>
     /// <param name="primaryProperty">Primary property for this rule.</param>
-    protected BusinessRuleBase(Csla.Core.IPropertyInfo primaryProperty)
+    protected BusinessRuleBase(IPropertyInfo primaryProperty)
     {
-      AffectedProperties = new List<Core.IPropertyInfo>();
-      InputProperties = new List<Core.IPropertyInfo>();
+      AffectedProperties = [];
+      InputProperties = [];
       PrimaryProperty = primaryProperty;
       this.RuleUri = new RuleUri(this, primaryProperty);
       RunMode = RunModes.Default;
@@ -174,9 +175,9 @@ namespace Csla.Rules
     /// Loading values does not cause validation rules to be
     /// invoked.
     /// </remarks>
-    protected void LoadProperty(object obj, Csla.Core.IPropertyInfo propertyInfo, object newValue)
+    protected void LoadProperty(object obj, IPropertyInfo propertyInfo, object newValue)
     {
-      if (obj is Core.IManageProperties target)
+      if (obj is IManageProperties target)
         target.LoadProperty(propertyInfo, newValue);
       else
         throw new ArgumentException(Resources.IManagePropertiesRequiredException);
@@ -193,9 +194,9 @@ namespace Csla.Rules
     /// <remarks>
     /// No authorization checks occur when this method is called.
     /// </remarks>
-    protected object ReadProperty(object obj, Csla.Core.IPropertyInfo propertyInfo)
+    protected object ReadProperty(object obj, IPropertyInfo propertyInfo)
     {
-      if (obj is Core.IManageProperties target)
+      if (obj is IManageProperties target)
         return target.ReadProperty(propertyInfo);
       else
         throw new ArgumentException(Resources.IManagePropertiesRequiredException);


### PR DESCRIPTION
- Remove protected set from InputProperties.
- Fix the breaking change
- Some code cleanup (namespace, nameof() instead of magic strings)

Fixes #3857

For discussion: Would it be better to change the `List` to `HashSet` since a property should only be once within the lists? Having a property multiple times in e.g. `InputProperties` will result in an exception due to the usage of `Dictionary.Add` which will throw when a duplicate key is added. And the affected properties are made to be unique with `Distinct()` which could also be discarded if changed to `HashSet`.