### PR TITLE
Update project to .NET 8.0 and refactor code

### DIFF
--- a/NuGet/Definition/Csla.AspNetCore.NuSpec
+++ b/NuGet/Definition/Csla.AspNetCore.NuSpec
@@ -16,11 +16,6 @@
     <description>UI helpers for using CSLA .NET business types with AspNetCore.</description>
     <language>en-US</language>
     <dependencies>
-      <group targetFramework="net6.0">
-        <dependency id="Csla" version="[4.6.3-Beta10]" />
-        <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" />
-        <dependency id="Microsoft.AspNetCore.Components.Authorization" version="6.0.25" />
-      </group>
       <group targetFramework="net8.0">
         <dependency id="Csla" version="[4.6.3-Beta10]" />
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.0" />
@@ -29,8 +24,6 @@
     </dependencies>
   </metadata>
   <files>
-    <!-- Net6.0 Assembly -->
-    <file src="..\..\bin\Release\net6.0\**\Csla.AspNetCore.*" target="lib\net6.0" />
     <!-- Net8.0 Assembly -->
     <file src="..\..\bin\Release\net8.0\**\Csla.AspNetCore.*" target="lib\net8.0" />
     <!-- resources -->

--- a/NuGet/Definition/Csla.Blazor.NuSpec
+++ b/NuGet/Definition/Csla.Blazor.NuSpec
@@ -16,12 +16,6 @@
     <description>UI helpers for using CSLA .NET business types with Blazor.</description>
     <language>en-US</language>
     <dependencies>
-      <group targetFramework="net6.0">
-        <dependency id="Csla" version="[4.6.3-Beta10]" />
-        <dependency id="Microsoft.AspNetCore.Components" version="6.0.25" />
-        <dependency id="Microsoft.AspNetCore.Components.Web" version="6.0.25" />
-        <dependency id="Microsoft.AspNetCore.Components.Authorization" version="6.0.25" />
-      </group>
       <group targetFramework="net8.0">
         <dependency id="Csla" version="[4.6.3-Beta10]" />
         <dependency id="Microsoft.AspNetCore.Components" version="8.0.0" />
@@ -35,10 +29,6 @@
     <file src="..\..\bin\Release\net8.0\**\Csla.Blazor.dll" target="lib\net8.0" />
     <file src="..\..\bin\Release\net8.0\**\Csla.Blazor.pdb" target="lib\net8.0" />
     <file src="..\..\bin\Release\net8.0\**\Csla.Blazor.xml" target="lib\net8.0" />
-    <!-- Net6.0 Assembly -->
-    <file src="..\..\bin\Release\net6.0\**\Csla.Blazor.dll" target="lib\net6.0" />
-    <file src="..\..\bin\Release\net6.0\**\Csla.Blazor.pdb" target="lib\net6.0" />
-    <file src="..\..\bin\Release\net6.0\**\Csla.Blazor.xml" target="lib\net6.0" />
     <!-- resources -->
     <file src="..\..\Support\Logos\csla.png" target="images\" />
     <file src="..\..\Support\readme.md" target="docs\" />

--- a/NuGet/Definition/Csla.Blazor.WebAssembly.NuSpec
+++ b/NuGet/Definition/Csla.Blazor.WebAssembly.NuSpec
@@ -16,12 +16,6 @@
     <description>UI helpers for using CSLA .NET business types with Blazor WebAssembly.</description>
     <language>en-US</language>
     <dependencies>
-      <group targetFramework="net6.0">
-        <dependency id="Csla" version="[4.6.3-Beta10]" />
-        <dependency id="Csla.Blazor" version="[4.6.3-Beta10]" />
-        <dependency id="Microsoft.AspNetCore.Components.WebAssembly" version="6.0.25" />
-        <dependency id="System.Net.Http.Json" version="6.0.1" />
-      </group>
       <group targetFramework="net8.0">
         <dependency id="Csla" version="[4.6.3-Beta10]" />
         <dependency id="Csla.Blazor" version="[4.6.3-Beta10]" />
@@ -33,8 +27,6 @@
   <files>
     <!-- Net8.0 Assembly -->
     <file src="..\..\bin\Release\net8.0\**\Csla.Blazor.WebAssembly.*" target="lib\net8.0" />
-    <!-- Net6.0 Assembly -->
-    <file src="..\..\bin\Release\net6.0\**\Csla.Blazor.WebAssembly.*" target="lib\net6.0" />
     <!-- resources -->
     <file src="..\..\Support\Logos\csla.png" target="images\" />
     <file src="..\..\Support\readme.md" target="docs\" />

--- a/NuGet/Definition/Csla.Channels.RabbitMq.NuSpec
+++ b/NuGet/Definition/Csla.Channels.RabbitMq.NuSpec
@@ -20,7 +20,7 @@
         <dependency id="Csla" version="[4.6.3-Beta10]" />
         <dependency id="RabbitMQ.Client" version="6.8.1" />
       </group>
-      <group targetFramework="net6.0">
+      <group targetFramework="net8.0">
         <dependency id="Csla" version="[4.6.3-Beta10]" />
         <dependency id="RabbitMQ.Client" version="6.8.1" />
       </group>
@@ -29,8 +29,8 @@
   <files>
     <!-- NetStandard Assembly -->
     <file src="..\..\bin\Release\netstandard2.1\**\Csla.Channels.RabbitMq.*" target="lib\netstandard2.1" />
-    <!-- net6.0 Assembly -->
-    <file src="..\..\bin\Release\net6.0\**\Csla.Channels.RabbitMq.*" target="lib\net6.0" />
+    <!-- net8.0 Assembly -->
+    <file src="..\..\bin\Release\net8.0\**\Csla.Channels.RabbitMq.*" target="lib\net8.0" />
     <!-- resources -->
     <file src="..\..\Support\Logos\csla.png" target="images\" />
     <file src="..\..\Support\readme.md" target="docs\" />

--- a/NuGet/Definition/Csla.NuSpec
+++ b/NuGet/Definition/Csla.NuSpec
@@ -73,15 +73,6 @@
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" />
         <dependency id="System.ComponentModel.Annotations" version="5.0.0" />
       </group>
-      <group targetFramework="net6.0">
-        <dependency id="Microsoft.Extensions.Configuration" version="6.0.1" />
-        <dependency id="Microsoft.Extensions.Configuration.Binder" version="6.0.0" />
-        <dependency id="Microsoft.Extensions.DependencyInjection" version="6.0.0" />
-        <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" />
-        <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.4" />
-        <dependency id="System.ComponentModel.Annotations" version="5.0.0" />
-        <dependency id="System.Runtime.Loader" version="4.3.0" />
-      </group>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Extensions.Configuration" version="8.0.0" />
         <dependency id="Microsoft.Extensions.Configuration.Binder" version="8.0.0" />
