### PR TITLE
Blazor ViewModel with ManagedObjectLifetime save issue #4026

### DIFF
--- a/Source/Csla.Blazor.Test/Fakes/FakeDataStorage.cs
+++ b/Source/Csla.Blazor.Test/Fakes/FakeDataStorage.cs
@@ -27,5 +27,10 @@ namespace Csla.Blazor.Test.Fakes
       if (!FakePersonsStorage.ContainsKey(person.Id)) throw new Exception($"Person having Id {person.Id} not found");
       FakePersonsStorage[person.Id] = person;
     }
+
+    public static void ClearDataStorage()
+    {
+      FakePersonsStorage.Clear();
+    }
   }
 }

--- a/Source/Csla.Blazor.Test/Fakes/FakeDataStorage.cs
+++ b/Source/Csla.Blazor.Test/Fakes/FakeDataStorage.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Csla.Blazor.Test.Fakes
+{
+  public static class FakeDataStorage
+  {
+    private static readonly Dictionary<Guid, FakePerson> FakePersonsStorage = new();
+
+    public static FakePerson GetFakePerson(Guid id)
+    {
+      _ = FakePersonsStorage.TryGetValue(id, out var result);
+      return result;
+    }
+
+    public static void InsertFakePerson(FakePerson person)
+    {
+      if (person == null) throw new ArgumentNullException(nameof(person));
+      if (FakePersonsStorage.ContainsKey(person.Id)) throw new Exception($"Cannot add duplicate person having Id {person.Id}");
+      FakePersonsStorage[person.Id] = person;
+    }
+
+    public static void UpdateFakePerson(FakePerson person)
+    {
+      if (person == null) throw new ArgumentNullException(nameof(person));
+      if (!FakePersonsStorage.ContainsKey(person.Id)) throw new Exception($"Person having Id {person.Id} not found");
+      FakePersonsStorage[person.Id] = person;
+    }
+  }
+}

--- a/Source/Csla.Blazor.Test/Fakes/FakePerson.cs
+++ b/Source/Csla.Blazor.Test/Fakes/FakePerson.cs
@@ -6,6 +6,7 @@ namespace Csla.Blazor.Test.Fakes
   [Serializable()]
   public class FakePerson : BusinessBase<FakePerson>
   {
+    public static Csla.PropertyInfo<Guid> IdProperty = RegisterProperty<Guid>(nameof(Id));
     public static Csla.PropertyInfo<string> FirstNameProperty = RegisterProperty<string>(nameof(FirstName));
     public static Csla.PropertyInfo<string> LastNameProperty = RegisterProperty<string>(nameof(LastName));
     public static Csla.PropertyInfo<string> HomeTelephoneProperty = RegisterProperty<string>(nameof(HomeTelephone));
@@ -13,6 +14,12 @@ namespace Csla.Blazor.Test.Fakes
     public static Csla.PropertyInfo<FakePersonEmailAddresses> EmailAddressesProperty = RegisterProperty<FakePersonEmailAddresses>(nameof(EmailAddresses));
 
     #region Properties 
+
+    public Guid Id
+    {
+      get => GetProperty(IdProperty);
+      private set => SetProperty(IdProperty, value);
+    }
 
     [MaxLength(25)]
     public string FirstName
@@ -85,6 +92,7 @@ namespace Csla.Blazor.Test.Fakes
     [Create]
     private void Create([Inject] IChildDataPortal<FakePersonEmailAddresses> dataPortal)
     {
+      Id = new Guid();
       // Create an empty list for holding email addresses
       LoadProperty(EmailAddressesProperty, dataPortal.CreateChild());
 
@@ -92,6 +100,26 @@ namespace Csla.Blazor.Test.Fakes
       BusinessRules.CheckRules();
     }
 
+    [RunLocal]
+    [Fetch]
+    private FakePerson Fetch(Guid id)
+    {
+      return FakeDataStorage.GetFakePerson(id);
+    }
+
+    [RunLocal]
+    [Insert]
+    private void Insert()
+    {
+      FakeDataStorage.InsertFakePerson(this);
+    }
+
+    [RunLocal]
+    [Update]
+    private void Update()
+    {
+      FakeDataStorage.UpdateFakePerson(this);
+    }
     #endregion
 
   }

