### PR TITLE
Simplify LocalProxyOptions initialization in UseLocalProxy

### DIFF
--- a/Source/Csla/DataPortalClient/LocalProxyExtensions.cs
+++ b/Source/Csla/DataPortalClient/LocalProxyExtensions.cs
@@ -33,9 +33,7 @@ namespace Csla.Configuration
     /// <param name="options">Data portal proxy options</param>
     public static DataPortalClientOptions UseLocalProxy(this DataPortalClientOptions config, Action<LocalProxyOptions> options)
     {
-      var existingOptions = config.Services.FirstOrDefault(i => i.ServiceType.Equals(typeof(IDataPortalProxy)));
-      if (existingOptions?.ImplementationInstance is not LocalProxyOptions proxyOptions)
-        proxyOptions = new LocalProxyOptions();
+      var proxyOptions = new LocalProxyOptions();
       options?.Invoke(proxyOptions);
       config.Services.AddTransient<IDataPortalProxy, LocalProxy>();
       config.Services.AddTransient(_ => proxyOptions);


### PR DESCRIPTION
The method `UseLocalProxy` now directly initializes a new `LocalProxyOptions` instance without checking for an existing instance. The conditional logic that checked for an existing `IDataPortalProxy` service and its implementation instance has been removed. This change simplifies the method by ensuring that a new `LocalProxyOptions` instance is always created and used.

Closes: #4130 
