### PR TITLE
#3207 Use CentralPackageVersioning in samples: BlazorExample 

### DIFF
--- a/Samples/BlazorExample/BlazorExample/BlazorExample.Client/BlazorExample.Client.csproj
+++ b/Samples/BlazorExample/BlazorExample/BlazorExample.Client/BlazorExample.Client.csproj
@@ -8,9 +8,11 @@
     <StaticWebAssetProjectMode>Default</StaticWebAssetProjectMode>
   </PropertyGroup>
 
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
+
   <ItemGroup>
-    <PackageReference Include="Csla.Blazor.WebAssembly" Version="9.0.0-R24051102" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.1" />
+    <PackageReference Include="Csla.Blazor.WebAssembly" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/BlazorExample/BlazorExample/BlazorExample/BlazorExample.csproj
+++ b/Samples/BlazorExample/BlazorExample/BlazorExample/BlazorExample.csproj
@@ -6,15 +6,17 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
+
   <ItemGroup>
     <ProjectReference Include="..\BlazorExample.Client\BlazorExample.Client.csproj" />
     <ProjectReference Include="..\BusinessLibrary\BusinessLibrary.csproj" />
     <ProjectReference Include="..\DataAccess.EF\DataAccess.EF.csproj" />
     <ProjectReference Include="..\DataAccess.Mock\DataAccess.Mock.csproj" />
     <ProjectReference Include="..\DataAccess\DataAccess.csproj" />
-    <PackageReference Include="Csla.AspNetCore" Version="9.0.0-R24051102" />
-    <PackageReference Include="Csla.Blazor" Version="9.0.0-R24051102" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.1" />
+    <PackageReference Include="Csla.AspNetCore" />
+    <PackageReference Include="Csla.Blazor" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
   </ItemGroup>
 
 </Project>

--- a/Samples/BlazorExample/BlazorExample/BusinessLibrary/BusinessLibrary.csproj
+++ b/Samples/BlazorExample/BlazorExample/BusinessLibrary/BusinessLibrary.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -6,8 +6,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
+
   <ItemGroup>
-    <PackageReference Include="Csla" Version="9.0.0-R24051102" />
+    <PackageReference Include="Csla" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/BlazorExample/BlazorExample/DataAccess.EF/DataAccess.EF.csproj
+++ b/Samples/BlazorExample/BlazorExample/DataAccess.EF/DataAccess.EF.csproj
@@ -4,10 +4,12 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
+
   <ItemGroup>
-    <PackageReference Include="Csla" Version="9.0.0-R24051102" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.1">
+    <PackageReference Include="Csla" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Samples/BlazorExample/BlazorExample/DataAccess.Mock/DataAccess.Mock.csproj
+++ b/Samples/BlazorExample/BlazorExample/DataAccess.Mock/DataAccess.Mock.csproj
@@ -5,8 +5,10 @@
     <AssemblyName>DataAccess.Mock</AssemblyName>
   </PropertyGroup>
 
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
+  
   <ItemGroup>
-    <PackageReference Include="Csla" Version="9.0.0-R24051102" />
+    <PackageReference Include="Csla" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/BlazorExample/BlazorExample/DataAccess/DataAccess.csproj
+++ b/Samples/BlazorExample/BlazorExample/DataAccess/DataAccess.csproj
@@ -1,12 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Csla" Version="9.0.0-R24051102" />
-  </ItemGroup>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
 
+  <ItemGroup>
+    <PackageReference Include="Csla" />
+  </ItemGroup>
 
 </Project>

--- a/Samples/BlazorExample/Directory.Packages.props
+++ b/Samples/BlazorExample/Directory.Packages.props
@@ -1,0 +1,18 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CslaVersion>9.0.0-R24051102</CslaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Csla" Version="$(CslaVersion)" />
+    <PackageVersion Include="Csla.AspNetCore" Version="$(CslaVersion)" />
+    <PackageVersion Include="Csla.Blazor" Version="$(CslaVersion)" />
+    <PackageVersion Include="Csla.Blazor.WebAssembly" Version="$(CslaVersion)" />
+
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.1" />
+
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Uses CentralPackageVersioning in samples for BlazorExample solution (#3207).

Please note, the CSVL version is temporary downgraded to v8 since there is no Nuget package found for v9:

```
Severity	Code	Description	Project	File	Line	Suppression State
Error (active)	NU1102	Unable to find package Csla with version (>= 9.0.0-R24051102)
  - Found 87 version(s) in nuget.org [ Nearest version: 8.2.2 ]
  - Found 0 version(s) in Microsoft Visual Studio Offline Packages
```

I found similar issue in the Duscussions resolved by publishing the corresponging packages: https://github.com/MarimerLLC/csla/discussions/3739#discussioncomment-9781222