@@ -105,11 +96,6 @@
     <file src="..\..\bin\Release\net8.0\**\Csla.pdb*" target="lib\net8.0" />
     <file src="..\..\bin\Release\net8.0\**\Csla.xml*" target="lib\net8.0" />
     <file src="..\..\bin\Release\net8.0\**\Csla.resources.dll*" target="lib\net8.0" />
-    <!-- Net 6.0 Assembly -->
-    <file src="..\..\bin\Release\net6.0\**\Csla.dll*" target="lib\net6.0" />
-    <file src="..\..\bin\Release\net6.0\**\Csla.pdb*" target="lib\net6.0" />
-    <file src="..\..\bin\Release\net6.0\**\Csla.xml*" target="lib\net6.0" />
-    <file src="..\..\bin\Release\net6.0\**\Csla.resources.dll*" target="lib\net6.0" />
     <!-- .NET 4.6.2 -->
     <file src="..\..\Bin\Release\NET462\**\Csla.dll*" target="lib\net462" />
     <file src="..\..\Bin\Release\NET462\**\Csla.pdb*" target="lib\net462" />

--- a/NuGet/Definition/Csla.Windows.Forms.NuSpec
+++ b/NuGet/Definition/Csla.Windows.Forms.NuSpec
@@ -21,11 +21,6 @@
         <dependency id="Microsoft.Extensions.Hosting" version="5.0.0" />
         <dependency id="Microsoft.Extensions.Hosting.Abstractions" version="5.0.0" />
       </group>
-      <group targetFramework="net6.0-windows10.0.19041.0">
-        <dependency id="Csla" version="[4.6.3-Beta10]" />
-        <dependency id="Microsoft.Extensions.Hosting" version="6.0.0" />
-        <dependency id="Microsoft.Extensions.Hosting.Abstractions" version="6.0.0" />
-      </group>
       <group targetFramework="net8.0-windows7.0">
         <dependency id="Csla" version="[4.6.3-Beta10]" />
         <dependency id="Microsoft.Extensions.Hosting" version="8.0.0" />
@@ -34,10 +29,8 @@
     </dependencies>
   </metadata>
   <files>
-     <!-- net8.0-windows Assembly -->
+    <!-- net8.0-windows Assembly -->
     <file src="..\..\bin\Release\net8.0-windows\**\Csla.Windows.*" target="lib\net8.0-windows7.0" />
-     <!-- net6.0-windows10.0.19041.0 Assembly -->
-    <file src="..\..\bin\Release\net6.0-windows10.0.19041.0\**\Csla.Windows.*" target="lib\net6.0-windows10.0.19041.0" />
     <!-- .NET 4.6 Client -->
     <file src="..\..\Bin\Release\NET462\**\Csla.Windows.*" target="lib\net462" />
     <!-- resources -->

--- a/NuGet/Definition/Csla.Wpf.NuSpec
+++ b/NuGet/Definition/Csla.Wpf.NuSpec
@@ -21,11 +21,6 @@
         <dependency id="Microsoft.Extensions.Hosting" version="3.1.20" />
         <dependency id="Microsoft.Extensions.Hosting.Abstractions" version="3.1.20" />
       </group>
-      <group targetFramework="net6.0-windows10.0.19041.0">
-        <dependency id="Csla" version="[4.6.3-Beta10]" />
-        <dependency id="Microsoft.Extensions.Hosting" version="6.0.0" />
-        <dependency id="Microsoft.Extensions.Hosting.Abstractions" version="6.0.0" />
-      </group>
       <group targetFramework="net8.0-windows7.0">
         <dependency id="Csla" version="[4.6.3-Beta10]" />
         <dependency id="Microsoft.Extensions.Hosting" version="8.0.0" />
@@ -34,10 +29,8 @@
     </dependencies>
   </metadata>
   <files>
-     <!-- net8.0-windows -->
+    <!-- net8.0-windows -->
     <file src="..\..\bin\Release\net8.0-windows\**\Csla.Xaml.*" target="lib\net8.0-windows7.0" />
-     <!-- net6.0-windows10.0.19041.0 Assembly -->
-    <file src="..\..\bin\Release\net6.0-windows10.0.19041.0\**\Csla.Xaml.*" target="lib\net6.0-windows10.0.19041.0" />
     <!-- .NET 4.6 Client -->
     <file src="..\..\Bin\Release\NET462\**\Csla.Xaml.*" target="lib\net462" />
     <!-- resources -->

--- a/Source/Csla.AspNetCore/ApplicationContextManagerHttpContext.cs
+++ b/Source/Csla.AspNetCore/ApplicationContextManagerHttpContext.cs
@@ -25,7 +25,7 @@ namespace Csla.AspNetCore
     private readonly IRuntimeInfo runtimeInfo;
 
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Gets the active circuit state.
     /// </summary>
@@ -80,7 +80,7 @@ namespace Csla.AspNetCore
         if (runtimeInfo.LocalProxyNewScopeExists)
           return false;
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
         if (ActiveCircuitState.CircuitExists)
           return false;
 #endif

--- a/Source/Csla.AspNetCore/Blazor/ActiveCircuitHandler.cs
+++ b/Source/Csla.AspNetCore/Blazor/ActiveCircuitHandler.cs
@@ -5,7 +5,7 @@
 // </copyright>
 // <summary>Circuit handler indicating if code in server-side Blazor</summary>
 //-----------------------------------------------------------------------
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using Microsoft.AspNetCore.Components.Server.Circuits;
 
 namespace Csla.AspNetCore.Blazor

