### PR TITLE
Make WaitForIdle() methods virtual so a user can extend it's functionality

### DIFF
--- a/Source/Csla/BusinessBase.cs
+++ b/Source/Csla/BusinessBase.cs
@@ -85,36 +85,6 @@ namespace Csla
     #region Data Access
 
     /// <summary>
-    /// Await this method to ensure business object
-    /// is not busy running async rules.
-    /// </summary>
-    public async Task WaitForIdle()
-    {
-      var cslaOptions = ApplicationContext.GetRequiredService<Configuration.CslaOptions>();
-      await WaitForIdle(TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds)).ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Await this method to ensure business object
-    /// is not busy running async rules.
-    /// </summary>
-    /// <param name="timeout">Timeout duration</param>
-    public Task WaitForIdle(TimeSpan timeout)
-    {
-      return BusyHelper.WaitForIdle(this, timeout);
-    }
-
-    /// <summary>
-    /// Await this method to ensure the business object
-    /// is not busy running async rules.
-    /// </summary>
-    /// <param name="ct">Cancellation token.</param>
-    public Task WaitForIdle(CancellationToken ct)
-    {
-      return BusyHelper.WaitForIdle(this, ct);
-    }
-
-    /// <summary>
     /// Saves the object to the database.
     /// </summary>
     /// <remarks>

--- a/Source/Csla/BusinessBindingListBase.cs
+++ b/Source/Csla/BusinessBindingListBase.cs
@@ -705,33 +705,12 @@ namespace Csla
     #region IsDirty, IsValid, IsSavable
 
     /// <summary>
-    /// Await this method to ensure business object
-    /// is not busy running async rules.
+    /// Await this method to ensure business object is not busy.
     /// </summary>
     public async Task WaitForIdle()
     {
       var cslaOptions = ApplicationContext.GetRequiredService<Configuration.CslaOptions>();
       await WaitForIdle(TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds)).ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Await this method to ensure business object
-    /// is not busy running async rules.
-    /// </summary>
-    /// <param name="timeout">Timeout duration</param>
-    public Task WaitForIdle(TimeSpan timeout)
-    {
-      return BusyHelper.WaitForIdle(this, timeout);
-    }
-
-    /// <summary>
-    /// Await this method to ensure the business object
-    /// is not busy running async rules.
-    /// </summary>
-    /// <param name="ct">Cancellation token.</param>
-    public Task WaitForIdle(CancellationToken ct)
-    {
-      return BusyHelper.WaitForIdle(this, ct);
     }
 
     /// <summary>

--- a/Source/Csla/BusinessListBase.cs
+++ b/Source/Csla/BusinessListBase.cs
@@ -723,33 +723,12 @@ namespace Csla
     #region IsDirty, IsValid, IsSavable
 
     /// <summary>
-    /// Await this method to ensure business object
-    /// is not busy running async rules.
+    /// Await this method to ensure business object is not busy.
     /// </summary>
     public async Task WaitForIdle()
     {
       var cslaOptions = ApplicationContext.GetRequiredService<Configuration.CslaOptions>();
       await WaitForIdle(TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds)).ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Await this method to ensure business object
-    /// is not busy running async rules.
-    /// </summary>
-    /// <param name="timeout">Timeout duration</param>
-    public Task WaitForIdle(TimeSpan timeout)
-    {
-      return BusyHelper.WaitForIdle(this, timeout);
-    }
-
-    /// <summary>
-    /// Await this method to ensure the business object
-    /// is not busy running async rules.
-    /// </summary>
-    /// <param name="ct">Cancellation token.</param>
-    public Task WaitForIdle(CancellationToken ct)
-    {
-      return BusyHelper.WaitForIdle(this, ct);
     }
 
     /// <summary>

