### PR TITLE
Cherry pick: Fix for #3581, Ensure unique identity values within identity managed collections

### DIFF
--- a/Source/Csla.test/GraphMerge/BranchUniqueIdentities.cs
+++ b/Source/Csla.test/GraphMerge/BranchUniqueIdentities.cs
@@ -1,0 +1,50 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="GraphMergeTests.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>no summary</summary>
+//-----------------------------------------------------------------------
+
+namespace Csla.Test.GraphMerge
+{
+  internal class BranchUniqueIdentities : BusinessBase<BranchUniqueIdentities>
+  {
+    public static readonly PropertyInfo<Guid> IdProperty = RegisterProperty<Guid>(nameof(Id));
+    public Guid Id
+    {
+      get => GetProperty(IdProperty);
+      private set => SetProperty(IdProperty, value);
+    }
+
+    public static readonly PropertyInfo<LeafsUniqueIdentities> LeafsProperty = RegisterProperty<LeafsUniqueIdentities>(nameof(Leafs));
+    public LeafsUniqueIdentities Leafs
+    {
+      get => GetProperty(LeafsProperty);
+      private set => SetProperty(LeafsProperty, value);
+    }
+
+    [FetchChild]
+    private async void Create([Inject] IChildDataPortal<LeafsUniqueIdentities> leafsPortal)
+    {
+      using (BypassPropertyChecks)
+      {
+        Id = Guid.NewGuid();
+
+        Leafs = await leafsPortal.FetchChildAsync();
+      }
+    }
+
+    [InsertChild]
+    private async Task Insert()
+    {
+      await FieldManager.UpdateChildrenAsync();
+    }
+
+    [UpdateChild]
+    private void Update()
+    {
+      FieldManager.UpdateChildren();
+    }
+  }
+}

--- a/Source/Csla.test/GraphMerge/IdentityTests.cs
+++ b/Source/Csla.test/GraphMerge/IdentityTests.cs
@@ -8,6 +8,7 @@
 
 using Csla.Core;
 using Csla.TestHelpers;
+using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 
@@ -136,6 +137,17 @@ namespace Csla.Test.GraphMerge
 
       var obj = dataPortal.Create();
       Assert.IsTrue(((IBusinessObject)obj).Identity >= 0);
+    }
+
+    [TestMethod]
+    public async Task Identity_WhenAddingANewListItemAfterFetchTheIdentityWithinTheListMustBeUnique()
+    {
+      var root = await _testDIContext.CreateDataPortal<RootUniqueIdentities>().FetchAsync();
+
+      var newItem = root.Branch.Leafs.AddNew();
+      newItem.LeafId = 1337;
+
+      root.Branch.Leafs.Should().OnlyHaveUniqueItems(l => ((IBusinessObject)l).Identity);
     }
   }
 }

--- a/Source/Csla.test/GraphMerge/LeafUniqueIdentities.cs
+++ b/Source/Csla.test/GraphMerge/LeafUniqueIdentities.cs
@@ -1,0 +1,44 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="GraphMergeTests.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>no summary</summary>
+//-----------------------------------------------------------------------
+
+namespace Csla.Test.GraphMerge
+{
+  internal class LeafUniqueIdentities : BusinessBase<LeafUniqueIdentities>
+  {
+    public static readonly PropertyInfo<int> LeafIdProperty = RegisterProperty<int>(nameof(LeafId));
+    public int LeafId
+    {
+      get => GetProperty(LeafIdProperty);
+      set => SetProperty(LeafIdProperty, value);
+    }
+
+    [Create]
+    [CreateChild]
+    private async Task Create(int leafId)
+    {
+      using (BypassPropertyChecks)
+      {
+        LeafId = leafId;
+      }
+
+      await BusinessRules.CheckRulesAsync();
+    }
+
+    [InsertChild]
+    private void Insert() { }
+
+    [FetchChild]
+    private void Fetch(int id)
+    {
+      using (BypassPropertyChecks)
+      {
+        LeafId = id;
+      }
+    }
+  }
+}

--- a/Source/Csla.test/GraphMerge/LeafsUniqueIdentities.cs
+++ b/Source/Csla.test/GraphMerge/LeafsUniqueIdentities.cs
@@ -1,0 +1,25 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="GraphMergeTests.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>no summary</summary>
+//-----------------------------------------------------------------------
+
+namespace Csla.Test.GraphMerge
+{
+  internal class LeafsUniqueIdentities : BusinessListBase<LeafsUniqueIdentities, LeafUniqueIdentities>
+  {
+    [FetchChild]
+    private async void Fetch([Inject] IChildDataPortal<LeafUniqueIdentities> childDataPortal)
+    {
+      using (LoadListMode)
+      {
+        foreach (var id in Enumerable.Range(1, 5))
+        {
+          Add(await childDataPortal.FetchChildAsync(id));
+        }
+      }
+    }
+  }
+}

