### PR TITLE
Refactor PropertyInfo to cache IsSerializable result

### DIFF
--- a/Source/Csla/PropertyInfo.cs
+++ b/Source/Csla/PropertyInfo.cs
@@ -196,13 +196,11 @@ namespace Csla
 
     private bool? _isSerializable;
     /// <summary>
-    /// Gets the friendly display name
-    /// for the property.
+    /// Gets or sets a value indicating whether this property is serializable.
     /// </summary>
     /// <remarks>
-    /// If no friendly name was provided, the
-    /// property name itself is returned as a
-    /// result.
+    /// If the property is marked with the <see cref="Csla.NonSerializedAttribute"/>,
+    /// it is considered not serializable. Otherwise, it is considered serializable.
     /// </remarks>
     public virtual bool IsSerializable
     {

--- a/Source/Csla/PropertyInfo.cs
+++ b/Source/Csla/PropertyInfo.cs
@@ -194,7 +194,7 @@ namespace Csla
       }
     }
 
-    private readonly bool? _isSerializable;
+    private bool? _isSerializable;
     /// <summary>
     /// Gets the friendly display name
     /// for the property.
@@ -208,15 +208,15 @@ namespace Csla
     {
       get
       {
-
         if (_isSerializable.HasValue)
         {
           return _isSerializable.Value;
         }
         else if (_propertyInfo != null)
         {
-          var display = _propertyInfo.GetCustomAttributes(typeof(Csla.NonSerializedAttribute), true).OfType<NonSerializedAttribute>().Any();
-          return !display;
+          var nonSerialized = _propertyInfo.GetCustomAttributes(typeof(Csla.NonSerializedAttribute), true).OfType<NonSerializedAttribute>().Any();
+          _isSerializable = !nonSerialized;
+          return !nonSerialized;
         }
         return true;
       }


### PR DESCRIPTION
Changed _isSerializable from readonly to regular field to allow caching of the IsSerializable result. Updated IsSerializable property getter to set _isSerializable based on the presence of Csla.NonSerializedAttribute, improving performance by avoiding repeated attribute lookups.

Closes: #4207 