--- a/Source/Csla/Core/BusinessBase.cs
+++ b/Source/Csla/Core/BusinessBase.cs
@@ -1240,9 +1240,9 @@ namespace Csla.Core
     /// Await this method to ensure business object is not busy.
     /// </summary>
     /// <param name="timeout">Timeout duration</param>
-    public virtual Task WaitForIdle(TimeSpan timeout)
+    public Task WaitForIdle(TimeSpan timeout)
     {
-      return BusyHelper.WaitForIdle(this, timeout);
+      return BusyHelper.WaitForIdleAsTimeout(() => WaitForIdle(timeout.ToCancellationToken()), this.GetType(), nameof(WaitForIdle), timeout);
     }
 
     /// <summary>

--- a/Source/Csla/Core/BusinessBase.cs
+++ b/Source/Csla/Core/BusinessBase.cs
@@ -1228,6 +1228,33 @@ namespace Csla.Core
     #region Data Access
 
     /// <summary>
+    /// Await this method to ensure business object is not busy.
+    /// </summary>
+    public async Task WaitForIdle()
+    {
+      var cslaOptions = ApplicationContext.GetRequiredService<Configuration.CslaOptions>();
+      await WaitForIdle(TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds)).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Await this method to ensure business object is not busy.
+    /// </summary>
+    /// <param name="timeout">Timeout duration</param>
+    public virtual Task WaitForIdle(TimeSpan timeout)
+    {
+      return BusyHelper.WaitForIdle(this, timeout);
+    }
+
+    /// <summary>
+    /// Await this method to ensure the business object is not busy.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    public virtual Task WaitForIdle(CancellationToken ct)
+    {
+      return BusyHelper.WaitForIdle(this, ct);
+    }
+
+    /// <summary>
     /// Called by the server-side DataPortal prior to calling the 
     /// requested DataPortal_XYZ method.
     /// </summary>
@@ -3377,8 +3404,8 @@ namespace Csla.Core
 
     async Task IDataPortalTarget.CheckRulesAsync() => await BusinessRules.CheckRulesAsync().ConfigureAwait(false);
 
-    async Task Csla.Server.IDataPortalTarget.WaitForIdle(TimeSpan timeout) => await BusyHelper.WaitForIdle(this, timeout).ConfigureAwait(false);
-    async Task Csla.Server.IDataPortalTarget.WaitForIdle(CancellationToken ct) => await BusyHelper.WaitForIdle(this, ct).ConfigureAwait(false);
+    Task IDataPortalTarget.WaitForIdle(TimeSpan timeout) => WaitForIdle(timeout);
+    Task IDataPortalTarget.WaitForIdle(CancellationToken ct) => WaitForIdle(ct);
 
     void IDataPortalTarget.MarkAsChild()
     {

--- a/Source/Csla/Core/BusyHelper.cs
+++ b/Source/Csla/Core/BusyHelper.cs
@@ -15,6 +15,18 @@ namespace Csla.Core
   /// </summary>
   public static class BusyHelper 
   {
+    internal static async Task WaitForIdleAsTimeout(Func<Task> operation, Type source, string methodName, TimeSpan timeout)
+    {
+      try
+      {
+        await operation();
+      }
+      catch (TaskCanceledException tcex)
+      {
+        throw new TimeoutException($"{source.GetType().FullName}.{methodName} - {timeout}.", tcex);
+      }
+    }
+
     /// <summary>
     /// Waits for the specified <see cref="INotifyBusy"/> object to become idle within the specified timeout.
     /// </summary>

--- a/Source/Csla/Core/ExtendedBindingList.cs
+++ b/Source/Csla/Core/ExtendedBindingList.cs
@@ -157,6 +157,24 @@ namespace Csla.Core
       OnBusyChanged(e);
     }
 
+    /// <summary>
+    /// Await this method to ensure business object is not busy.
+    /// </summary>
+    /// <param name="timeout">Timeout duration</param>
+    public virtual Task WaitForIdle(TimeSpan timeout)
+    {
+      return BusyHelper.WaitForIdle(this, timeout);
+    }
+
+    /// <summary>
+    /// Await this method to ensure the business object is not busy.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    public virtual Task WaitForIdle(CancellationToken ct)
+    {
+      return BusyHelper.WaitForIdle(this, ct);
+    }
+
     [NotUndoable]
     [NonSerialized]
     private EventHandler<ErrorEventArgs> _unhandledAsyncException;

--- a/Source/Csla/Core/ObservableBindingList.cs
+++ b/Source/Csla/Core/ObservableBindingList.cs
@@ -232,6 +232,24 @@ namespace Csla.Core
       OnBusyChanged(e);
     }
 