--- a/Source/Csla.Blazor.Test/Fakes/FakePerson.cs
+++ b/Source/Csla.Blazor.Test/Fakes/FakePerson.cs
@@ -92,7 +92,7 @@ namespace Csla.Blazor.Test.Fakes
     [Create]
     private void Create([Inject] IChildDataPortal<FakePersonEmailAddresses> dataPortal)
     {
-      Id = new Guid();
+      Id = Guid.NewGuid();
       // Create an empty list for holding email addresses
       LoadProperty(EmailAddressesProperty, dataPortal.CreateChild());
 

--- a/Source/Csla.Blazor.Test/ViewModelEditChildListSaveEditLevelTests.cs
+++ b/Source/Csla.Blazor.Test/ViewModelEditChildListSaveEditLevelTests.cs
@@ -70,19 +70,35 @@ namespace Csla.Blazor.Test
       var vm = new MyViewModel<FakePerson>(appCntxt);
       await vm.RefreshAsync(FetchFakePerson);
 
+      // Act
       await vm.SaveAsync();
+   
+      // Assert
+      Assert.IsFalse(vm.Model.IsSavable);
+      Assert.IsFalse(vm.Model.IsDirty);
+      Assert.IsFalse(vm.Model.IsNew);
 
       // Act
       string firstName = "SaveThis";
       vm.Model.FirstName = firstName;
       await vm.SaveAsync();
+
+      // Assert
+      Assert.IsFalse(vm.Model.IsSavable);
+      Assert.IsFalse(vm.Model.IsDirty);
+      Assert.IsFalse(vm.Model.IsNew);
       Assert.IsTrue(vm.Model.FirstName == firstName);
 
+      // Act
       string cancelName = "Cancel This";
       vm.Model.FirstName = cancelName;
       vm.Cancel();
 
       // Assert
+      Assert.IsFalse(vm.Model.IsSavable);
+      Assert.IsFalse(vm.Model.IsDirty);
+      Assert.IsFalse(vm.Model.IsNew);
+
       Assert.IsTrue(vm.Model.FirstName == firstName);
 
     }

--- a/Source/Csla.Blazor.Test/ViewModelEditChildListSaveEditLevelTests.cs
+++ b/Source/Csla.Blazor.Test/ViewModelEditChildListSaveEditLevelTests.cs
@@ -69,11 +69,14 @@ namespace Csla.Blazor.Test
       var appCntxt = TestDIContextExtensions.CreateTestApplicationContext(_testDIContext);
       var vm = new MyViewModel<FakePerson>(appCntxt);
       await vm.RefreshAsync(FetchFakePerson);
+      var id = vm.Model.Id;
 
       // Act
       await vm.SaveAsync();
-   
+
       // Assert
+      var save1_Id = vm.Model.Id;
+      Assert.AreEqual(save1_Id, id);
       Assert.IsFalse(vm.Model.IsSavable);
       Assert.IsFalse(vm.Model.IsDirty);
       Assert.IsFalse(vm.Model.IsNew);
@@ -84,6 +87,8 @@ namespace Csla.Blazor.Test
       await vm.SaveAsync();
 
       // Assert
+      save1_Id = vm.Model.Id;
+      Assert.AreEqual(save1_Id, id);
       Assert.IsFalse(vm.Model.IsSavable);
       Assert.IsFalse(vm.Model.IsDirty);
       Assert.IsFalse(vm.Model.IsNew);
@@ -95,6 +100,8 @@ namespace Csla.Blazor.Test
       vm.Cancel();
 
       // Assert
+      save1_Id = vm.Model.Id;
+      Assert.AreEqual(save1_Id, id);
       Assert.IsFalse(vm.Model.IsSavable);
       Assert.IsFalse(vm.Model.IsDirty);
       Assert.IsFalse(vm.Model.IsNew);
@@ -111,7 +118,16 @@ namespace Csla.Blazor.Test
       return await Task.FromResult(person);
     }
 
-    FakePerson GetValidFakePerson()
+    private async Task<FakePerson> NewFakePerson()
+    {
+      IDataPortal<FakePerson> dataPortal;
+
+      // Create an instance of a DataPortal that can be used for instantiating objects
+      dataPortal = _testDIContext.CreateDataPortal<FakePerson>();
+      return await dataPortal.CreateAsync();
+    }
+
+    private FakePerson GetValidFakePerson()
     {
       IDataPortal<FakePerson> dataPortal;
       FakePerson person;

--- a/Source/Csla.Blazor.Test/ViewModelEditChildListSaveEditLevelTests.cs
+++ b/Source/Csla.Blazor.Test/ViewModelEditChildListSaveEditLevelTests.cs
@@ -32,6 +32,12 @@ namespace Csla.Blazor.Test
       _testDIContext = TestDIContextFactory.CreateDefaultContext();
     }
 
