### PR TITLE
Backport of the #4059 to 8.x

### DIFF
--- a/Source/Csla.test/Fakes/Server/DataPortal/Single.cs
+++ b/Source/Csla.test/Fakes/Server/DataPortal/Single.cs
@@ -229,5 +229,11 @@ namespace Csla.Test.DataPortalTest
         throw new Exception("bad value");
       Value += 1;
     }
+
+    [Execute]
+    protected void DataPortal_ExecuteWithInt(int value)
+    {
+      Value += value;
+    }
   }
 }

--- a/Source/Csla.test/HttpProxy/HttpProxyTests.cs
+++ b/Source/Csla.test/HttpProxy/HttpProxyTests.cs
@@ -1,7 +1,11 @@
 ﻿using Csla.Channels.Http;
 using Csla.Configuration;
+using Csla.Test.DataPortalTest;
 using Csla.TestHelpers;
+using Csla.TestHelpers.Http;
 using FluentAssertions;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Csla.Test.HttpProxy;
@@ -12,6 +16,8 @@ public class HttpProxyTests
   private TestDIContext _testDIContext;
   private TestHttpProxy _systemUnderTest;
   private TestHttpClientHandler _testHttClientHandler;
+  private static TestServer _server;
+  private static ServiceProvider _clientSideServiceProvider;
 
   [TestInitialize]
   public void Setup()
@@ -24,6 +30,10 @@ public class HttpProxyTests
     _systemUnderTest = new TestHttpProxy(applicationContext, null, proxyOptions, dataPortalOptions);
     _testHttClientHandler = new TestHttpClientHandler();
     _systemUnderTest.TestHttpClientHandlerToReturn = _testHttClientHandler;
+
+    var (server, clientServiceProvider) = HttpTestServerFactory.CreateHttpTestServerAndClientServiceProvider();
+    _server = server;
+    _clientSideServiceProvider = clientServiceProvider;
   }
 
   [TestMethod]
@@ -32,6 +42,27 @@ public class HttpProxyTests
     using var createdHttpClient = _systemUnderTest.CreateHttpClient();
     _ = await createdHttpClient.GetAsync("http://localhost:1234/weatherForecast");
     _testHttClientHandler.WasCalled.Should().BeTrue();
+  }
+
+  [TestMethod]
+  public async Task ExecuteAsync_WithPrimitiveObject()
+  {
+    IDataPortal<SingleCommand> dataPortal = _clientSideServiceProvider.GetRequiredService<IDataPortal<SingleCommand>>();
+
+    var result = await dataPortal.ExecuteAsync(123);
+    Assert.IsNotNull(result);
+    Assert.AreEqual(123, result.Value);
+  }
+
+  [TestMethod]
+  public async Task ExecuteAsync()
+  {
+    IDataPortal<SingleCommand> dataPortal = _clientSideServiceProvider.GetRequiredService<IDataPortal<SingleCommand>>();
+
+    SingleCommand cmd = dataPortal.Create(123);
+    var result = await dataPortal.ExecuteAsync(cmd);
+    Assert.IsNotNull(result);
+    Assert.AreEqual(124, result.Value);
   }
 
   private class TestHttpClientHandler : HttpClientHandler

--- a/Source/Csla/DataPortalT.cs
+++ b/Source/Csla/DataPortalT.cs
@@ -661,7 +661,7 @@ namespace Csla
     /// <returns>The resulting command object.</returns>
     public async Task<T> ExecuteAsync(params object[] criteria)
     {
-      return (T)await DoFetchAsync(typeof(T), criteria, false);
+      return (T)await DoFetchAsync(typeof(T), Server.DataPortal.GetCriteriaFromArray(criteria), false);
     }
 
     private DataPortalClient.IDataPortalProxy GetDataPortalProxy(Reflection.ServiceProviderMethodInfo method)


### PR DESCRIPTION
Add missing unpacking of the criteria in Execute

Closes #4057