+    /// <summary>
+    /// Await this method to ensure business object is not busy.
+    /// </summary>
+    /// <param name="timeout">Timeout duration</param>
+    public virtual Task WaitForIdle(TimeSpan timeout)
+    {
+      return BusyHelper.WaitForIdle(this, timeout);
+    }
+
+    /// <summary>
+    /// Await this method to ensure the business object is not busy.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    public virtual Task WaitForIdle(CancellationToken ct)
+    {
+      return BusyHelper.WaitForIdle(this, ct);
+    }
+
     #endregion
 
     #region INotifyUnhandledAsyncException Members

--- a/Source/Csla/DynamicBindingListBase.cs
+++ b/Source/Csla/DynamicBindingListBase.cs
@@ -546,33 +546,12 @@ namespace Csla
     #region IsBusy
 
     /// <summary>
-    /// Await this method to ensure business object
-    /// is not busy running async rules.
+    /// Await this method to ensure business object is not busy.
     /// </summary>
     public async Task WaitForIdle()
     {
       var cslaOptions = ApplicationContext.GetRequiredService<Configuration.CslaOptions>();
       await WaitForIdle(TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds)).ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Await this method to ensure business object
-    /// is not busy running async rules.
-    /// </summary>
-    /// <param name="timeout">Timeout duration</param>
-    public Task WaitForIdle(TimeSpan timeout)
-    {
-      return BusyHelper.WaitForIdle(this, timeout);
-    }
-
-    /// <summary>
-    /// Await this method to ensure the business object
-    /// is not busy running async rules.
-    /// </summary>
-    /// <param name="ct">Cancellation token.</param>
-    public Task WaitForIdle(CancellationToken ct)
-    {
-      return BusyHelper.WaitForIdle(this, ct);
     }
 
     /// <summary>

--- a/Source/Csla/DynamicListBase.cs
+++ b/Source/Csla/DynamicListBase.cs
@@ -435,33 +435,12 @@ namespace Csla
     #region IsBusy
 
     /// <summary>
-    /// Await this method to ensure business object
-    /// is not busy running async rules.
+    /// Await this method to ensure business object is not busy.
     /// </summary>
     public async Task WaitForIdle()
     {
       var cslaOptions = ApplicationContext.GetRequiredService<Configuration.CslaOptions>();
       await WaitForIdle(TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds)).ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Await this method to ensure business object
-    /// is not busy running async rules.
-    /// </summary>
-    /// <param name="timeout">Timeout duration</param>
-    public Task WaitForIdle(TimeSpan timeout)
-    {
-      return BusyHelper.WaitForIdle(this, timeout);
-    }
-
-    /// <summary>
-    /// Await this method to ensure the business object
-    /// is not busy running async rules.
-    /// </summary>
-    /// <param name="ct">Cancellation token.</param>
-    public Task WaitForIdle(CancellationToken ct)
-    {
-        return BusyHelper.WaitForIdle(this, ct);
     }
 
     /// <summary>

--- a/Source/Csla/NameValueListBase.cs
+++ b/Source/Csla/NameValueListBase.cs
@@ -269,6 +269,15 @@ namespace Csla
 
     #region Data Access
 