+    [TestCleanup]
+    public void CleanupTests()
+    {
+      FakeDataStorage.ClearDataStorage();
+    }
+
     [TestMethod]
     public async Task SaveModelChildListChange_ValidateEditLevel()
     {

--- a/Source/Csla.Blazor.Test/ViewModelEditChildListSaveEditLevelTests.cs
+++ b/Source/Csla.Blazor.Test/ViewModelEditChildListSaveEditLevelTests.cs
@@ -13,7 +13,7 @@ namespace Csla.Blazor.Test
 {
   public class MyViewModel<T> : ViewModel<T>
   {
-    public MyViewModel(ApplicationContext context) : base(context) { }
+    public MyViewModel(ApplicationContext context) : base(context) { ManageObjectLifetime = true; }
 
     public void Cancel()
     {
@@ -68,8 +68,6 @@ namespace Csla.Blazor.Test
       //var iuo = person as IUndoableObject;
       var appCntxt = TestDIContextExtensions.CreateTestApplicationContext(_testDIContext);
       var vm = new MyViewModel<FakePerson>(appCntxt);
-      vm.ManageObjectLifetime = true;
-      //vm.Model = person;
       await vm.RefreshAsync(FetchFakePerson);
 
       await vm.SaveAsync();

--- a/Source/Csla.Blazor/ViewModel.cs
+++ b/Source/Csla.Blazor/ViewModel.cs
@@ -9,6 +9,8 @@
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Csla.Core;
 using Csla.Reflection;
 using Csla.Rules;
 
@@ -257,13 +259,17 @@ namespace Csla.Blazor
         var savable = Model as Core.ISavable;
         if (ManageObjectLifetime)
         {
+          //apply changes - must apply edit to Model not clone
+          if (Model is Core.ISupportUndo undoable)
+            undoable.ApplyEdit();
+
           // clone the object if possible
           if (Model is ICloneable clonable)
             savable = (Core.ISavable)clonable.Clone();
 
           //apply changes
-          if (savable is Core.ISupportUndo undoable)
-            undoable.ApplyEdit();
+          //if (savable is Core.ISupportUndo undoable)
+          //  undoable.ApplyEdit();
         }
 
         IsBusy = true;
@@ -282,8 +288,8 @@ namespace Csla.Blazor
       }
       finally
       {
-        //if (ManageObjectLifetime && Model is Core.ISupportUndo undo)
-        //  undo.BeginEdit();
+        if (ManageObjectLifetime && Model is IUndoableObject udbl && udbl.EditLevel == 0 && Model is Core.ISupportUndo undo)
+          undo.BeginEdit();
 
         _propertyInfoCache.Clear();
 

--- a/Source/Csla.Blazor/ViewModel.cs
+++ b/Source/Csla.Blazor/ViewModel.cs
@@ -282,6 +282,11 @@ namespace Csla.Blazor
       }
       finally
       {
+        //if (ManageObjectLifetime && Model is Core.ISupportUndo undo)
+        //  undo.BeginEdit();
+
+        _propertyInfoCache.Clear();
+
         HookChangedEvents(Model);
         IsBusy = false;
       }

--- a/Source/Csla.Blazor/ViewModel.cs
+++ b/Source/Csla.Blazor/ViewModel.cs
@@ -266,10 +266,6 @@ namespace Csla.Blazor
           // clone the object if possible
           if (Model is ICloneable clonable)
             savable = (Core.ISavable)clonable.Clone();
-
-          //apply changes
-          //if (savable is Core.ISupportUndo undoable)
-          //  undoable.ApplyEdit();
         }
 
         IsBusy = true;
@@ -290,8 +286,6 @@ namespace Csla.Blazor
       {
         if (ManageObjectLifetime && Model is IUndoableObject udbl && udbl.EditLevel == 0 && Model is Core.ISupportUndo undo)
           undo.BeginEdit();
-
-        _propertyInfoCache.Clear();
 
         HookChangedEvents(Model);
         IsBusy = false;

--- a/Source/Csla/BusinessBase.cs
+++ b/Source/Csla/BusinessBase.cs
@@ -216,6 +216,10 @@ namespace Csla
           {
             result = await dp.UpdateAsync((T)this);
           }
+          catch(Exception ex)
+          {
+            var msg = ex.Message;
+          }
           finally
           {
             if (dataPortalOptions.DataPortalClientOptions.AutoCloneOnUpdate)

--- a/Source/Csla/BusinessBase.cs
+++ b/Source/Csla/BusinessBase.cs
@@ -216,10 +216,6 @@ namespace Csla
           {
             result = await dp.UpdateAsync((T)this);
           }
-          catch(Exception ex)
-          {
-            var msg = ex.Message;
-          }
           finally
           {
             if (dataPortalOptions.DataPortalClientOptions.AutoCloneOnUpdate)


### PR DESCRIPTION
Blazor ViewModel with ManagedObjectLifetime save issue #4026

1)	Created unit test SaveThenCancel_ValidatePropertyValue to reproduce the issue
2)	We moved the ApplyEdit from after the clone to before the clone so that it is applied to the model.
3)	Added logic to the finally block of the save to call BeginEdit if the ManagedObjectLifetime is true and the EditLevel is zero.
4)	SaveThenCancel_ValidatePropertyValue unit test now passes
