### PR TITLE
Add .ConfigureAwait(false) on (thread) context irrelevant operations

### DIFF
--- a/Source/Csla.Blazor.WebAssembly/State/SessionManager.cs
+++ b/Source/Csla.Blazor.WebAssembly/State/SessionManager.cs
@@ -74,7 +74,7 @@ namespace Csla.Blazor.WebAssembly.State
         if (_session != null)
           lastTouched = _session.LastTouched;
         var url = $"{_options.StateControllerName}?lastTouched={lastTouched}";
-        var stateResult = await client.GetFromJsonAsync<StateResult>(url, ct);
+        var stateResult = await client.GetFromJsonAsync<StateResult>(url, ct).ConfigureAwait(false);
         if (stateResult.ResultStatus == ResultStatuses.Success)
         {
           var formatter = SerializationFormatterFactory.GetFormatter(ApplicationContext);
@@ -144,7 +144,7 @@ namespace Csla.Blazor.WebAssembly.State
         var buffer = new MemoryStream();
         formatter.Serialize(buffer, _session);
         buffer.Position = 0;
-        await client.PutAsJsonAsync<byte[]>(_options.StateControllerName, buffer.ToArray(), ct);
+        await client.PutAsJsonAsync<byte[]>(_options.StateControllerName, buffer.ToArray(), ct).ConfigureAwait(false);
       }
     }
 

--- a/Source/Csla/DataPortalClient/DataPortalProxy.cs
+++ b/Source/Csla/DataPortalClient/DataPortalProxy.cs
@@ -76,7 +76,7 @@ namespace Csla.DataPortalClient
         request.CriteriaData = SerializationFormatterFactory.GetFormatter(ApplicationContext).Serialize(criteria);
         request = ConvertRequest(request);
         var serialized = SerializationFormatterFactory.GetFormatter(ApplicationContext).Serialize(request);
-        serialized = await CallDataPortalServer(serialized, "create", GetRoutingToken(objectType), isSync);
+        serialized = await CallDataPortalServer(serialized, "create", GetRoutingToken(objectType), isSync).ConfigureAwait(false);
         var response = (DataPortalResponse)SerializationFormatterFactory.GetFormatter(ApplicationContext).Deserialize(serialized);
         response = ConvertResponse(response);
 
@@ -137,7 +137,7 @@ namespace Csla.DataPortalClient
 
         var serialized = SerializationFormatterFactory.GetFormatter(ApplicationContext).Serialize(request);
 
-        serialized = await CallDataPortalServer(serialized, "fetch", GetRoutingToken(objectType), isSync);
+        serialized = await CallDataPortalServer(serialized, "fetch", GetRoutingToken(objectType), isSync).ConfigureAwait(false);
 
         var response = (DataPortalResponse)SerializationFormatterFactory.GetFormatter(ApplicationContext).Deserialize(serialized);
         response = ConvertResponse(response);
@@ -192,7 +192,7 @@ namespace Csla.DataPortalClient
 
         var serialized = SerializationFormatterFactory.GetFormatter(ApplicationContext).Serialize(request);
 
-        serialized = await CallDataPortalServer(serialized, "update", GetRoutingToken(obj.GetType()), isSync);
+        serialized = await CallDataPortalServer(serialized, "update", GetRoutingToken(obj.GetType()), isSync).ConfigureAwait(false);
 
         var response = (DataPortalResponse)SerializationFormatterFactory.GetFormatter(ApplicationContext).Deserialize(serialized);
         response = ConvertResponse(response);
@@ -237,8 +237,7 @@ namespace Csla.DataPortalClient
     /// <see cref="Server.DataPortalContext" /> object passed to the server.
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public async virtual Task<DataPortalResult> Delete(Type objectType, object criteria, DataPortalContext context,
-      bool isSync)
+    public async virtual Task<DataPortalResult> Delete(Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       DataPortalResult result;
       try
@@ -254,7 +253,7 @@ namespace Csla.DataPortalClient
 
         var serialized = SerializationFormatterFactory.GetFormatter(ApplicationContext).Serialize(request);
 
-        serialized = await CallDataPortalServer(serialized, "delete", GetRoutingToken(objectType), isSync);
+        serialized = await CallDataPortalServer(serialized, "delete", GetRoutingToken(objectType), isSync).ConfigureAwait(false);
 
         var response = (DataPortalResponse)SerializationFormatterFactory.GetFormatter(ApplicationContext).Deserialize(serialized);
         response = ConvertResponse(response);

--- a/Source/Csla/DataPortalClient/HttpProxy.cs
+++ b/Source/Csla/DataPortalClient/HttpProxy.cs
@@ -110,7 +110,7 @@ namespace Csla.Channels.Http
     {
       return isSync
         ? CallViaWebClient(serialized, operation, routingToken)
-        : await CallViaHttpClient(serialized, operation, routingToken);
+        : await CallViaHttpClient(serialized, operation, routingToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -162,12 +162,12 @@ namespace Csla.Channels.Http
         httpRequest.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
       }
 #endif
-      using var httpResponse = await client.SendAsync(httpRequest);
-      await VerifyResponseSuccess(httpResponse);
+      using var httpResponse = await client.SendAsync(httpRequest).ConfigureAwait(false);
+      await VerifyResponseSuccess(httpResponse).ConfigureAwait(false);
       if (Options.UseTextSerialization)
-        serialized = Convert.FromBase64String(await httpResponse.Content.ReadAsStringAsync());
+        serialized = Convert.FromBase64String(await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false));
       else
-        serialized = await httpResponse.Content.ReadAsByteArrayAsync();
+        serialized = await httpResponse.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
       return serialized;
     }
 
@@ -219,7 +219,7 @@ namespace Csla.Channels.Http
         message.Append((int)httpResponse.StatusCode);
         message.Append(": ");
         message.Append(httpResponse.ReasonPhrase);
-        var content = await httpResponse.Content.ReadAsStringAsync();
+        var content = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
         if (!string.IsNullOrWhiteSpace(content))
         {
           message.AppendLine();


### PR DESCRIPTION
Add some .ConfigureAwait(false) to remove pressure on a sync context when available

Motivation for our WPF application:
We experience a lot of work and pressure on the UI thread due to the current handling of async calls to a remote data portal.
With this PR that should be solved because the low level operations are now free to use a thread pool thread to perform non UI related work.
The PR only adds `.ConfigureAwait(false);` to `await`s where the result _can't_ be known to the UI thread.


@rockfordlhotka Should we consider this a breaking change?