+    /// <summary>
+    /// Await this method to ensure business object is not busy.
+    /// </summary>
+    public async Task WaitForIdle()
+    {
+      var cslaOptions = ApplicationContext.GetRequiredService<Configuration.CslaOptions>();
+      await WaitForIdle(TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds)).ConfigureAwait(false);
+    }
+
     private void DataPortal_Update()
     {
       throw new NotSupportedException(Resources.UpdateNotSupportedException);
@@ -327,8 +336,8 @@ namespace Csla
 
     Task Server.IDataPortalTarget.CheckRulesAsync() => Task.CompletedTask;
 
-    async Task Csla.Server.IDataPortalTarget.WaitForIdle(TimeSpan timeout) => await BusyHelper.WaitForIdle(this, timeout).ConfigureAwait(false);
-    async Task Csla.Server.IDataPortalTarget.WaitForIdle(CancellationToken ct) => await BusyHelper.WaitForIdle(this, ct).ConfigureAwait(false);
+    async Task Csla.Server.IDataPortalTarget.WaitForIdle(TimeSpan timeout) => await WaitForIdle(timeout).ConfigureAwait(false);
+    async Task Csla.Server.IDataPortalTarget.WaitForIdle(CancellationToken ct) => await WaitForIdle(ct).ConfigureAwait(false);
 
     void Server.IDataPortalTarget.MarkAsChild()
     { }

--- a/Source/Csla/ReadOnlyBindingListBase.cs
+++ b/Source/Csla/ReadOnlyBindingListBase.cs
@@ -194,8 +194,8 @@ namespace Csla
 
     Task Server.IDataPortalTarget.CheckRulesAsync() => Task.CompletedTask;
 
-    async Task Csla.Server.IDataPortalTarget.WaitForIdle(TimeSpan timeout) => await BusyHelper.WaitForIdle(this, timeout).ConfigureAwait(false);
-    async Task Csla.Server.IDataPortalTarget.WaitForIdle(CancellationToken ct) => await BusyHelper.WaitForIdle(this, ct).ConfigureAwait(false);
+    Task Csla.Server.IDataPortalTarget.WaitForIdle(TimeSpan timeout) => WaitForIdle(timeout);
+    Task Csla.Server.IDataPortalTarget.WaitForIdle(CancellationToken ct) => WaitForIdle(ct);
 
     void Server.IDataPortalTarget.MarkAsChild()
     { }

--- a/Source/Csla/ReadOnlyListBase.cs
+++ b/Source/Csla/ReadOnlyListBase.cs
@@ -207,8 +207,8 @@ namespace Csla
 
     Task Server.IDataPortalTarget.CheckRulesAsync() => Task.CompletedTask;
 
-    async Task Csla.Server.IDataPortalTarget.WaitForIdle(TimeSpan timeout) => await BusyHelper.WaitForIdle(this, timeout).ConfigureAwait(false);
-    async Task Csla.Server.IDataPortalTarget.WaitForIdle(CancellationToken ct) => await BusyHelper.WaitForIdle(this, ct).ConfigureAwait(false);
+    Task Csla.Server.IDataPortalTarget.WaitForIdle(TimeSpan timeout) => WaitForIdle(timeout);
+    Task Csla.Server.IDataPortalTarget.WaitForIdle(CancellationToken ct) => WaitForIdle(ct);
 
     void Server.IDataPortalTarget.MarkAsChild()
     { }


### PR DESCRIPTION
* WaitForIdle() methods are now virtual
* Reorganze WaitForIdle() methods to reduce code duplication

@rockfordlhotka 
During the changes I've become unhappy with the currenty `WaitForIdle()` structure, because a user would now have to override two methods to get consistent behavior. The methods with `TimeSpan` and `CancellationToken` because the first throws a `TimeoutException` and the latter a `TaskCanceledException`. I understand _why_ both implementation use different exceptions but from a user perspective it's awkward to override two methods to have consistent behavior. Any ideas?