--- a/Source/Csla.test/GraphMerge/RootUniqueIdentities.cs
+++ b/Source/Csla.test/GraphMerge/RootUniqueIdentities.cs
@@ -1,0 +1,50 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="GraphMergeTests.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>no summary</summary>
+//-----------------------------------------------------------------------
+
+namespace Csla.Test.GraphMerge
+{
+  internal class RootUniqueIdentities : BusinessBase<RootUniqueIdentities>
+  {
+    public static readonly PropertyInfo<Guid> IdProperty = RegisterProperty<Guid>(nameof(Id));
+    public Guid Id
+    {
+      get => GetProperty(IdProperty);
+      private set => SetProperty(IdProperty, value);
+    }
+
+    public static readonly PropertyInfo<BranchUniqueIdentities> BranchProperty = RegisterProperty<BranchUniqueIdentities>(nameof(Branch));
+    public BranchUniqueIdentities Branch
+    {
+      get => GetProperty(BranchProperty);
+      private set => SetProperty(BranchProperty, value);
+    }
+
+    [Fetch]
+    private async void Create([Inject] IChildDataPortal<BranchUniqueIdentities> portalBranch)
+    {
+      using (BypassPropertyChecks)
+      {
+        Id = Guid.NewGuid();
+
+        Branch = await portalBranch.FetchChildAsync();
+      }
+    }
+
+    [Insert]
+    private async Task Insert()
+    {
+      await FieldManager.UpdateChildrenAsync();
+    }
+
+    [Update]
+    private async Task Update()
+    {
+      await FieldManager.UpdateChildrenAsync();
+    }
+  }
+}

--- a/Source/Csla/BusinessBindingListBase.cs
+++ b/Source/Csla/BusinessBindingListBase.cs
@@ -338,6 +338,8 @@ namespace Csla
     {
       if (item.IsChild)
       {
+        IdentityManager.EnsureNextIdentityValueIsUnique(this, this);
+
         // set parent reference
         item.SetParent(this);
         // ensure child uses same context as parent

--- a/Source/Csla/BusinessListBase.cs
+++ b/Source/Csla/BusinessListBase.cs
@@ -342,6 +342,8 @@ namespace Csla
     {
       if (item.IsChild)
       {
+        IdentityManager.EnsureNextIdentityValueIsUnique(this, this);
+
         // set parent reference
         item.SetParent(this);
         // ensure child uses same context as parent

--- a/Source/Csla/Core/IdentityManager.cs
+++ b/Source/Csla/Core/IdentityManager.cs
@@ -45,5 +45,23 @@ namespace Csla.Core
       }
       return result;
     }
+
+    /// <summary>
+    /// Ensures that the internal value of <see cref="_nextIdentity"/> is greater than the greatest <see cref="IBusinessObject.Identity"/> within the given collection.
+    /// That ensures that new object get a unique identity within the collection.
+    /// </summary>
+    /// <typeparam name="T">Item type of the list</typeparam>
+    /// <param name="parent"></param>
+    /// <param name="items"></param>
+    internal static void EnsureNextIdentityValueIsUnique<T>(IParent parent, IReadOnlyCollection<T> items) where T : IBusinessObject
+    {
+      // No items means we do not have to worry about any identity duplicates
+      if (items.Count == 0)
+      {
+        return;
+      }
+
+      _ = parent.GetNextIdentity(items.Max(c => c.Identity));
+    }
   }
 }

--- a/Source/Csla/DynamicBindingListBase.cs
+++ b/Source/Csla/DynamicBindingListBase.cs
@@ -283,6 +283,7 @@ namespace Csla
     /// <param name="item">Item to insert.</param>
     protected override void InsertItem(int index, T item)
     {
+      IdentityManager.EnsureNextIdentityValueIsUnique(this, this);
       item.SetParent(this);
       base.InsertItem(index, item);
     }

--- a/Source/Csla/DynamicListBase.cs
+++ b/Source/Csla/DynamicListBase.cs
@@ -316,6 +316,7 @@ namespace Csla
     /// <param name="item">Item to insert.</param>
     protected override void InsertItem(int index, T item)
     {
+      IdentityManager.EnsureNextIdentityValueIsUnique(this, this);
       item.SetParent(this);
       // ensure child uses same context as parent
       if (item is IUseApplicationContext iuac)


### PR DESCRIPTION
Cherry pick of #4333 
Ensures that before adding an item to a collection with identity management the next identity value will be unique within the collection.

Fixes #3581