--- a/Source/Csla.AspNetCore/Blazor/ActiveCircuitState.cs
+++ b/Source/Csla.AspNetCore/Blazor/ActiveCircuitState.cs
@@ -5,7 +5,7 @@
 // </copyright>
 // <summary>Circuit handler indicating if code in server-side Blazor</summary>
 //-----------------------------------------------------------------------
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
 namespace Csla.AspNetCore.Blazor
 {

--- a/Source/Csla.AspNetCore/Blazor/ApplicationContextManagerBlazor.cs
+++ b/Source/Csla.AspNetCore/Blazor/ApplicationContextManagerBlazor.cs
@@ -1,4 +1,4 @@
-﻿#if NET5_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 //-----------------------------------------------------------------------
 // <copyright file="ApplicationContextManager.cs" company="Marimer LLC">
 //     Copyright (c) Marimer LLC. All rights reserved.

--- a/Source/Csla.AspNetCore/Blazor/ApplicationContextManagerInMemory.cs
+++ b/Source/Csla.AspNetCore/Blazor/ApplicationContextManagerInMemory.cs
@@ -1,4 +1,4 @@
-﻿#if NET5_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 //-----------------------------------------------------------------------
 // <copyright file="ApplicationContextManagerInMemory.cs" company="Marimer LLC">
 //     Copyright (c) Marimer LLC. All rights reserved.

--- a/Source/Csla.AspNetCore/ConfigurationExtensions.cs
+++ b/Source/Csla.AspNetCore/ConfigurationExtensions.cs
@@ -6,7 +6,7 @@
 // <summary>Implement extension methods for AspNet configuration</summary>
 //-----------------------------------------------------------------------
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using Csla.AspNetCore.Blazor;
 using Microsoft.AspNetCore.Components.Server.Circuits;
 #endif
@@ -39,7 +39,7 @@ namespace Csla.Configuration
     {
       var localOptions = new AspNetCoreConfigurationOptions();
       options?.Invoke(localOptions);
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
       config.Services.AddScoped<ActiveCircuitState>();
       config.Services.AddScoped(typeof(CircuitHandler), typeof(ActiveCircuitHandler));
 #endif

--- a/Source/Csla.AspNetCore/Csla.AspNetCore.csproj
+++ b/Source/Csla.AspNetCore/Csla.AspNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <AssemblyName>Csla.AspNetCore</AssemblyName>
     <RootNamespace>Csla.AspNetCore</RootNamespace>
     <PackageId>Csla.AspNetCore</PackageId>
@@ -17,11 +17,6 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="6.0.31" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Csla.Blazor.Test/Csla.Blazor.Test.csproj
+++ b/Source/Csla.Blazor.Test/Csla.Blazor.Test.csproj
@@ -19,10 +19,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Csla.AspNetCore\Csla.AspNetCore.csproj" />

--- a/Source/Csla.Blazor.WebAssembly.Tests/Csla.Blazor.WebAssembly.Tests.csproj
+++ b/Source/Csla.Blazor.WebAssembly.Tests/Csla.Blazor.WebAssembly.Tests.csproj
@@ -21,10 +21,6 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Csla.AspNetCore\Csla.AspNetCore.csproj" />
     <ProjectReference Include="..\Csla.Blazor.WebAssembly\Csla.Blazor.WebAssembly.csproj" />

--- a/Source/Csla.Blazor.WebAssembly/Csla.Blazor.WebAssembly.csproj
+++ b/Source/Csla.Blazor.WebAssembly/Csla.Blazor.WebAssembly.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <RazorLangVersion>3.0</RazorLangVersion>
     <Product>CSLA .NET Blazor WebAssembly</Product>
     <Description>UI helpers for using CSLA .NET business types with Blazor WebAssembly.</Description>
@@ -19,11 +19,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;BLAZOR</DefineConstants>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.25" />
-    <PackageReference Include="System.Net.Http.Json" Version="6.0.1" />
-  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />

--- a/Source/Csla.Blazor/Csla.Blazor.csproj
+++ b/Source/Csla.Blazor/Csla.Blazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <RazorLangVersion>3.0</RazorLangVersion>
     <Product>CSLA .NET Blazor</Product>
     <Description>UI helpers for using CSLA .NET business types with Blazor.</Description>
@@ -24,12 +24,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.31" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.25" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="6.0.31" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Csla.Channels.Grpc/Csla.Channels.Grpc.csproj
+++ b/Source/Csla.Channels.Grpc/Csla.Channels.Grpc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0</TargetFrameworks>
     <Product>CSLA .NET gRPC Channel</Product>
     <Description>gRPC data portal channel for CSLA .NET.</Description>
     <SignAssembly>true</SignAssembly>

--- a/Source/Csla.Channels.Grpc/GrpcProxy.cs
+++ b/Source/Csla.Channels.Grpc/GrpcProxy.cs
@@ -64,7 +64,7 @@ namespace Csla.Channels.Grpc
     /// </summary>
     /// <param name="channel">GrpcChannel instance</param>
     /// <exception cref="ArgumentNullException"><paramref name="channel"/> is <see langword="null"/>.</exception>
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [MemberNotNull(nameof(_defaultChannel))]
 #endif
     protected static void SetChannel(GrpcChannel channel)

--- a/Source/Csla.Channels.RabbitMq/Csla.Channels.RabbitMq.csproj
+++ b/Source/Csla.Channels.RabbitMq/Csla.Channels.RabbitMq.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0</TargetFrameworks>
     <Product>CSLA .NET RabbitMQ Channel</Product>
     <Description>RabbitMQ data portal channel for CSLA .NET.</Description>
     <SignAssembly>true</SignAssembly>

--- a/Source/Csla.Channels.RabbitMq/ProxyListener.cs
+++ b/Source/Csla.Channels.RabbitMq/ProxyListener.cs
@@ -73,7 +73,7 @@ namespace Csla.Channels.RabbitMq
     /// Channel, ReplyQueue, and DataPortalQueueName values
     /// used for bi-directional communication.
     /// </summary>
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [MemberNotNull(nameof(Connection), nameof(Channel), nameof(ReplyQueue))]
 #endif
     private void InitializeRabbitMQ()

--- a/Source/Csla.Channels.RabbitMq/RabbitMqPortal.cs
+++ b/Source/Csla.Channels.RabbitMq/RabbitMqPortal.cs
@@ -68,7 +68,7 @@ namespace Csla.Channels.RabbitMq
 
     private Uri? DataPortalUri { get; set; }
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [MemberNotNull(nameof(DataPortalUri), nameof(DataPortalQueueName), nameof(Connection), nameof(Channel))]
 #endif
     private void InitializeRabbitMQ()

--- a/Source/Csla.Channels.RabbitMq/RabbitMqProxy.cs
+++ b/Source/Csla.Channels.RabbitMq/RabbitMqProxy.cs
@@ -68,7 +68,7 @@ namespace Csla.Channels.RabbitMq
     /// Channel, ReplyQueue, and DataPortalQueueName values
     /// used for bi-directional communication.
     /// </summary>
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [MemberNotNull(nameof(Connection), nameof(Channel), nameof(QueueListener))]
 #endif
     protected virtual void InitializeRabbitMQ()

--- a/Source/Csla.Web.Mvc.Shared/Controller.cs
+++ b/Source/Csla.Web.Mvc.Shared/Controller.cs
@@ -6,7 +6,7 @@
 // <summary>Provides methods that respond to HTTP requests</summary>
 //-----------------------------------------------------------------------
 
-#if NETSTANDARD2_0  || NET5_0_OR_GREATER || NETCOREAPP3_1
+#if NETSTANDARD2_0  || NET8_0_OR_GREATER 
 using Csla.Core;
 using Csla.Rules;
 #endif
@@ -17,7 +17,7 @@ namespace Csla.Web.Mvc
   /// Provides methods that respond to HTTP requests
   /// in an ASP.NET MVC web site.
   /// </summary>
-#if NETSTANDARD2_0 || NET5_0_OR_GREATER || NETCOREAPP3_1
+#if NETSTANDARD2_0 || NET8_0_OR_GREATER
   public class Controller : Microsoft.AspNetCore.Mvc.Controller
 #else
   public class Controller : System.Web.Mvc.Controller
@@ -37,7 +37,7 @@ namespace Csla.Web.Mvc
     /// </summary>
     protected ApplicationContext ApplicationContext { get; }
 
-#if NETSTANDARD2_0 || NET5_0_OR_GREATER || NETCOREAPP3_1
+#if NETSTANDARD2_0 || NET8_0_OR_GREATER 
     /// <summary>
     /// Performs a Save() operation on an
     /// editable business object, with appropriate
@@ -47,7 +47,7 @@ namespace Csla.Web.Mvc
     /// <param name="item">The business object to insert.</param>
     /// <param name="forceUpdate">true to force Save() to be an update.</param>
     /// <returns>true the Save() succeeds, false if not.</returns>
-    protected Task<bool> SaveObjectAsync<T>(T item, bool forceUpdate) 
+    protected Task<bool> SaveObjectAsync<T>(T item, bool forceUpdate)
       where T : class, ISavable
     {
       return SaveObjectAsync(item, null, forceUpdate);
@@ -63,7 +63,7 @@ namespace Csla.Web.Mvc
     /// <param name="updateModel">Delegate that invokes the UpdateModel() method.</param>
     /// <param name="forceUpdate">true to force Save() to be an update.</param>
     /// <returns>true the Save() succeeds, false if not.</returns>
-    protected virtual async Task<bool> SaveObjectAsync<T>(T item, Action<T> updateModel, bool forceUpdate) 
+    protected virtual async Task<bool> SaveObjectAsync<T>(T item, Action<T> updateModel, bool forceUpdate)
       where T : class, ISavable
     {
       try

--- a/Source/Csla.Web.Mvc.Shared/CslaModelBinder.cs
+++ b/Source/Csla.Web.Mvc.Shared/CslaModelBinder.cs
@@ -5,7 +5,7 @@
 // </copyright>
 // <summary>Model binder for use with CSLA .NET editable business objects.</summary>
 //-----------------------------------------------------------------------
-#if NETSTANDARD2_0 || NET5_0_OR_GREATER || NETCOREAPP3_1
+#if NETSTANDARD2_0 || NET8_0_OR_GREATER 
 using System.Collections;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.DependencyInjection;

--- a/Source/Csla.Web.Mvc.Shared/CslaModelBinderProvider.cs
+++ b/Source/Csla.Web.Mvc.Shared/CslaModelBinderProvider.cs
@@ -5,7 +5,7 @@
 // </copyright>
 // <summary>Model binder provider.</summary>
 //-----------------------------------------------------------------------
-#if NETSTANDARD2_0 || NET5_0_OR_GREATER || NETCOREAPP3_1
+#if NETSTANDARD2_0 || NET8_0_OR_GREATER 
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Csla.Web.Mvc

--- a/Source/Csla.Web.Mvc.Shared/CslaPermissionRequirement.cs
+++ b/Source/Csla.Web.Mvc.Shared/CslaPermissionRequirement.cs
@@ -5,7 +5,7 @@
 // </copyright>
 // <summary>Restricts callers to an action method.</summary>
 //-----------------------------------------------------------------------
-#if NETSTANDARD2_0 || NET5_0_OR_GREATER || NETCOREAPP3_1
+#if NETSTANDARD2_0 || NET8_0_OR_GREATER 
 using Csla.Rules;
 using Microsoft.AspNetCore.Authorization;
 

--- a/Source/Csla.Web.Mvc.Shared/HasPermissionAttribute.cs
+++ b/Source/Csla.Web.Mvc.Shared/HasPermissionAttribute.cs
@@ -5,7 +5,7 @@
 // </copyright>
 // <summary>Restricts callers to an action method.</summary>
 //-----------------------------------------------------------------------
-#if !NETSTANDARD2_0 && !NETCOREAPP3_1 && !NET5_0_OR_GREATER
+#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
 using System.Web;
 using System.Web.Mvc;
 using Csla.Rules;

--- a/Source/Csla.Web.Mvc.Shared/HtmlExtensions.cs
+++ b/Source/Csla.Web.Mvc.Shared/HtmlExtensions.cs
@@ -5,7 +5,7 @@
 // </copyright>
 // <summary>Html extension methods providing support for HTML rendering based on security permissions in an application.</summary>
 //-----------------------------------------------------------------------
-#if NETSTANDARD2_0 || NET5_0_OR_GREATER || NETCOREAPP3_1
+#if NETSTANDARD2_0 || NET8_0_OR_GREATER 
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
 

--- a/Source/Csla.Web.Mvc.Shared/Server/Hosts/HttpPortalController.cs
+++ b/Source/Csla.Web.Mvc.Shared/Server/Hosts/HttpPortalController.cs
@@ -9,7 +9,7 @@
 using Csla.Serialization;
 using Csla.Server.Hosts.DataPortalChannel;
 
-#if NETSTANDARD2_0 || NET5_0_OR_GREATER || NETCOREAPP3_1
+#if NETSTANDARD2_0 || NET8_0_OR_GREATER 
 using Microsoft.AspNetCore.Mvc;
 #else
 using System.Net.Http;
@@ -22,7 +22,7 @@ namespace Csla.Server.Hosts
   /// Exposes server-side DataPortal functionality
   /// through HTTP request/response.
   /// </summary>
-#if NETSTANDARD2_0 || NET5_0_OR_GREATER || NETCOREAPP3_1
+#if NETSTANDARD2_0 || NET8_0_OR_GREATER 
 
   public class HttpPortalController : Controller
   {
@@ -169,7 +169,7 @@ namespace Csla.Server.Hosts
       set { _portal = value; }
     }
 
-#if NETSTANDARD2_0 || NET5_0_OR_GREATER || NETCOREAPP3_1
+#if NETSTANDARD2_0 || NET8_0_OR_GREATER 
 
     /// <summary>
     /// Override to add elements to the HttpReponse

--- a/Source/Csla.Web.Mvc.Shared/ViewModelBase.cs
+++ b/Source/Csla.Web.Mvc.Shared/ViewModelBase.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0 && !NETCOREAPP3_1 && !NET5_0_OR_GREATER
+﻿#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
 //-----------------------------------------------------------------------
 // <copyright file="ViewModelBase.cs" company="Marimer LLC">
 //     Copyright (c) Marimer LLC. All rights reserved.

--- a/Source/Csla.Web.Mvc.Shared/WebConfiguration.cs
+++ b/Source/Csla.Web.Mvc.Shared/WebConfiguration.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0 || NETCOREAPP3_1 || NET5_0_OR_GREATER
+﻿#if NETSTANDARD2_0  || NET8_0_OR_GREATER
 //-----------------------------------------------------------------------
 // <copyright file="WebConfiguration.cs" company="Marimer LLC">
 //     Copyright (c) Marimer LLC. All rights reserved.
@@ -24,7 +24,7 @@ namespace Csla.Configuration
       return app;
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Configures the application to use CSLA .NET
     /// </summary>

--- a/Source/Csla.Windows/BindingSourceRefresh.cs
+++ b/Source/Csla.Windows/BindingSourceRefresh.cs
@@ -132,7 +132,7 @@ namespace Csla.Windows
     /// </summary>
     [Browsable(false)]
     [DefaultValue(null)]
-#if NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if NETSTANDARD2_0 || NET8_0_OR_GREATER
     [System.ComponentModel.DataAnnotations.ScaffoldColumn(false)]
 #endif
     public ContainerControl Host { get; set; }

--- a/Source/Csla.Windows/Csla.Windows.csproj
+++ b/Source/Csla.Windows/Csla.Windows.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0-windows10.0.19041.0;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <AssemblyName>Csla.Windows</AssemblyName>
     <RootNamespace>Csla.Windows</RootNamespace>

--- a/Source/Csla.Xaml.Shared/ApplicationContextManager.cs
+++ b/Source/Csla.Xaml.Shared/ApplicationContextManager.cs
@@ -44,7 +44,7 @@ namespace Csla.Xaml
     {
       if (_principal == null)
       {
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
         if (OperatingSystem.IsWindows() && !SecurityOptions.FlowSecurityPrincipalFromClient)
           SetUser(new WindowsPrincipal(WindowsIdentity.GetCurrent()));
         else

--- a/Source/Csla.Xaml.Wpf/Csla.Xaml.Wpf.csproj
+++ b/Source/Csla.Xaml.Wpf/Csla.Xaml.Wpf.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows10.0.19041.0;net462;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <AssemblyName>Csla.Xaml</AssemblyName>
     <RootNamespace>Csla.Xaml</RootNamespace>

--- a/Source/Csla/Configuration/Abstraction/ConfigurationManager.cs
+++ b/Source/Csla/Configuration/Abstraction/ConfigurationManager.cs
@@ -18,7 +18,7 @@ namespace Csla.Configuration
   {
     static ConfigurationManager()
     {
-#if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
+#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
       try
       {
         AppSettings = System.Configuration.ConfigurationManager.AppSettings;

--- a/Source/Csla/Configuration/Abstraction/ConnectionStringSettings.cs
+++ b/Source/Csla/Configuration/Abstraction/ConnectionStringSettings.cs
@@ -20,7 +20,7 @@ namespace Csla.Configuration
     public ConnectionStringSettings()
     { }
 
-#if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
+#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
     /// <summary>
     /// Creates an instance of the type.
     /// </summary>

--- a/Source/Csla/Configuration/ConfigurationExtensions.cs
+++ b/Source/Csla/Configuration/ConfigurationExtensions.cs
@@ -1,4 +1,4 @@
-﻿#if NET462_OR_GREATER || NETSTANDARD2_0 || NET6_0_OR_GREATER
+﻿#if NET462_OR_GREATER || NETSTANDARD2_0 || NET8_0_OR_GREATER
 //-----------------------------------------------------------------------
 // <copyright file="ConfigurationExtensions.cs" company="Marimer LLC">
 //     Copyright (c) Marimer LLC. All rights reserved.

--- a/Source/Csla/Core/BusyHelper.cs
+++ b/Source/Csla/Core/BusyHelper.cs
@@ -70,7 +70,7 @@ namespace Csla.Core
         {
           return;
         }
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
         var finishedTask = await tcs.Task.WaitAsync(ct).ConfigureAwait(false);
 #else
         ct.Register(() => tcs.TrySetCanceled(), useSynchronizationContext: false);

--- a/Source/Csla/Core/FieldManager/FieldDataManager.cs
+++ b/Source/Csla/Core/FieldManager/FieldDataManager.cs
@@ -7,7 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.Reflection;
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using System.Runtime.Loader;
 
 using Csla.Runtime;
@@ -106,7 +106,7 @@ namespace Csla.Core.FieldManager
 
     #region ConsolidatedPropertyList
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
     private static Dictionary<Type, Tuple<string, List<IPropertyInfo>>> _consolidatedLists = new Dictionary<Type, Tuple<string, List<IPropertyInfo>>>();
 #else
     private static readonly Dictionary<Type, List<IPropertyInfo>> _consolidatedLists = new();
@@ -120,7 +120,7 @@ namespace Csla.Core.FieldManager
 
       try
       {
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
         found = _consolidatedLists.TryGetValue(type, out var consolidatedListsInfo);
 
         result = consolidatedListsInfo?.Item2;
@@ -135,7 +135,7 @@ namespace Csla.Core.FieldManager
       {
         lock (_consolidatedLists)
         {
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
           if (_consolidatedLists.TryGetValue(type, out var list))
           {
             result = list.Item2;
@@ -859,7 +859,7 @@ namespace Csla.Core.FieldManager
         }
       }
     }
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
     private static void OnAssemblyLoadContextUnload(AssemblyLoadContext context)
     {

--- a/Source/Csla/Core/FieldManager/PropertyInfoManager.cs
+++ b/Source/Csla/Core/FieldManager/PropertyInfoManager.cs
@@ -7,7 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.Collections.Concurrent;
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using System.Runtime.Loader;
 
 using Csla.Runtime;
@@ -34,7 +34,7 @@ namespace Csla.Core.FieldManager
   {
     private static readonly object _cacheLock = new object();
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
     private static ConcurrentDictionary<Type, Tuple<string, PropertyInfoList>> _propertyInfoCache;
 
     private static ConcurrentDictionary<Type, Tuple<string, PropertyInfoList>> PropertyInfoCache
@@ -50,7 +50,7 @@ namespace Csla.Core.FieldManager
         {
           lock (_cacheLock)
           {
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
             if (_propertyInfoCache == null)
               _propertyInfoCache = new ConcurrentDictionary<Type, Tuple<string, PropertyInfoList>>();
 #else
@@ -68,7 +68,7 @@ namespace Csla.Core.FieldManager
     {
       var cache = PropertyInfoCache;
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
       var list = cache.GetOrAdd(objectType, type => 
       {
         lock (_cacheLock) 
@@ -178,7 +178,7 @@ namespace Csla.Core.FieldManager
     {
       return GetRegisteredProperties(objectType).FirstOrDefault(p => p.Name == propertyName);
     }
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
     private static void OnAssemblyLoadContextUnload(AssemblyLoadContext context)
     {

--- a/Source/Csla/Core/UndoableHandler.cs
+++ b/Source/Csla/Core/UndoableHandler.cs
@@ -8,7 +8,7 @@
 // <summary>no summary</summary>
 //-----------------------------------------------------------------------
 using System.Reflection;
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using System.Runtime.Loader;
 
 using Csla.Runtime;
@@ -19,7 +19,7 @@ namespace Csla.Core
 {
     internal static class UndoableHandler
     {
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
         private static readonly Dictionary<Type, Tuple<string, List<DynamicMemberHandle>>> _undoableFieldCache = [];
 #else
         private static readonly Dictionary<Type, List<DynamicMemberHandle>> _undoableFieldCache = [];
@@ -29,7 +29,7 @@ namespace Csla.Core
         {
             List<DynamicMemberHandle> handlers;
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
             var found = _undoableFieldCache.TryGetValue(type, out var handlersInfo);
 
             handlers = handlersInfo?.Item2;
@@ -105,7 +105,7 @@ namespace Csla.Core
             // see if this field is marked as not undoable or IsInitOnly (ie: readonly property)
             return field.IsInitOnly || Attribute.IsDefined(field, typeof(NotUndoableAttribute));
         }
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
         private static void OnAssemblyLoadContextUnload(AssemblyLoadContext context)
         {

--- a/Source/Csla/Csla.csproj
+++ b/Source/Csla/Csla.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net462;net472;net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net472;net48;net8.0</TargetFrameworks>
     <PackageId>Csla</PackageId>
     <Product>CSLA .NET Core</Product>
     <Description>CSLA .NET provides a home for your business logic. It is an application development framework that reduces the cost of building and maintaining applications. The framework enables developers to build an object-oriented business layer for their application that encapsulates all business, authorization and validation logic for the application.</Description>
@@ -64,15 +64,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/Source/Csla/Data/ObjectContextManager.cs
+++ b/Source/Csla/Data/ObjectContextManager.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
+﻿#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
 //-----------------------------------------------------------------------
 // <copyright file="ObjectContextManager.cs" company="Marimer LLC">
 //     Copyright (c) Marimer LLC. All rights reserved.

--- a/Source/Csla/Data/SafeDataReader.cs
+++ b/Source/Csla/Data/SafeDataReader.cs
@@ -7,7 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.Data;
-#if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
+#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
 using System.Data.SqlClient;
 #endif
 
@@ -19,7 +19,7 @@ namespace Csla.Data
   /// </summary>
   public class SafeDataReader : IDataReader
   {
-#if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
+#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
     private SqlDataReader _sqlDataReader;
 #endif
 
@@ -38,12 +38,12 @@ namespace Csla.Data
     public SafeDataReader(IDataReader dataReader)
     {
       DataReader = dataReader;
-#if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
+#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
       _sqlDataReader = DataReader as SqlDataReader;
 #endif
     }
 
-#if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
+#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
     /// <summary>
     /// Asynchronously gets the data value as a type.
     /// </summary>

--- a/Source/Csla/DataPortalClient/HttpProxyOptions.cs
+++ b/Source/Csla/DataPortalClient/HttpProxyOptions.cs
@@ -8,7 +8,7 @@
 //-----------------------------------------------------------------------
 
 using Microsoft.Extensions.DependencyInjection;
-#if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
+#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
 using System.Net.Http;
 #endif
 

--- a/Source/Csla/DataPortalClient/HttpProxyOptionsExtensions.cs
+++ b/Source/Csla/DataPortalClient/HttpProxyOptionsExtensions.cs
@@ -7,7 +7,7 @@
 // <summary>Extensions for HttpProxyOptions</summary>
 //-----------------------------------------------------------------------
 
-#if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
+#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
 using System.Net.Http;
 #endif
 

--- a/Source/Csla/EnterpriseServicesSettings.cs
+++ b/Source/Csla/EnterpriseServicesSettings.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
+#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
 //-----------------------------------------------------------------------
 // <copyright file="EnterpriseServicesSettings.cs" company="Marimer LLC">
 //     Copyright (c) Marimer LLC. All rights reserved.

--- a/Source/Csla/Reflection/DynamicMethodHandlerFactory.cs
+++ b/Source/Csla/Reflection/DynamicMethodHandlerFactory.cs
@@ -8,7 +8,7 @@
 //-----------------------------------------------------------------------
 using System.Linq.Expressions;
 using System.Reflection;
-#if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
+#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
 using System.Reflection.Emit;
 #endif
 using Csla.Properties;
@@ -199,7 +199,7 @@ namespace Csla.Reflection
       return lambda.Compile();
     }
 
-#if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
+#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
     private static void EmitCastToReference(ILGenerator il, Type type)
     {
       if (type.IsValueType)

--- a/Source/Csla/Reflection/MethodCaller.cs
+++ b/Source/Csla/Reflection/MethodCaller.cs
@@ -10,7 +10,7 @@ using System.ComponentModel;
 using System.Reflection;
 using System.Globalization;
 using Csla.Properties;
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using System.Runtime.Loader;
 using Csla.Runtime;
 #endif
@@ -55,7 +55,7 @@ namespace Csla.Reflection
 
     #region Dynamic Method Cache
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
     private static readonly Dictionary<MethodCacheKey, Tuple<string, DynamicMethodHandle>> _methodCache = [];
 #else
     private readonly static Dictionary<MethodCacheKey, DynamicMethodHandle> _methodCache = [];
@@ -69,7 +69,7 @@ namespace Csla.Reflection
 
       DynamicMethodHandle mh = null;
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
       var key = new MethodCacheKey(objectType.FullName, info.Name, GetParameterTypes(parameters));
 
       try
@@ -133,7 +133,7 @@ namespace Csla.Reflection
 
     private static DynamicMethodHandle GetCachedMethod(object obj, string method, bool hasParameters, params object[] parameters)
     {
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
       var objectType = obj.GetType();
 
       var key = new MethodCacheKey(objectType.FullName, method, GetParameterTypes(hasParameters, parameters));
@@ -243,7 +243,7 @@ namespace Csla.Reflection
       }
       catch
       {
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
         string[] splitName = typeName.Split(',');
 
         if (splitName.Length > 2)
@@ -289,7 +289,7 @@ namespace Csla.Reflection
     private const BindingFlags propertyFlags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy;
     private const BindingFlags fieldFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
     private static readonly Dictionary<MethodCacheKey, Tuple<string, DynamicMemberHandle>> _memberCache = [];
 #else
     private static readonly Dictionary<MethodCacheKey, DynamicMemberHandle> _memberCache = [];
@@ -299,7 +299,7 @@ namespace Csla.Reflection
     {
       var key = new MethodCacheKey(objectType.FullName, propertyName, GetParameterTypes(null));
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
       var found = _memberCache.TryGetValue(key, out var memberHandleInfo);
 
       var mh = memberHandleInfo?.Item2;
@@ -354,7 +354,7 @@ namespace Csla.Reflection
     {
       var key = new MethodCacheKey(objectType.FullName, fieldName, GetParameterTypes(null));
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
       var found = _memberCache.TryGetValue(key, out var memberHandleInfo);
 
       var mh = memberHandleInfo?.Item2;
@@ -1380,7 +1380,7 @@ namespace Csla.Reflection
 
       return info;
     }
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
     private static void OnMethodAssemblyLoadContextUnload(AssemblyLoadContext context)
     {

--- a/Source/Csla/Reflection/ServiceProviderMethodCaller.cs
+++ b/Source/Csla/Reflection/ServiceProviderMethodCaller.cs
@@ -8,7 +8,7 @@
 
 using System.Collections.Concurrent;
 using System.Reflection;
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using System.Runtime.Loader;
 
 using Csla.Runtime;
@@ -27,7 +27,7 @@ namespace Csla.Reflection
     private static readonly BindingFlags _bindingAttr = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
     private static readonly BindingFlags _factoryBindingAttr = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
     private static readonly ConcurrentDictionary<string, Tuple<string, ServiceProviderMethodInfo>> _methodCache = [];
 #else
     private static readonly ConcurrentDictionary<string, ServiceProviderMethodInfo> _methodCache = [];
@@ -74,7 +74,7 @@ namespace Csla.Reflection
 
       var cacheKey = GetCacheKeyName(targetType, typeOfOperation, criteria);
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
       if (_methodCache.TryGetValue(cacheKey, out var unloadableCachedMethodInfo))
       {
         var cachedMethod = unloadableCachedMethodInfo?.Item2;
@@ -313,7 +313,7 @@ namespace Csla.Reflection
 
       if (resultingMethod != null)
       {
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
         var cacheInstance = AssemblyLoadContextManager.CreateCacheInstance(targetType, resultingMethod, OnAssemblyLoadContextUnload);
         _ = _methodCache.TryAdd(cacheKey, cacheInstance);
 #else
@@ -525,7 +525,7 @@ namespace Csla.Reflection
         throw new CallMethodException(obj.GetType().Name + "." + info.Name + " " + Resources.MethodCallFailed, inner);
       }
     }
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
     private static void OnAssemblyLoadContextUnload(AssemblyLoadContext context)
     {

--- a/Source/Csla/Rules/AuthorizationRuleManager.cs
+++ b/Source/Csla/Rules/AuthorizationRuleManager.cs
@@ -7,7 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.Reflection;
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using System.Runtime.Loader;
 
 using Csla.Runtime;
@@ -21,7 +21,7 @@ namespace Csla.Rules
   /// </summary>
   public class AuthorizationRuleManager
   {
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
     private static Lazy<System.Collections.Concurrent.ConcurrentDictionary<RuleSetKey, Tuple<string, AuthorizationRuleManager>>> _perTypeRules =
       new Lazy<System.Collections.Concurrent.ConcurrentDictionary<RuleSetKey, Tuple<string, AuthorizationRuleManager>>>();
 #else
@@ -36,7 +36,7 @@ namespace Csla.Rules
 
       var key = new RuleSetKey { Type = type, RuleSet = ruleSet };
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
       var rulesInfo = _perTypeRules.Value
         .GetOrAdd(
           key,
@@ -176,7 +176,7 @@ namespace Csla.Rules
     {
       Rules = new List<IAuthorizationRuleBase>();
     }
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
     private static void OnAssemblyLoadContextUnload(AssemblyLoadContext context)
     {

--- a/Source/Csla/Rules/BusinessRuleManager.cs
+++ b/Source/Csla/Rules/BusinessRuleManager.cs
@@ -6,7 +6,7 @@
 // <summary>Manages the list of rules for a business type.</summary>
 //-----------------------------------------------------------------------
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using System.Runtime.Loader;
 
 using Csla.Runtime;
@@ -19,7 +19,7 @@ namespace Csla.Rules
   /// </summary>
   public class BusinessRuleManager
   {
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
     private static Lazy<System.Collections.Concurrent.ConcurrentDictionary<RuleSetKey, Tuple<string, BusinessRuleManager>>> _perTypeRules =
       new Lazy<System.Collections.Concurrent.ConcurrentDictionary<RuleSetKey, Tuple<string, BusinessRuleManager>>>();
 #else
@@ -34,7 +34,7 @@ namespace Csla.Rules
 
       var key = new RuleSetKey { Type = type, RuleSet = ruleSet };
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
       var rulesInfo = _perTypeRules.Value
         .GetOrAdd(
           key,
@@ -102,7 +102,7 @@ namespace Csla.Rules
       Rules = new List<IBusinessRuleBase>();
     }
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
     private static void OnAssemblyLoadContextUnload(AssemblyLoadContext context)
     {
       lock (_perTypeRules)

--- a/Source/Csla/Rules/BusinessRules.cs
+++ b/Source/Csla/Rules/BusinessRules.cs
@@ -1131,7 +1131,7 @@ namespace Csla.Rules
     public void AddDataAnnotations()
     {
       Type metadataType;
-#if !NETSTANDARD2_0 || NET6_0_OR_GREATER
+#if !NETSTANDARD2_0 || NET8_0_OR_GREATER
       // add data annotations from metadata class if specified
       var classAttList = _target.GetType().GetCustomAttributes(typeof(System.ComponentModel.DataAnnotations.MetadataTypeAttribute), true);
       if (classAttList.Length > 0)

--- a/Source/Csla/Runtime/AssemblyLoadContextManager.cs
+++ b/Source/Csla/Runtime/AssemblyLoadContextManager.cs
@@ -1,4 +1,4 @@
-﻿#if NET5_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 //-----------------------------------------------------------------------
 // <copyright file="AssemblyLoadContextManager.cs" company="Marimer LLC">
 //     Copyright (c) Marimer LLC. All rights reserved.

--- a/Source/Csla/Serialization/BinaryFormatterWrapper.cs
+++ b/Source/Csla/Serialization/BinaryFormatterWrapper.cs
@@ -1,4 +1,4 @@
-#if !NET6_0_OR_GREATER
+#if !NET8_0_OR_GREATER
 //-----------------------------------------------------------------------
 // <copyright file="BinaryFormatterWrapper.cs" company="Marimer LLC">
 //     Copyright (c) Marimer LLC. All rights reserved.

--- a/Source/Csla/Serialization/NetDataContractSerializerWrapper.cs
+++ b/Source/Csla/Serialization/NetDataContractSerializerWrapper.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
+#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
 //-----------------------------------------------------------------------
 // <copyright file="NetDataContractSerializerWrapper.cs" company="Marimer LLC">
 //     Copyright (c) Marimer LLC. All rights reserved.

--- a/Source/Csla/Server/DataPortal.cs
+++ b/Source/Csla/Server/DataPortal.cs
@@ -77,7 +77,7 @@ namespace Csla.Server
 
     #region Data Access
 
-#if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
+#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
     private IDataPortalServer GetServicedComponentPortal(TransactionalAttribute transactionalAttribute)
     {
       switch (transactionalAttribute.TransactionIsolationLevel)
@@ -141,7 +141,7 @@ namespace Csla.Server
         IDataPortalServer portal;
         switch (method.TransactionalAttribute.TransactionType)
         {
-#if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
+#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
           case TransactionalTypes.EnterpriseServices:
             portal = GetServicedComponentPortal(method.TransactionalAttribute);
             try
@@ -243,7 +243,7 @@ namespace Csla.Server
         IDataPortalServer portal;
         switch (method.TransactionalAttribute.TransactionType)
         {
-#if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
+#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
           case TransactionalTypes.EnterpriseServices:
             portal = GetServicedComponentPortal(method.TransactionalAttribute);
             try
@@ -337,7 +337,7 @@ namespace Csla.Server
         IDataPortalServer portal;
         switch (method.TransactionalAttribute.TransactionType)
         {
-#if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
+#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
           case TransactionalTypes.EnterpriseServices:
             portal = GetServicedComponentPortal(method.TransactionalAttribute);
             try
@@ -470,7 +470,7 @@ namespace Csla.Server
         IDataPortalServer portal;
         switch (method.TransactionalAttribute.TransactionType)
         {
-#if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
+#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
           case TransactionalTypes.EnterpriseServices:
             portal = GetServicedComponentPortal(method.TransactionalAttribute);
             try
@@ -573,7 +573,7 @@ namespace Csla.Server
         IDataPortalServer portal;
         switch (method.TransactionalAttribute.TransactionType)
         {
-#if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
+#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
           case TransactionalTypes.EnterpriseServices:
             portal = GetServicedComponentPortal(method.TransactionalAttribute);
             try

--- a/Source/Csla/Server/DataPortalMethodCache.cs
+++ b/Source/Csla/Server/DataPortalMethodCache.cs
@@ -5,7 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using System.Runtime.Loader;
 
 using Csla.Runtime;
@@ -16,7 +16,7 @@ namespace Csla.Server
 {
   internal static class DataPortalMethodCache
   {
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
     private static Dictionary<MethodCacheKey, Tuple<string, DataPortalMethodInfo>> _cache = [];
 #else
     private static Dictionary<MethodCacheKey, DataPortalMethodInfo> _cache = [];
@@ -30,7 +30,7 @@ namespace Csla.Server
 
       var found = false;
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
       try
       {
         found = _cache.TryGetValue(key, out var methodInfo);
@@ -83,7 +83,7 @@ namespace Csla.Server
       return result;
     }
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
     private static void OnAssemblyLoadContextUnload(AssemblyLoadContext context)
     {
       lock (_cache)

--- a/Source/Csla/Server/DataPortalTarget.cs
+++ b/Source/Csla/Server/DataPortalTarget.cs
@@ -9,7 +9,7 @@
 using System.Collections.Concurrent;
 using Csla.Core;
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using System.Runtime.Loader;
 
 using Csla.Runtime;
@@ -20,7 +20,7 @@ namespace Csla.Server
 {
   internal class DataPortalTarget : LateBoundObject
   {
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
     private static readonly ConcurrentDictionary<Type, Tuple<string, DataPortalMethodNames>> _methodNameList =
       new ConcurrentDictionary<Type, Tuple<string, DataPortalMethodNames>>();
 #else
@@ -37,7 +37,7 @@ namespace Csla.Server
       _target = obj as IDataPortalTarget;
       _waitForIdleTimeout = TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds);
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
       var objectType = obj.GetType();
 
       var methodNameListInfo = _methodNameList.GetOrAdd(
@@ -276,7 +276,7 @@ namespace Csla.Server
     {
       return InvokeOperationAsync<DeleteAttribute>(criteria, isSync);
     }
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
     private static void OnAssemblyLoadContextUnload(AssemblyLoadContext context)
     {

--- a/Source/Csla/Server/ServicedDataPortalReadCommitted.cs
+++ b/Source/Csla/Server/ServicedDataPortalReadCommitted.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
+#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
 //-----------------------------------------------------------------------
 // <copyright file="ServicedDataPortal.cs" company="Marimer LLC">
 //     Copyright (c) Marimer LLC. All rights reserved.

--- a/Source/Csla/Server/ServicedDataPortalReadUncommitted.cs
+++ b/Source/Csla/Server/ServicedDataPortalReadUncommitted.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
+#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
 //-----------------------------------------------------------------------
 // <copyright file="ServicedDataPortal.cs" company="Marimer LLC">
 //     Copyright (c) Marimer LLC. All rights reserved.

--- a/Source/Csla/Server/ServicedDataPortalRepeatableRead.cs
+++ b/Source/Csla/Server/ServicedDataPortalRepeatableRead.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
+#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
 //-----------------------------------------------------------------------
 // <copyright file="ServicedDataPortal.cs" company="Marimer LLC">
 //     Copyright (c) Marimer LLC. All rights reserved.

--- a/Source/Csla/Server/ServicedDataPortalSerializable.cs
+++ b/Source/Csla/Server/ServicedDataPortalSerializable.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
+#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
 //-----------------------------------------------------------------------
 // <copyright file="ServicedDataPortal.cs" company="Marimer LLC">
 //     Copyright (c) Marimer LLC. All rights reserved.

--- a/Source/Csla/TransactionalTypes.cs
+++ b/Source/Csla/TransactionalTypes.cs
@@ -32,7 +32,7 @@ namespace Csla
     /// style transactions.
     /// </summary>
     TransactionScope
-#if !NETSTANDARD2_0 && !NET6_0_OR_GREATER
+#if !NETSTANDARD2_0 && !NET8_0_OR_GREATER
     ,
     /// <summary>
     /// Causes the server-side DataPortal to

--- a/Source/GraphMergerTest/GraphMergerTest.Business/GraphMergerTest.Business.csproj
+++ b/Source/GraphMergerTest/GraphMergerTest.Business/GraphMergerTest.Business.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
-    <TargetFrameworks>net462;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Csla\Csla.csproj" />

--- a/Source/GraphMergerTest/GraphMergerTest.BusinessTests/GraphMergerTest.BusinessTests.csproj
+++ b/Source/GraphMergerTest/GraphMergerTest.BusinessTests/GraphMergerTest.BusinessTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
-    <TargetFrameworks>net462;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\GraphMergerTest.Business\GraphMergerTest.Business.csproj" />


### PR DESCRIPTION
Updated the target framework for the projects from .NET 6.0 and .NET 5.0 to .NET 8.0. This includes changes to the `.csproj` files and the conditional compilation symbols in the code. Package references have been updated to their respective versions for .NET 8.0. Removed code blocks and package references specific to .NET 6.0 or .NET Core 3.1. Introduced the use of `AssemblyLoadContext` class for managing the execution context of an assembly. Updated the usage of `System.Runtime.Loader` and `Csla.Runtime` namespaces, type rules and method cache handling, transaction types handling, and `TransactionalTypes` enum to be compatible with .NET 8.0. Updated usage of several classes and `AssemblyLoadContextManager` based on the .NET version.

#3712 
