### PR TITLE
Re enable CommandBaseTest

### DIFF
--- a/Source/Csla.test/CommandBase/CommandBaseTest.cs
+++ b/Source/Csla.test/CommandBase/CommandBaseTest.cs
@@ -10,7 +10,7 @@ namespace Csla.Test.CommandBase
   [TestClass]
   public class CommandBaseTest : Csla.Server.ObjectFactory
   {
-    public CommandBaseTest(ApplicationContext applicationContext) : base(applicationContext)
+    public CommandBaseTest() : base(null)
     {
     }
 

--- a/Source/Csla.test/CommandBase/CommandBaseTest.cs
+++ b/Source/Csla.test/CommandBase/CommandBaseTest.cs
@@ -24,8 +24,8 @@ namespace Csla.Test.CommandBase
 
     [ClassInitialize()]
     public static void ClassInitialize(TestContext testContext) 
-    { 
-
+    {
+      _ = testContext;
     }
 
     #region Additional test attributes


### PR DESCRIPTION
Those tests weren't running due to the ctor requiring the ApplicationContext. Currently the ObjectFactory does not check for `null` hence it's working. But that will change with #1233. But until then we can use them.