### PR TITLE
Add global.json to pin used SDK to .Net 9

### DIFF
--- a/Source/global.json
+++ b/Source/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "rollForward": "latestFeature",
+    "version": "9.0.100",
+	"allowPrerelease": false
+  }
+}


### PR DESCRIPTION
Adds a global.json to ensure we all are building the solution with the same SDK.
