### PR TITLE
Remove redundant imports

### DIFF
--- a/Samples/BlazorExample/BlazorExample/BlazorExample.Client/BlazorExample.Client.csproj
+++ b/Samples/BlazorExample/BlazorExample/BlazorExample.Client/BlazorExample.Client.csproj
@@ -8,8 +8,6 @@
     <StaticWebAssetProjectMode>Default</StaticWebAssetProjectMode>
   </PropertyGroup>
 
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
-
   <ItemGroup>
     <PackageReference Include="Csla.Blazor.WebAssembly" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />

--- a/Samples/BlazorExample/BlazorExample/BlazorExample/BlazorExample.csproj
+++ b/Samples/BlazorExample/BlazorExample/BlazorExample/BlazorExample.csproj
@@ -6,8 +6,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
-
   <ItemGroup>
     <ProjectReference Include="..\BlazorExample.Client\BlazorExample.Client.csproj" />
     <ProjectReference Include="..\BusinessLibrary\BusinessLibrary.csproj" />

--- a/Samples/BlazorExample/BlazorExample/BusinessLibrary/BusinessLibrary.csproj
+++ b/Samples/BlazorExample/BlazorExample/BusinessLibrary/BusinessLibrary.csproj
@@ -6,8 +6,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
-
   <ItemGroup>
     <PackageReference Include="Csla" />
   </ItemGroup>

--- a/Samples/BlazorExample/BlazorExample/DataAccess.EF/DataAccess.EF.csproj
+++ b/Samples/BlazorExample/BlazorExample/DataAccess.EF/DataAccess.EF.csproj
@@ -4,8 +4,6 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
-
   <ItemGroup>
     <PackageReference Include="Csla" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />

--- a/Samples/BlazorExample/BlazorExample/DataAccess.Mock/DataAccess.Mock.csproj
+++ b/Samples/BlazorExample/BlazorExample/DataAccess.Mock/DataAccess.Mock.csproj
@@ -4,8 +4,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>DataAccess.Mock</AssemblyName>
   </PropertyGroup>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
   
   <ItemGroup>
     <PackageReference Include="Csla" />

--- a/Samples/BlazorExample/BlazorExample/DataAccess/DataAccess.csproj
+++ b/Samples/BlazorExample/BlazorExample/DataAccess/DataAccess.csproj
@@ -4,8 +4,6 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
-
   <ItemGroup>
     <PackageReference Include="Csla" />
   </ItemGroup>


### PR DESCRIPTION
They produce following errors (for all projects in the solution)
```
C:\d\github\csla\Samples\BlazorExample\BlazorExample\DataAccess\DataAccess.csproj(7,3): warning MSB4011: "C:\d\github\csla\Samples\BlazorExample\Directory.Packages.props" cannot be imported again. It was alre
ady imported at "C:\Program Files\dotnet\sdk\8.0.300\NuGet.props (35,3)". This is most likely a build authoring error. This subsequent import will be ignored.
```

Related to #3207
