### PR TITLE
Change nullable warnings to errors in already NRT enabled projects

### DIFF
--- a/Source/Csla.AspNetCore/Csla.AspNetCore.csproj
+++ b/Source/Csla.AspNetCore/Csla.AspNetCore.csproj
@@ -12,6 +12,7 @@
     <BaseOutputPath>..\..\Bin</BaseOutputPath>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
     <Title>CSLA .NET AspNetCore</Title>
     <PackageTags>CSLA;AspNetCore;Razor</PackageTags>
   </PropertyGroup>

--- a/Source/Csla.Channels.Grpc/Csla.Channels.Grpc.csproj
+++ b/Source/Csla.Channels.Grpc/Csla.Channels.Grpc.csproj
@@ -11,6 +11,7 @@
     <Title>CSLA .NET gRPC data portal channel</Title>
     <PackageTags>CSLA;gRPC</PackageTags>
     <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/Source/Csla.Channels.RabbitMq/Csla.Channels.RabbitMq.csproj
+++ b/Source/Csla.Channels.RabbitMq/Csla.Channels.RabbitMq.csproj
@@ -9,6 +9,7 @@
     <AssemblyOriginatorKeyFile>..\Csla\CslaKey.snk</AssemblyOriginatorKeyFile>
     <BaseOutputPath>..\..\Bin</BaseOutputPath>
     <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
     <Title>CSLA .NET RabbitMQ data portal channel</Title>
     <PackageTags>CSLA;RabbitMQ</PackageTags>
   </PropertyGroup>

--- a/Source/Csla.Data.SqlClient.Fx/Csla.Data.SqlClient.Fx.csproj
+++ b/Source/Csla.Data.SqlClient.Fx/Csla.Data.SqlClient.Fx.csproj
@@ -11,6 +11,7 @@
     <DelaySign>false</DelaySign>
     <BaseOutputPath>..\..\Bin</BaseOutputPath>
     <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
     <Title>CSLA .NET System.Data.SqlClient</Title>
     <PackageTags>CSLA;SqlClient;Sql Server</PackageTags>
   </PropertyGroup>

--- a/Source/Csla.Data.SqlClient/Csla.Data.SqlClient.csproj
+++ b/Source/Csla.Data.SqlClient/Csla.Data.SqlClient.csproj
@@ -9,6 +9,7 @@
     <AssemblyOriginatorKeyFile>CslaKey.snk</AssemblyOriginatorKeyFile>
     <BaseOutputPath>..\..\Bin</BaseOutputPath>
     <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
     <Title>CSLA .NET Microsoft.Data.SqlClient</Title>
     <PackageTags>CSLA;SqlClient;Sql Server</PackageTags>
   </PropertyGroup>

--- a/Source/Csla.Web.Mvc5.Net4.6/Csla.Web.Mvc5-Net4.6.csproj
+++ b/Source/Csla.Web.Mvc5.Net4.6/Csla.Web.Mvc5-Net4.6.csproj
@@ -12,6 +12,7 @@
     <BaseOutputPath>..\..\Bin</BaseOutputPath>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
     <Title>CSLA .NET ASP.NET MVC 5</Title>
     <PackageTags>CSLA;ASP.NET;MVC</PackageTags>
   </PropertyGroup>


### PR DESCRIPTION
Treat nullable warnings as errors to avoid introducing easily fixed bugs.
Currently only for the already migrated projects enabled.