### PR TITLE
Remove conditional package and doc generation properties

### DIFF
--- a/Source/Csla.Blazor.WebAssembly/Csla.Blazor.WebAssembly.csproj
+++ b/Source/Csla.Blazor.WebAssembly/Csla.Blazor.WebAssembly.csproj
@@ -15,8 +15,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <DefineConstants>TRACE;BLAZOR</DefineConstants>
   </PropertyGroup>
 

--- a/Source/Csla.Blazor/Csla.Blazor.csproj
+++ b/Source/Csla.Blazor/Csla.Blazor.csproj
@@ -16,7 +16,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <DefineConstants>TRACE;BLAZOR</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
Removed <GenerateDocumentationFile> and <GeneratePackageOnBuild> properties from Csla.Blazor.WebAssembly.csproj and Csla.Blazor.csproj. This ensures packages are always generated on build and documentation files are not generated for the Release configuration in Csla.Blazor.WebAssembly.csproj.
