### PR TITLE
3235 backport to v7.x

### DIFF
--- a/Source/Csla/DataPortalClient/HttpProxy.cs
+++ b/Source/Csla/DataPortalClient/HttpProxy.cs
@@ -159,8 +159,16 @@ namespace Csla.Channels.Http
       catch (WebException ex)
       {
         string message;
-        using (var reader = new System.IO.StreamReader(ex.Response.GetResponseStream()))
-          message = reader.ReadToEnd();
+        if (ex.Response != null)
+        {
+          using (var reader = new System.IO.StreamReader(ex.Response.GetResponseStream()))
+            message = reader.ReadToEnd();
+        }
+        else
+        {
+          message = ex.Message;
+        }
+
         throw new DataPortalException(message, ex);
       }
     }


### PR DESCRIPTION
#3235 - Backport to v7.x. 

Fixing null issue when throwing exception from CallViaWebClient().