### PR TITLE
Add exception message for string.IsNullOrWhiteSpace() exception

### DIFF
--- a/Source/Csla/Properties/Resources.Designer.cs
+++ b/Source/Csla/Properties/Resources.Designer.cs
@@ -1042,6 +1042,15 @@ namespace Csla.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} must not be null, empty or only consisting of white spaces..
+        /// </summary>
+        public static string StringNotNullOrWhiteSpaceException {
+            get {
+                return ResourceManager.GetString("StringNotNullOrWhiteSpaceException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} required.
         /// </summary>
         public static string StringRequiredRule {

--- a/Source/Csla/Properties/Resources.resx
+++ b/Source/Csla/Properties/Resources.resx
@@ -487,4 +487,7 @@
   <data name="SanitizedServerSideDataPortalDetailedException" xml:space="preserve">
     <value>An exception has occured during a server-side dataportal operation. Request Id: {0}</value>
   </data>
+  <data name="StringNotNullOrWhiteSpaceException" xml:space="preserve">
+    <value>{0} must not be null, empty or only consisting of white spaces.</value>
+  </data>
 </root>


### PR DESCRIPTION
I'm currently working on #1233 to add the nullable annotation context.
Because we have currently a lot of incoming PR's it's a nightmare to have one big add of the context with all those merge conflicts.
Because of that I'm now transitioning to migrate project based to keep the merge hell smaller.
But because I need some general stuff like this localizable exception message to be used I've created this PR.
So I can just keep working and adding stuff as my time allows it.