### PR TITLE
Add statically analyzeable AOT annotations

### DIFF
--- a/Source/Csla/ApplicationContext.cs
+++ b/Source/Csla/ApplicationContext.cs
@@ -12,6 +12,7 @@ using System.Security.Claims;
 using Microsoft.Extensions.DependencyInjection;
 using System.ComponentModel;
 using Csla.Server;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Csla
 {
@@ -367,7 +368,11 @@ namespace Csla
     /// <typeparam name="T">Type of object to create.</typeparam>
     /// <param name="parameters">Parameters for constructor</param>
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public T CreateInstanceDI<T>(params object[] parameters)
+    public T CreateInstanceDI<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      T>(params object[] parameters)
     {
       return (T)CreateInstanceDI(typeof(T), parameters);
     }
@@ -378,7 +383,11 @@ namespace Csla
     /// <param name="objectType">Type of object to create</param>
     /// <param name="parameters">Manually passed in parameters for constructor</param>
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public object CreateInstanceDI(Type objectType, params object[] parameters)
+    public object CreateInstanceDI(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, params object[] parameters)
     {
       try
       {
@@ -411,7 +420,11 @@ namespace Csla
     /// <typeparam name="T">Type of object to create.</typeparam>
     /// <param name="parameters">Parameters for constructor</param>
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public T CreateInstance<T>(params object[] parameters)
+    public T CreateInstance<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      T>(params object[] parameters)
     {
       return (T)CreateInstance(typeof(T), parameters);
     }
@@ -422,7 +435,11 @@ namespace Csla
     /// <param name="objectType">Type of object to create</param>
     /// <param name="parameters">Parameters for constructor</param>
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public object CreateInstance(Type objectType, params object[] parameters)
+    public object CreateInstance(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, params object[] parameters)
     {
       object result;
       result = Activator.CreateInstance(objectType, parameters);

--- a/Source/Csla/BusinessBase.cs
+++ b/Source/Csla/BusinessBase.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using Csla.Core;
@@ -32,7 +33,11 @@ namespace Csla
   /// </remarks>
   /// <typeparam name="T">Type of the business object being defined.</typeparam>
   [Serializable]
-  public abstract class BusinessBase<T> :
+  public abstract class BusinessBase<
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+    T> :
     BusinessBase, ISavable, ISavable<T>, IBusinessBase where T : BusinessBase<T>
   {
 
@@ -365,7 +370,11 @@ namespace Csla
     /// <returns>
     /// The provided IPropertyInfo object.
     /// </returns>
-    protected static PropertyInfo<P> RegisterProperty<P>(PropertyInfo<P> info)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> info)
     {
       return Core.FieldManager.PropertyInfoManager.RegisterProperty<P>(typeof(T), info);
     }
@@ -376,7 +385,11 @@ namespace Csla
     /// </summary>
     /// <typeparam name="P">Type of property</typeparam>
     /// <param name="propertyName">Property name from nameof()</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(string propertyName)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(string propertyName)
     {
       return RegisterProperty(Core.FieldManager.PropertyInfoFactory.Factory.Create<P>(typeof(T), propertyName));
     }
@@ -387,7 +400,11 @@ namespace Csla
     /// </summary>
     /// <typeparam name="P">Type of property</typeparam>
     /// <param name="propertyLambdaExpression">Property Expression</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(Expression<Func<T, object>> propertyLambdaExpression)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(Expression<Func<T, object>> propertyLambdaExpression)
     {
       PropertyInfo reflectedPropertyInfo = Reflect<T>.GetProperty(propertyLambdaExpression);
       return RegisterProperty<P>(reflectedPropertyInfo.Name);
@@ -400,7 +417,11 @@ namespace Csla
     /// <typeparam name="P">Type of property</typeparam>
     /// <param name="propertyName">Property name from nameof()</param>
     /// <param name="relationship">Relationship with property value.</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(string propertyName, RelationshipTypes relationship)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(string propertyName, RelationshipTypes relationship)
     {
       return RegisterProperty(Core.FieldManager.PropertyInfoFactory.Factory.Create<P>(typeof(T), propertyName, string.Empty, relationship));
     }
@@ -412,7 +433,11 @@ namespace Csla
     /// <typeparam name="P">Type of property</typeparam>
     /// <param name="propertyLambdaExpression">Property Expression</param>
     /// <param name="relationship">Relationship with property value.</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(Expression<Func<T, object>> propertyLambdaExpression, RelationshipTypes relationship)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(Expression<Func<T, object>> propertyLambdaExpression, RelationshipTypes relationship)
     {
       PropertyInfo reflectedPropertyInfo = Reflect<T>.GetProperty(propertyLambdaExpression);
       return RegisterProperty<P>(reflectedPropertyInfo.Name, relationship);
@@ -425,7 +450,11 @@ namespace Csla
     /// <typeparam name="P">Type of property</typeparam>
     /// <param name="propertyName">Property name from nameof()</param>
     /// <param name="friendlyName">Friendly description for a property to be used in databinding</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(string propertyName, string friendlyName)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(string propertyName, string friendlyName)
     {
       return RegisterProperty(Core.FieldManager.PropertyInfoFactory.Factory.Create<P>(typeof(T), propertyName, friendlyName));
     }
@@ -437,7 +466,11 @@ namespace Csla
     /// <typeparam name="P">Type of property</typeparam>
     /// <param name="propertyLambdaExpression">Property Expression</param>
     /// <param name="friendlyName">Friendly description for a property to be used in databinding</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName)
     {
       PropertyInfo reflectedPropertyInfo = Reflect<T>.GetProperty(propertyLambdaExpression);
       return RegisterProperty<P>(reflectedPropertyInfo.Name, friendlyName);
@@ -451,7 +484,11 @@ namespace Csla
     /// <param name="propertyName">Property name from nameof()</param>
     /// <param name="friendlyName">Friendly description for a property to be used in databinding</param>
     /// <param name="defaultValue">Default Value for the property</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(string propertyName, string friendlyName, P defaultValue)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(string propertyName, string friendlyName, P defaultValue)
     {
       return RegisterProperty(Core.FieldManager.PropertyInfoFactory.Factory.Create<P>(typeof(T), propertyName, friendlyName, defaultValue));
     }
@@ -464,7 +501,11 @@ namespace Csla
     /// <param name="propertyLambdaExpression">Property Expression</param>
     /// <param name="friendlyName">Friendly description for a property to be used in databinding</param>
     /// <param name="defaultValue">Default Value for the property</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName, P defaultValue)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName, P defaultValue)
     {
       PropertyInfo reflectedPropertyInfo = Reflect<T>.GetProperty(propertyLambdaExpression);
       return RegisterProperty(reflectedPropertyInfo.Name, friendlyName, defaultValue);
@@ -479,7 +520,11 @@ namespace Csla
     /// <param name="friendlyName">Friendly description for a property to be used in databinding</param>
     /// <param name="defaultValue">Default Value for the property</param>
     /// <param name="relationship">Relationship with property value.</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(string propertyName, string friendlyName, P defaultValue, RelationshipTypes relationship)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(string propertyName, string friendlyName, P defaultValue, RelationshipTypes relationship)
     {
       return RegisterProperty(Core.FieldManager.PropertyInfoFactory.Factory.Create<P>(typeof(T), propertyName, friendlyName, defaultValue, relationship));
     }
@@ -493,7 +538,11 @@ namespace Csla
     /// <param name="friendlyName">Friendly description for a property to be used in databinding</param>
     /// <param name="defaultValue">Default Value for the property</param>
     /// <param name="relationship">Relationship with property value.</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName, P defaultValue, RelationshipTypes relationship)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName, P defaultValue, RelationshipTypes relationship)
     {
       PropertyInfo reflectedPropertyInfo = Reflect<T>.GetProperty(propertyLambdaExpression);
       return RegisterProperty(reflectedPropertyInfo.Name, friendlyName, defaultValue, relationship);

--- a/Source/Csla/BusinessBindingListBase.cs
+++ b/Source/Csla/BusinessBindingListBase.cs
@@ -8,6 +8,7 @@
 
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 using Csla.Core;
 using Csla.Properties;
 using Csla.Server;
@@ -23,7 +24,15 @@ namespace Csla
   [System.Diagnostics.CodeAnalysis.SuppressMessage(
     "Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix")]
   [Serializable]
-  public abstract class BusinessBindingListBase<T, C> :
+  public abstract class BusinessBindingListBase<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+    T,
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      C> :
       ExtendedBindingList<C>, IContainsDeletedList,
       IEditableCollection, IUndoableObject, ICloneable,
       ISavable, ISavable<T>, IParent, IDataPortalTarget,

--- a/Source/Csla/BusinessListBase.cs
+++ b/Source/Csla/BusinessListBase.cs
@@ -9,6 +9,7 @@
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 using Csla.Core;
 using Csla.Properties;
 using Csla.Serialization.Mobile;
@@ -26,7 +27,15 @@ namespace Csla
   [System.Diagnostics.DebuggerStepThrough]
 #endif
   [Serializable]
-  public abstract class BusinessListBase<T, C> :
+  public abstract class BusinessListBase<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      T,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      C> :
       ObservableBindingList<C>,
       IContainsDeletedList,
       ISavable<T>,

--- a/Source/Csla/CommandBase.cs
+++ b/Source/Csla/CommandBase.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using Csla.Core;
@@ -39,7 +40,11 @@ namespace Csla
   /// </para>
   /// </remarks>
   [Serializable]
-  public abstract class CommandBase<T> : ManagedObjectBase,
+  public abstract class CommandBase<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T> : ManagedObjectBase,
       IDataPortalTarget,
       IManageProperties,
       ICommandBase
@@ -239,7 +244,11 @@ namespace Csla
     /// <returns>
     /// The provided IPropertyInfo object.
     /// </returns>
-    protected static PropertyInfo<P> RegisterProperty<P>(PropertyInfo<P> info)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> info)
     {
       return Core.FieldManager.PropertyInfoManager.RegisterProperty<P>(typeof(T), info);
     }
@@ -250,7 +259,11 @@ namespace Csla
     /// </summary>
     /// <typeparam name="P">Type of property</typeparam>
     /// <param name="propertyName">Property name from nameof()</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(string propertyName)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(string propertyName)
     {
       return RegisterProperty(Core.FieldManager.PropertyInfoFactory.Factory.Create<P>(typeof(T), propertyName));
     }
@@ -261,7 +274,11 @@ namespace Csla
     /// </summary>
     /// <typeparam name="P">Type of property</typeparam>
     /// <param name="propertyLambdaExpression">Property Expression</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(Expression<Func<T, object>> propertyLambdaExpression)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(Expression<Func<T, object>> propertyLambdaExpression)
     {
       PropertyInfo reflectedPropertyInfo = Reflect<T>.GetProperty(propertyLambdaExpression);
       return RegisterProperty<P>(reflectedPropertyInfo.Name);
@@ -274,7 +291,11 @@ namespace Csla
     /// <typeparam name="P">Type of property</typeparam>
     /// <param name="propertyName">Property name from nameof()</param>
     /// <param name="relationship">Relationship with property value.</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(string propertyName, RelationshipTypes relationship)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(string propertyName, RelationshipTypes relationship)
     {
       return RegisterProperty(Core.FieldManager.PropertyInfoFactory.Factory.Create<P>(typeof(T), propertyName, string.Empty, relationship));
     }
@@ -286,7 +307,11 @@ namespace Csla
     /// <typeparam name="P">Type of property</typeparam>
     /// <param name="propertyLambdaExpression">Property Expression</param>
     /// <param name="relationship">Relationship with property value.</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(Expression<Func<T, object>> propertyLambdaExpression, RelationshipTypes relationship)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(Expression<Func<T, object>> propertyLambdaExpression, RelationshipTypes relationship)
     {
       PropertyInfo reflectedPropertyInfo = Reflect<T>.GetProperty(propertyLambdaExpression);
       return RegisterProperty<P>(reflectedPropertyInfo.Name, relationship);
@@ -299,7 +324,11 @@ namespace Csla
     /// <typeparam name="P">Type of property</typeparam>
     /// <param name="propertyName">Property name from nameof()</param>
     /// <param name="friendlyName">Friendly description for a property to be used in databinding</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(string propertyName, string friendlyName)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(string propertyName, string friendlyName)
     {
       return RegisterProperty(Core.FieldManager.PropertyInfoFactory.Factory.Create<P>(typeof(T), propertyName, friendlyName));
     }
@@ -311,7 +340,11 @@ namespace Csla
     /// <typeparam name="P">Type of property</typeparam>
     /// <param name="propertyLambdaExpression">Property Expression</param>
     /// <param name="friendlyName">Friendly description for a property to be used in databinding</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName)
     {
       PropertyInfo reflectedPropertyInfo = Reflect<T>.GetProperty(propertyLambdaExpression);
       return RegisterProperty<P>(reflectedPropertyInfo.Name, friendlyName);
@@ -325,7 +358,11 @@ namespace Csla
     /// <param name="propertyName">Property name from nameof()</param>
     /// <param name="friendlyName">Friendly description for a property to be used in databinding</param>
     /// <param name="defaultValue">Default Value for the property</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(string propertyName, string friendlyName, P defaultValue)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(string propertyName, string friendlyName, P defaultValue)
     {
       return RegisterProperty(Core.FieldManager.PropertyInfoFactory.Factory.Create<P>(typeof(T), propertyName, friendlyName, defaultValue));
     }
@@ -338,7 +375,11 @@ namespace Csla
     /// <param name="propertyLambdaExpression">Property Expression</param>
     /// <param name="friendlyName">Friendly description for a property to be used in databinding</param>
     /// <param name="defaultValue">Default Value for the property</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName, P defaultValue)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName, P defaultValue)
     {
       PropertyInfo reflectedPropertyInfo = Reflect<T>.GetProperty(propertyLambdaExpression);
       return RegisterProperty<P>(reflectedPropertyInfo.Name, friendlyName, defaultValue);
@@ -353,7 +394,11 @@ namespace Csla
     /// <param name="friendlyName">Friendly description for a property to be used in databinding</param>
     /// <param name="defaultValue">Default Value for the property</param>
     /// <param name="relationship">Relationship with property value.</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(string propertyName, string friendlyName, P defaultValue, RelationshipTypes relationship)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(string propertyName, string friendlyName, P defaultValue, RelationshipTypes relationship)
     {
       return RegisterProperty(Core.FieldManager.PropertyInfoFactory.Factory.Create<P>(typeof(T), propertyName, friendlyName, defaultValue, relationship));
     }
@@ -367,7 +412,11 @@ namespace Csla
     /// <param name="friendlyName">Friendly description for a property to be used in databinding</param>
     /// <param name="defaultValue">Default Value for the property</param>
     /// <param name="relationship">Relationship with property value.</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName, P defaultValue, RelationshipTypes relationship)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName, P defaultValue, RelationshipTypes relationship)
     {
       PropertyInfo reflectedPropertyInfo = Reflect<T>.GetProperty(propertyLambdaExpression);
       return RegisterProperty<P>(reflectedPropertyInfo.Name, friendlyName, defaultValue, relationship);
@@ -397,7 +446,11 @@ namespace Csla
       return ReadProperty(propertyInfo);
     }
 
-    P IManageProperties.ReadProperty<P>(PropertyInfo<P> propertyInfo)
+    P IManageProperties.ReadProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo)
     {
       return ReadProperty<P>(propertyInfo);
     }
@@ -412,7 +465,11 @@ namespace Csla
       LoadProperty(propertyInfo, newValue);
     }
 
-    void IManageProperties.LoadProperty<P>(PropertyInfo<P> propertyInfo, P newValue)
+    void IManageProperties.LoadProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, P newValue)
     {
       LoadProperty<P>(propertyInfo, newValue);
     }
@@ -433,22 +490,38 @@ namespace Csla
       return FieldManager.FieldExists(property);
     }
 
-    object IManageProperties.LazyGetProperty<P>(PropertyInfo<P> propertyInfo, Func<P> valueGenerator)
+    object IManageProperties.LazyGetProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, Func<P> valueGenerator)
     {
       throw new NotImplementedException();
     }
 
-    object IManageProperties.LazyGetPropertyAsync<P>(PropertyInfo<P> propertyInfo, Task<P> factory)
+    object IManageProperties.LazyGetPropertyAsync<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, Task<P> factory)
     {
       throw new NotImplementedException();
     }
 
-    P IManageProperties.LazyReadProperty<P>(PropertyInfo<P> propertyInfo, Func<P> valueGenerator)
+    P IManageProperties.LazyReadProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, Func<P> valueGenerator)
     {
       throw new NotImplementedException();
     }
 
-    P IManageProperties.LazyReadPropertyAsync<P>(PropertyInfo<P> propertyInfo, Task<P> factory)
+    P IManageProperties.LazyReadPropertyAsync<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, Task<P> factory)
     {
       throw new NotImplementedException();
     }

--- a/Source/Csla/Configuration/Fluent/CslaOptions.cs
+++ b/Source/Csla/Configuration/Fluent/CslaOptions.cs
@@ -5,6 +5,8 @@
 // </copyright>
 // <summary>Use this type to configure the settings for CSLA .NET</summary>
 //-----------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
 using Csla.Core;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -52,7 +54,11 @@ namespace Csla.Configuration
     /// <summary>
     /// Sets the factory type that creates PropertyInfo objects.
     /// </summary>
-    public CslaOptions RegisterPropertyInfoFactory<T>() where T : IPropertyInfoFactory
+    public CslaOptions RegisterPropertyInfoFactory<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+      T>() where T : IPropertyInfoFactory
     {
       Core.FieldManager.PropertyInfoFactory.FactoryType = typeof(T);
       return this;

--- a/Source/Csla/Configuration/Fluent/DataPortalClientOptions.cs
+++ b/Source/Csla/Configuration/Fluent/DataPortalClientOptions.cs
@@ -6,6 +6,7 @@
 // <summary>Client-side data portal options.</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using Csla.DataPortalClient;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -42,6 +43,9 @@ namespace Csla.Configuration
     /// Gets or sets the type that implements 
     /// IDataPortalCache for client-side caching.
     /// </summary>
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
     public Type DataPortalCacheType { get; set; } = typeof(DataPortalNoCache);
   }
 }

--- a/Source/Csla/Configuration/Fluent/DataPortalServerOptions.cs
+++ b/Source/Csla/Configuration/Fluent/DataPortalServerOptions.cs
@@ -6,6 +6,7 @@
 // <summary>Server-side data portal options.</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using Csla.Server;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -26,6 +27,9 @@ namespace Csla.Configuration
     /// Gets or sets a value containing the type of the
     /// IDashboard to be used by the data portal.
     /// </summary>
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
     internal Type DashboardType { get; set; } = typeof(Server.Dashboard.NullDashboard);
 
     /// <summary>
@@ -33,7 +37,11 @@ namespace Csla.Configuration
     /// used by the data portal. 
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public DataPortalServerOptions RegisterDashboard<T>() where T : Server.Dashboard.IDashboard
+    public DataPortalServerOptions RegisterDashboard<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      T>() where T : Server.Dashboard.IDashboard
     {
       DashboardType = typeof(T);
       return this;
@@ -45,6 +53,9 @@ namespace Csla.Configuration
     /// An instance of this type is created using dependency
     /// injection.
     /// </summary>
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
     internal Type AuthorizerProviderType { get; set; } = typeof(ActiveAuthorizer);
 
     /// <summary>
@@ -52,7 +63,11 @@ namespace Csla.Configuration
     /// used by the data portal. 
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public DataPortalServerOptions RegisterAuthorizerProvider<T>() where T : IAuthorizeDataPortal
+    public DataPortalServerOptions RegisterAuthorizerProvider<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      T>() where T : IAuthorizeDataPortal
     {
       AuthorizerProviderType = typeof(T);
       return this;
@@ -99,13 +114,20 @@ namespace Csla.Configuration
     /// <summary>
     /// Gets or sets the type of the ExceptionInspector.
     /// </summary>
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
     internal Type ExceptionInspectorType { get; set; } = typeof(DefaultExceptionInspector);
 
     /// <summary>
     /// Sets the type of the ExceptionInspector.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public DataPortalServerOptions RegisterExceptionInspector<T>() where T: IDataPortalExceptionInspector
+    public DataPortalServerOptions RegisterExceptionInspector<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      T>() where T: IDataPortalExceptionInspector
     {
       ExceptionInspectorType = typeof(T);
       return this;
@@ -114,13 +136,20 @@ namespace Csla.Configuration
     /// <summary>
     /// Gets or sets the type of the Activator.
     /// </summary>
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
     internal Type ActivatorType { get; set; } = typeof(DefaultDataPortalActivator);
 
     /// <summary>
     /// Sets the type of the Activator.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public DataPortalServerOptions RegisterActivator<T>() where T: IDataPortalActivator
+    public DataPortalServerOptions RegisterActivator<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      T>() where T: IDataPortalActivator
     {
       ActivatorType = typeof(T);
       return this;
@@ -132,6 +161,9 @@ namespace Csla.Configuration
     /// the FactoryDataPortal model. Type must implement
     /// <see cref="IObjectFactoryLoader"/>.
     /// </summary>
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
     internal Type ObjectFactoryLoaderType { get; set; } = typeof(ObjectFactoryLoader);
 
     /// <summary>
@@ -141,7 +173,11 @@ namespace Csla.Configuration
     /// <see cref="IObjectFactoryLoader"/>.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public DataPortalServerOptions RegisterObjectFactoryLoader<T>() where T: IObjectFactoryLoader
+    public DataPortalServerOptions RegisterObjectFactoryLoader<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      T>() where T: IObjectFactoryLoader
     {
       ObjectFactoryLoaderType = typeof(T);
       return this;

--- a/Source/Csla/Configuration/Fluent/SerializationOptions.cs
+++ b/Source/Csla/Configuration/Fluent/SerializationOptions.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using Csla.Serialization;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Csla.Configuration
@@ -32,7 +33,11 @@ namespace Csla.Configuration
     /// for all explicit object serialization (such as cloning,
     /// n-level undo, etc). Default is MobileFormatter.
     /// </summary>
-    public SerializationOptions UseSerializationFormatter<T>() where T : ISerializationFormatter
+    public SerializationOptions UseSerializationFormatter<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      T>() where T : ISerializationFormatter
     {
       CslaOptions.Services.AddTransient(typeof(ISerializationFormatter), typeof(T));
       return this;

--- a/Source/Csla/Core/BusinessBase.cs
+++ b/Source/Csla/Core/BusinessBase.cs
@@ -12,6 +12,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Csla.Core.FieldManager;
 using Csla.Core.LoadManager;
@@ -1605,7 +1606,15 @@ namespace Csla.Core
     /// <returns>
     /// The provided IPropertyInfo object.
     /// </returns>
-    protected static PropertyInfo<P> RegisterProperty<P>(Type objectType, PropertyInfo<P> info)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      Type objectType, PropertyInfo<P> info)
     {
       return PropertyInfoManager.RegisterProperty<P>(objectType, info);
     }
@@ -1685,7 +1694,11 @@ namespace Csla.Core
     /// value, the defaultValue value is returned as a
     /// result.
     /// </remarks>
-    protected P GetProperty<P>(PropertyInfo<P> propertyInfo, P field)
+    protected P GetProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, P field)
     {
       return GetProperty<P>(propertyInfo.Name, field, propertyInfo.DefaultValue, NoAccessBehavior.SuppressException);
     }
@@ -1706,7 +1719,11 @@ namespace Csla.Core
     /// <param name="noAccess">
     /// True if an exception should be thrown when the
     /// user is not authorized to read this property.</param>
-    protected P GetProperty<P>(PropertyInfo<P> propertyInfo, P field, P defaultValue, NoAccessBehavior noAccess)
+    protected P GetProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, P field, P defaultValue, NoAccessBehavior noAccess)
     {
       return GetProperty<P>(propertyInfo.Name, field, defaultValue, noAccess);
     }
@@ -1730,7 +1747,15 @@ namespace Csla.Core
     /// value, the defaultValue value is returned as a
     /// result.
     /// </remarks>
-    protected P GetPropertyConvert<F, P>(PropertyInfo<F> propertyInfo, F field)
+    protected P GetPropertyConvert<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+    F,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+    P>(PropertyInfo<F> propertyInfo, F field)
     {
       return Utilities.CoerceValue<P>(typeof(F), null, GetProperty<F>(propertyInfo.Name, field, propertyInfo.DefaultValue, NoAccessBehavior.SuppressException));
     }
@@ -1757,7 +1782,15 @@ namespace Csla.Core
     /// value, the defaultValue value is returned as a
     /// result.
     /// </remarks>
-    protected P GetPropertyConvert<F, P>(PropertyInfo<F> propertyInfo, F field, NoAccessBehavior noAccess)
+    protected P GetPropertyConvert<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      F,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<F> propertyInfo, F field, NoAccessBehavior noAccess)
     {
       return Utilities.CoerceValue<P>(typeof(F), null, GetProperty<F>(propertyInfo.Name, field, propertyInfo.DefaultValue, noAccess));
     }
@@ -1776,7 +1809,11 @@ namespace Csla.Core
     /// value, the defaultValue value is returned as a
     /// result.
     /// </remarks>
-    protected P GetProperty<P>(PropertyInfo<P> propertyInfo)
+    protected P GetProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo)
     {
       return GetProperty<P>(propertyInfo, NoAccessBehavior.SuppressException);
     }
@@ -1799,7 +1836,15 @@ namespace Csla.Core
     /// value, the defaultValue value is returned as a
     /// result.
     /// </remarks>
-    protected P GetPropertyConvert<F, P>(PropertyInfo<F> propertyInfo)
+    protected P GetPropertyConvert<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      F,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<F> propertyInfo)
     {
       return Utilities.CoerceValue<P>(typeof(F), null, GetProperty<F>(propertyInfo, NoAccessBehavior.SuppressException));
     }
@@ -1825,7 +1870,15 @@ namespace Csla.Core
     /// value, the defaultValue value is returned as a
     /// result.
     /// </remarks>
-    protected P GetPropertyConvert<F, P>(PropertyInfo<F> propertyInfo, NoAccessBehavior noAccess)
+    protected P GetPropertyConvert<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      F,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<F> propertyInfo, NoAccessBehavior noAccess)
     {
       return Utilities.CoerceValue<P>(typeof(F), null, GetProperty<F>(propertyInfo, noAccess));
     }
@@ -1847,7 +1900,11 @@ namespace Csla.Core
     /// value, the defaultValue value is returned as a
     /// result.
     /// </remarks>
-    protected P GetProperty<P>(PropertyInfo<P> propertyInfo, NoAccessBehavior noAccess)
+    protected P GetProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+    P>(PropertyInfo<P> propertyInfo, NoAccessBehavior noAccess)
     {
       if (((propertyInfo.RelationshipType & RelationshipTypes.LazyLoad) == RelationshipTypes.LazyLoad) && !FieldManager.FieldExists(propertyInfo))
       {
@@ -1920,7 +1977,11 @@ namespace Csla.Core
     /// value, the defaultValue value is returned as a
     /// result.
     /// </remarks>
-    protected P LazyGetProperty<P>(PropertyInfo<P> property, Func<P> valueGenerator)
+    protected P LazyGetProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> property, Func<P> valueGenerator)
     {
       if (!(FieldManager.FieldExists(property)))
       {
@@ -1961,7 +2022,11 @@ namespace Csla.Core
     /// result.
     /// </para>
     /// </remarks>
-    protected P LazyGetPropertyAsync<P>(PropertyInfo<P> property, Task<P> factory)
+    protected P LazyGetPropertyAsync<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> property, Task<P> factory)
     {
       if (!(FieldManager.FieldExists(property)) && !PropertyIsLoading(property))
       {
@@ -1970,12 +2035,20 @@ namespace Csla.Core
       return GetProperty<P>(property);
     }
 
-    object IManageProperties.LazyGetProperty<P>(PropertyInfo<P> propertyInfo, Func<P> valueGenerator)
+    object IManageProperties.LazyGetProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, Func<P> valueGenerator)
     {
       return LazyGetProperty(propertyInfo, valueGenerator);
     }
 
-    object IManageProperties.LazyGetPropertyAsync<P>(PropertyInfo<P> propertyInfo, Task<P> factory)
+    object IManageProperties.LazyGetPropertyAsync<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, Task<P> factory)
     {
       return LazyGetPropertyAsync(propertyInfo, factory);
     }
@@ -1997,7 +2070,15 @@ namespace Csla.Core
     /// </typeparam>
     /// <param name="propertyInfo">
     /// PropertyInfo object containing property metadata.</param>
-    protected P ReadPropertyConvert<F, P>(PropertyInfo<F> propertyInfo)
+    protected P ReadPropertyConvert<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      F,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<F> propertyInfo)
     {
       return Utilities.CoerceValue<P>(typeof(F), null, ReadProperty<F>(propertyInfo));
     }
@@ -2010,7 +2091,11 @@ namespace Csla.Core
     /// </typeparam>
     /// <param name="propertyInfo">
     /// PropertyInfo object containing property metadata.</param>
-    protected P ReadProperty<P>(PropertyInfo<P> propertyInfo)
+    protected P ReadProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo)
     {
       if (((propertyInfo.RelationshipType & RelationshipTypes.LazyLoad) == RelationshipTypes.LazyLoad) && !FieldManager.FieldExists(propertyInfo))
       {
@@ -2078,7 +2163,11 @@ namespace Csla.Core
     /// <param name="property">
     /// PropertyInfo object containing property metadata.</param>
     /// <param name="valueGenerator">Method returning the new value.</param>
-    protected P LazyReadProperty<P>(PropertyInfo<P> property, Func<P> valueGenerator)
+    protected P LazyReadProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> property, Func<P> valueGenerator)
     {
       if (!(FieldManager.FieldExists(property)))
       {
@@ -2097,7 +2186,11 @@ namespace Csla.Core
     /// <param name="property">
     /// PropertyInfo object containing property metadata.</param>
     /// <param name="factory">Async method returning the new value.</param>
-    protected P LazyReadPropertyAsync<P>(PropertyInfo<P> property, Task<P> factory)
+    protected P LazyReadPropertyAsync<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> property, Task<P> factory)
     {
       if (!(FieldManager.FieldExists(property)) && !PropertyIsLoading(property))
       {
@@ -2106,12 +2199,20 @@ namespace Csla.Core
       return ReadProperty<P>(property);
     }
 
-    P IManageProperties.LazyReadProperty<P>(PropertyInfo<P> propertyInfo, Func<P> valueGenerator)
+    P IManageProperties.LazyReadProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, Func<P> valueGenerator)
     {
       return LazyReadProperty(propertyInfo, valueGenerator);
     }
 
-    P IManageProperties.LazyReadPropertyAsync<P>(PropertyInfo<P> propertyInfo, Task<P> factory)
+    P IManageProperties.LazyReadPropertyAsync<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, Task<P> factory)
     {
       return LazyReadPropertyAsync(propertyInfo, factory);
     }
@@ -2135,7 +2236,11 @@ namespace Csla.Core
     /// If the user is not authorized to change the property, this
     /// overload throws a SecurityException.
     /// </remarks>
-    protected void SetProperty<P>(PropertyInfo<P> propertyInfo, ref P field, P newValue)
+    protected void SetProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, ref P field, P newValue)
     {
       SetProperty<P>(propertyInfo.Name, ref field, newValue, NoAccessBehavior.ThrowException);
     }
@@ -2155,7 +2260,11 @@ namespace Csla.Core
     /// If the user is not authorized to change the property, this
     /// overload throws a SecurityException.
     /// </remarks>
-    protected void SetProperty<P>(string propertyName, ref P field, P newValue)
+    protected void SetProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(string propertyName, ref P field, P newValue)
     {
       SetProperty<P>(propertyName, ref field, newValue, NoAccessBehavior.ThrowException);
     }
@@ -2181,7 +2290,15 @@ namespace Csla.Core
     /// If the user is not authorized to change the property, this
     /// overload throws a SecurityException.
     /// </remarks>
-    protected void SetPropertyConvert<P, V>(PropertyInfo<P> propertyInfo, ref P field, V newValue)
+    protected void SetPropertyConvert<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      V>(PropertyInfo<P> propertyInfo, ref P field, V newValue)
     {
       SetPropertyConvert<P, V>(propertyInfo, ref field, newValue, NoAccessBehavior.ThrowException);
     }
@@ -2210,7 +2327,15 @@ namespace Csla.Core
     /// If the field value is of type string, any incoming
     /// null values are converted to string.Empty.
     /// </remarks>
-    protected void SetPropertyConvert<P, V>(PropertyInfo<P> propertyInfo, ref P field, V newValue, NoAccessBehavior noAccess)
+    protected void SetPropertyConvert<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      V>(PropertyInfo<P> propertyInfo, ref P field, V newValue, NoAccessBehavior noAccess)
     {
       SetPropertyConvert<P, V>(propertyInfo.Name, ref field, newValue, noAccess);
     }
@@ -2229,7 +2354,11 @@ namespace Csla.Core
     /// <param name="noAccess">
     /// True if an exception should be thrown when the
     /// user is not authorized to change this property.</param>
-    protected void SetProperty<P>(string propertyName, ref P field, P newValue, NoAccessBehavior noAccess)
+    protected void SetProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(string propertyName, ref P field, P newValue, NoAccessBehavior noAccess)
     {
       try
       {
@@ -2304,7 +2433,15 @@ namespace Csla.Core
     /// If the field value is of type string, any incoming
     /// null values are converted to string.Empty.
     /// </remarks>
-    protected void SetPropertyConvert<P, V>(string propertyName, ref P field, V newValue, NoAccessBehavior noAccess)
+    protected void SetPropertyConvert<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      V>(string propertyName, ref P field, V newValue, NoAccessBehavior noAccess)
     {
       try
       {
@@ -2369,7 +2506,11 @@ namespace Csla.Core
     /// If the user is not authorized to change the property, this
     /// overload throws a SecurityException.
     /// </remarks>
-    protected void SetProperty<P>(PropertyInfo<P> propertyInfo, P newValue)
+    protected void SetProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, P newValue)
     {
       SetProperty<P>(propertyInfo, newValue, NoAccessBehavior.ThrowException);
     }
@@ -2387,7 +2528,15 @@ namespace Csla.Core
     /// If the user is not authorized to change the property, this
     /// overload throws a SecurityException.
     /// </remarks>
-    protected void SetPropertyConvert<P, F>(PropertyInfo<P> propertyInfo, F newValue)
+    protected void SetPropertyConvert<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      F>(PropertyInfo<P> propertyInfo, F newValue)
     {
       SetPropertyConvert<P, F>(propertyInfo, newValue, NoAccessBehavior.ThrowException);
     }
@@ -2404,7 +2553,15 @@ namespace Csla.Core
     /// <param name="noAccess">
     /// True if an exception should be thrown when the
     /// user is not authorized to change this property.</param>
-    protected void SetPropertyConvert<P, F>(PropertyInfo<P> propertyInfo, F newValue, NoAccessBehavior noAccess)
+    protected void SetPropertyConvert<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      F>(PropertyInfo<P> propertyInfo, F newValue, NoAccessBehavior noAccess)
     {
       try
       {
@@ -2459,7 +2616,11 @@ namespace Csla.Core
     /// <param name="noAccess">
     /// True if an exception should be thrown when the
     /// user is not authorized to change this property.</param>
-    protected void SetProperty<P>(PropertyInfo<P> propertyInfo, P newValue, NoAccessBehavior noAccess)
+    protected void SetProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, P newValue, NoAccessBehavior noAccess)
     {
       if (_bypassPropertyChecks || CanWriteProperty(propertyInfo, noAccess == NoAccessBehavior.ThrowException))
       {
@@ -2569,7 +2730,15 @@ namespace Csla.Core
     /// Loading values does not cause validation rules to be
     /// invoked.
     /// </remarks>
-    protected void LoadPropertyConvert<P, F>(PropertyInfo<P> propertyInfo, F newValue)
+    protected void LoadPropertyConvert<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      F>(PropertyInfo<P> propertyInfo, F newValue)
     {
       try
       {
@@ -2596,7 +2765,11 @@ namespace Csla.Core
       }
     }
 
-    void IManageProperties.LoadProperty<P>(PropertyInfo<P> propertyInfo, P newValue)
+    void IManageProperties.LoadProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, P newValue)
     {
       LoadProperty<P>(propertyInfo, newValue);
     }
@@ -2623,7 +2796,11 @@ namespace Csla.Core
     /// Loading values does not cause validation rules to be
     /// invoked.
     /// </remarks>
-    protected void LoadProperty<P>(PropertyInfo<P> propertyInfo, P newValue)
+    protected void LoadProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, P newValue)
     {
       try
       {
@@ -2667,7 +2844,11 @@ namespace Csla.Core
     /// Loading values does not cause validation rules to be
     /// invoked.
     /// </remarks>
-    protected bool LoadPropertyMarkDirty<P>(PropertyInfo<P> propertyInfo, P newValue)
+    protected bool LoadPropertyMarkDirty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, P newValue)
     {
       try
       {
@@ -2724,7 +2905,11 @@ namespace Csla.Core
     /// <param name="propertyInfo">The property info.</param>
     /// <param name="newValue">The new value.</param>
     /// <param name="oldValue">The old value.</param>
-    private static bool ValuesDiffer<P>(PropertyInfo<P> propertyInfo, P newValue, P oldValue)
+    private static bool ValuesDiffer<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, P newValue, P oldValue)
     {
       var valuesDiffer = false;
       if (oldValue == null)
@@ -2744,7 +2929,11 @@ namespace Csla.Core
       return valuesDiffer;
     }
 
-    private void LoadPropertyValue<P>(PropertyInfo<P> propertyInfo, P oldValue, P newValue, bool markDirty)
+    private void LoadPropertyValue<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, P oldValue, P newValue, bool markDirty)
     {
       var valuesDiffer = ValuesDiffer(propertyInfo, newValue, oldValue);
 
@@ -3040,7 +3229,11 @@ namespace Csla.Core
     /// <typeparam name="R"></typeparam>
     /// <param name="property"></param>
     /// <param name="factory"></param>
-    protected void LoadPropertyAsync<R>(PropertyInfo<R> property, Task<R> factory)
+    protected void LoadPropertyAsync<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      R>(PropertyInfo<R> property, Task<R> factory)
     {
       LoadManager.BeginLoad(new TaskLoader<R>(property, factory));
     }
@@ -3489,7 +3682,11 @@ namespace Csla.Core
       return ReadProperty(propertyInfo);
     }
 
-    P IManageProperties.ReadProperty<P>(PropertyInfo<P> propertyInfo)
+    P IManageProperties.ReadProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo)
     {
       return ReadProperty<P>(propertyInfo);
     }

--- a/Source/Csla/Core/ExtendedBindingList.cs
+++ b/Source/Csla/Core/ExtendedBindingList.cs
@@ -396,7 +396,11 @@ namespace Csla.Core
     /// Will be instanciated by a factory property on the ObservableBindingList implementation.
     /// </summary>
     /// <typeparam name="TC">The type of the C.</typeparam>
-    class SuppressListChangedEventsClass<TC> : IDisposable
+    class SuppressListChangedEventsClass<
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      TC> : IDisposable
     {
       private readonly BindingList<TC> _businessObject;
       private readonly bool _initialRaiseListChangedEvents;

--- a/Source/Csla/Core/FieldManager/DefaultPropertyInfoFactory.cs
+++ b/Source/Csla/Core/FieldManager/DefaultPropertyInfoFactory.cs
@@ -6,6 +6,8 @@
 // <summary>Creates PropertyInfo objects.</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Csla.Core.FieldManager
 {
   /// <summary>
@@ -21,7 +23,11 @@ namespace Csla.Core.FieldManager
     /// declaration.
     /// </param>
     /// <param name="name">Name of the property.</param>
-    public PropertyInfo<T> Create<T>(Type containingType, string name)
+    public PropertyInfo<T> Create<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(Type containingType, string name)
     {
       return new PropertyInfo<T>(name, null, containingType, PropertyInfo<T>.DataBindingFriendlyDefault(), RelationshipTypes.None, null);
     }
@@ -37,7 +43,11 @@ namespace Csla.Core.FieldManager
     /// <param name="friendlyName">
     /// Friendly display name for the property.
     /// </param>
-    public PropertyInfo<T> Create<T>(Type containingType, string name, string friendlyName)
+    public PropertyInfo<T> Create<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(Type containingType, string name, string friendlyName)
     {
       return new PropertyInfo<T>(name, friendlyName, containingType, PropertyInfo<T>.DataBindingFriendlyDefault(), RelationshipTypes.None, null);
     }
@@ -55,7 +65,11 @@ namespace Csla.Core.FieldManager
     /// </param>
     /// <param name="relationship">Relationship with
     /// referenced object.</param>
-    public PropertyInfo<T> Create<T>(Type containingType, string name, string friendlyName, RelationshipTypes relationship)
+    public PropertyInfo<T> Create<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(Type containingType, string name, string friendlyName, RelationshipTypes relationship)
     {
       return new PropertyInfo<T>(name, friendlyName, containingType, PropertyInfo<T>.DataBindingFriendlyDefault(), relationship, null);
     }
@@ -74,7 +88,11 @@ namespace Csla.Core.FieldManager
     /// <param name="defaultValue">
     /// Default value for the property.
     /// </param>
-    public PropertyInfo<T> Create<T>(Type containingType, string name, string friendlyName, T defaultValue)
+    public PropertyInfo<T> Create<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(Type containingType, string name, string friendlyName, T defaultValue)
     {
       return new PropertyInfo<T>(name, friendlyName, containingType, defaultValue, RelationshipTypes.None, null);
     }
@@ -95,7 +113,11 @@ namespace Csla.Core.FieldManager
     /// </param>
     /// <param name="relationship">Relationship with
     /// referenced object.</param>
-    public PropertyInfo<T> Create<T>(Type containingType, string name, string friendlyName, T defaultValue, RelationshipTypes relationship)
+    public PropertyInfo<T> Create<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(Type containingType, string name, string friendlyName, T defaultValue, RelationshipTypes relationship)
     {
       return new PropertyInfo<T>(name, friendlyName, containingType, defaultValue, relationship, null);
     }
@@ -109,7 +131,11 @@ namespace Csla.Core.FieldManager
     /// </param>
     /// <param name="name">Name of the property.</param>
     /// <param name="isSerializable">If property is serializable</param>
-    public PropertyInfo<T> Create<T>(Type containingType, string name, bool isSerializable)
+    public PropertyInfo<T> Create<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(Type containingType, string name, bool isSerializable)
     {
       return new PropertyInfo<T>(name, null, containingType, PropertyInfo<T>.DataBindingFriendlyDefault(), RelationshipTypes.None, isSerializable);
     }
@@ -126,7 +152,11 @@ namespace Csla.Core.FieldManager
     /// Friendly display name for the property.
     /// </param>
     /// <param name="isSerializable">If property is serializable</param>
-    public PropertyInfo<T> Create<T>(Type containingType, string name, string friendlyName, bool isSerializable)
+    public PropertyInfo<T> Create<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(Type containingType, string name, string friendlyName, bool isSerializable)
     {
       return new PropertyInfo<T>(name, friendlyName, containingType, PropertyInfo<T>.DataBindingFriendlyDefault(), RelationshipTypes.None, isSerializable);
     }
@@ -145,7 +175,11 @@ namespace Csla.Core.FieldManager
     /// <param name="relationship">Relationship with
     /// referenced object.</param>
     /// <param name="isSerializable">If property is serializable</param>
-    public PropertyInfo<T> Create<T>(Type containingType, string name, string friendlyName, RelationshipTypes relationship, bool isSerializable)
+    public PropertyInfo<T> Create<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(Type containingType, string name, string friendlyName, RelationshipTypes relationship, bool isSerializable)
     {
       return new PropertyInfo<T>(name, friendlyName, containingType, PropertyInfo<T>.DataBindingFriendlyDefault(), relationship, isSerializable);
     }
@@ -165,7 +199,11 @@ namespace Csla.Core.FieldManager
     /// Default value for the property.
     /// </param>
     /// <param name="isSerializable">If property is serializable</param>
-    public PropertyInfo<T> Create<T>(Type containingType, string name, string friendlyName, T defaultValue, bool isSerializable)
+    public PropertyInfo<T> Create<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(Type containingType, string name, string friendlyName, T defaultValue, bool isSerializable)
     {
       return new PropertyInfo<T>(name, friendlyName, containingType, defaultValue, RelationshipTypes.None, isSerializable);
     }
@@ -187,7 +225,11 @@ namespace Csla.Core.FieldManager
     /// <param name="relationship">Relationship with
     /// referenced object.</param>
     /// <param name="isSerializable">If property is serializable</param>
-    public PropertyInfo<T> Create<T>(Type containingType, string name, string friendlyName, T defaultValue, RelationshipTypes relationship, bool isSerializable)
+    public PropertyInfo<T> Create<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(Type containingType, string name, string friendlyName, T defaultValue, RelationshipTypes relationship, bool isSerializable)
     {
       return new PropertyInfo<T>(name, friendlyName, containingType, defaultValue, relationship, isSerializable);
     }

--- a/Source/Csla/Core/FieldManager/FieldData.cs
+++ b/Source/Csla/Core/FieldManager/FieldData.cs
@@ -8,6 +8,7 @@
 
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 using Csla.Serialization.Mobile;
 
 namespace Csla.Core.FieldManager
@@ -17,7 +18,11 @@ namespace Csla.Core.FieldManager
   /// </summary>
   /// <typeparam name="T">Type of field value contained.</typeparam>
   [Serializable]
-  public class FieldData<T> : IFieldData<T>
+  public class FieldData<
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+    T> : IFieldData<T>
   {
     [NonSerialized]
     [NotUndoable]

--- a/Source/Csla/Core/FieldManager/FieldDataManager.cs
+++ b/Source/Csla/Core/FieldManager/FieldDataManager.cs
@@ -16,6 +16,7 @@ using Csla.Properties;
 using Csla.Serialization;
 using Csla.Serialization.Mobile;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Csla.Core.FieldManager
 {
@@ -45,7 +46,11 @@ namespace Csla.Core.FieldManager
     /// </summary>
     public FieldDataManager() { }
 
-    internal FieldDataManager(ApplicationContext applicationContext, Type businessObjectType)
+    internal FieldDataManager(ApplicationContext applicationContext,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      Type businessObjectType)
     {
       _applicationContext = applicationContext;
       SetPropertyList(businessObjectType);
@@ -56,7 +61,11 @@ namespace Csla.Core.FieldManager
     /// Called when parent object is deserialized to
     /// restore property list.
     /// </summary>
-    internal void SetPropertyList(Type businessObjectType)
+    internal void SetPropertyList(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      Type businessObjectType)
     {
       _businessObjectType = businessObjectType.AssemblyQualifiedName;
       _propertyList = GetConsolidatedList(businessObjectType);
@@ -113,7 +122,11 @@ namespace Csla.Core.FieldManager
     private static readonly Dictionary<Type, List<IPropertyInfo>> _consolidatedLists = new();
 #endif
 
-    private static List<IPropertyInfo> GetConsolidatedList(Type type)
+    private static List<IPropertyInfo> GetConsolidatedList(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      Type type)
     {
       List<IPropertyInfo> result = null;
 
@@ -172,7 +185,11 @@ namespace Csla.Core.FieldManager
       return result;
     }
 
-    private static List<IPropertyInfo> CreateConsolidatedList(Type type)
+    private static List<IPropertyInfo> CreateConsolidatedList(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      Type type)
     {
       ForceStaticFieldInit(type);
       List<IPropertyInfo> result = [];
@@ -842,7 +859,11 @@ namespace Csla.Core.FieldManager
     /// by a type, and any of its base class types.
     /// </summary>
     /// <param name="type">Type of object to initialize.</param>
-    public static void ForceStaticFieldInit(Type type)
+    public static void ForceStaticFieldInit(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      Type type)
     {
       const BindingFlags attr =
         BindingFlags.Static |

--- a/Source/Csla/Core/FieldManager/PropertyInfoFactory.cs
+++ b/Source/Csla/Core/FieldManager/PropertyInfoFactory.cs
@@ -6,6 +6,8 @@
 // <summary>Creates the factory object that</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Csla.Core.FieldManager
 {
   /// <summary>
@@ -17,6 +19,9 @@ namespace Csla.Core.FieldManager
     /// <summary>
     /// Gets the PropertyInfoFactory type.
     /// </summary>
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
     public static Type FactoryType { get; internal set; } = typeof(DefaultPropertyInfoFactory);
 
     private static IPropertyInfoFactory _factory;

--- a/Source/Csla/Core/FieldManager/PropertyInfoManager.cs
+++ b/Source/Csla/Core/FieldManager/PropertyInfoManager.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 #if NET8_0_OR_GREATER
 using System.Runtime.Loader;
 
@@ -64,7 +65,15 @@ namespace Csla.Core.FieldManager
       }
     }
 
-    internal static PropertyInfoList GetPropertyListCache(Type objectType)
+#if NET8_0_OR_GREATER
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2067:UnrecognizedReflectionPattern",
+          Justification = "Type in cache is the same as objectType")]
+#endif
+    internal static PropertyInfoList GetPropertyListCache(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      Type objectType)
     {
       var cache = PropertyInfoCache;
 
@@ -118,7 +127,15 @@ namespace Csla.Core.FieldManager
     /// <returns>
     /// The provided IPropertyInfo object.
     /// </returns>
-    internal static PropertyInfo<T> RegisterProperty<T>(Type objectType, PropertyInfo<T> info)
+    internal static PropertyInfo<T> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      Type objectType, PropertyInfo<T> info)
     {
       var list = GetPropertyListCache(objectType);
       lock (list)
@@ -160,7 +177,11 @@ namespace Csla.Core.FieldManager
     /// Registered property information is only available after at least one instance
     /// of the object type has been created within the current AppDomain.
     /// </remarks>
-    public static PropertyInfoList GetRegisteredProperties(Type objectType)
+    public static PropertyInfoList GetRegisteredProperties(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      Type objectType)
     {
       // return a copy of the list to avoid
       // possible locking issues
@@ -174,7 +195,11 @@ namespace Csla.Core.FieldManager
     /// </summary>
     /// <param name="objectType">The business object type.</param>
     /// <param name="propertyName">The name of the property.</param>
-    public static IPropertyInfo GetRegisteredProperty(Type objectType, string propertyName)
+    public static IPropertyInfo GetRegisteredProperty(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      Type objectType, string propertyName)
     {
       return GetRegisteredProperties(objectType).FirstOrDefault(p => p.Name == propertyName);
     }

--- a/Source/Csla/Core/GraphMerger.cs
+++ b/Source/Csla/Core/GraphMerger.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Csla.Core
 {
@@ -151,7 +152,11 @@ namespace Csla.Core
     /// </summary>
     /// <param name="target">Target of merge.</param>
     /// <param name="source">Source for merge.</param>
-    public void MergeBusinessListGraph<T, C>(T target, T source)
+    public void MergeBusinessListGraph<T,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      C>(T target, T source)
       where T : BusinessListBase<T, C>
       where C : IEditableBusinessObject
     {
@@ -181,7 +186,11 @@ namespace Csla.Core
     /// </summary>
     /// <param name="target">Target of merge.</param>
     /// <param name="source">Source for merge.</param>
-    public void MergeBusinessBindingListGraph<T, C>(T target, T source)
+    public void MergeBusinessBindingListGraph<T,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      C>(T target, T source)
       where T : BusinessBindingListBase<T, C>
       where C : IEditableBusinessObject
     {
@@ -325,7 +334,11 @@ namespace Csla.Core
     /// </summary>
     /// <param name="target">Target of merge.</param>
     /// <param name="source">Source for merge.</param>
-    public async Task MergeBusinessListGraphAsync<T, C>(T target, T source)
+    public async Task MergeBusinessListGraphAsync<T,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      C>(T target, T source)
       where T : BusinessListBase<T, C>
       where C : IEditableBusinessObject
     {
@@ -355,7 +368,11 @@ namespace Csla.Core
     /// </summary>
     /// <param name="target">Target of merge.</param>
     /// <param name="source">Source for merge.</param>
-    public async Task MergeBusinessBindingListGraphAsync<T, C>(T target, T source)
+    public async Task MergeBusinessBindingListGraphAsync<T,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      C>(T target, T source)
       where T : BusinessBindingListBase<T, C>
       where C : IEditableBusinessObject
     {

--- a/Source/Csla/Core/IManageProperties.cs
+++ b/Source/Csla/Core/IManageProperties.cs
@@ -6,6 +6,8 @@
 // <summary>no summary</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Csla.Core
 {
   internal interface IManageProperties
@@ -14,16 +16,40 @@ namespace Csla.Core
     bool FieldExists(IPropertyInfo property);
     List<IPropertyInfo> GetManagedProperties();
     object GetProperty(IPropertyInfo propertyInfo);
-    object LazyGetProperty<P>(PropertyInfo<P> propertyInfo, Func<P> valueGenerator);
-    object LazyGetPropertyAsync<P>(PropertyInfo<P> propertyInfo, Task<P> factory);
+    object LazyGetProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, Func<P> valueGenerator);
+    object LazyGetPropertyAsync<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, Task<P> factory);
     object ReadProperty(IPropertyInfo propertyInfo);
-    P ReadProperty<P>(PropertyInfo<P> propertyInfo);
-    P LazyReadProperty<P>(PropertyInfo<P> propertyInfo, Func<P> valueGenerator);
-    P LazyReadPropertyAsync<P>(PropertyInfo<P> propertyInfo, Task<P> factory);
+    P ReadProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo);
+    P LazyReadProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, Func<P> valueGenerator);
+    P LazyReadPropertyAsync<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, Task<P> factory);
     void SetProperty(IPropertyInfo propertyInfo, object newValue);
     void LoadProperty(IPropertyInfo propertyInfo, object newValue);
     bool LoadPropertyMarkDirty(IPropertyInfo propertyInfo, object newValue);
-    void LoadProperty<P>(PropertyInfo<P> propertyInfo, P newValue);
+    void LoadProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, P newValue);
     List<object> GetChildren();
   }
 }

--- a/Source/Csla/Core/IPropertyInfoFactory.cs
+++ b/Source/Csla/Core/IPropertyInfoFactory.cs
@@ -6,6 +6,8 @@
 // <summary>Defines the interface for a factory object</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Csla.Core
 {
   /// <summary>
@@ -22,7 +24,11 @@ namespace Csla.Core
     /// declaration.
     /// </param>
     /// <param name="name">Name of the property.</param>
-    PropertyInfo<T> Create<T>(Type containingType, string name);
+    PropertyInfo<T> Create<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(Type containingType, string name);
     /// <summary>
     /// Creates a new instance of PropertyInfo.
     /// </summary>
@@ -34,7 +40,11 @@ namespace Csla.Core
     /// <param name="friendlyName">
     /// Friendly display name for the property.
     /// </param>
-    PropertyInfo<T> Create<T>(Type containingType, string name, string friendlyName);
+    PropertyInfo<T> Create<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(Type containingType, string name, string friendlyName);
     /// <summary>
     /// Creates a new instance of PropertyInfo.
     /// </summary>
@@ -48,7 +58,11 @@ namespace Csla.Core
     /// </param>
     /// <param name="relationship">Relationship with
     /// referenced object.</param>
-    PropertyInfo<T> Create<T>(Type containingType, string name, string friendlyName, RelationshipTypes relationship);
+    PropertyInfo<T> Create<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(Type containingType, string name, string friendlyName, RelationshipTypes relationship);
     /// <summary>
     /// Creates a new instance of PropertyInfo.
     /// </summary>
@@ -63,7 +77,11 @@ namespace Csla.Core
     /// <param name="defaultValue">
     /// Default value for the property.
     /// </param>
-    PropertyInfo<T> Create<T>(Type containingType, string name, string friendlyName, T defaultValue);
+    PropertyInfo<T> Create<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(Type containingType, string name, string friendlyName, T defaultValue);
     /// <summary>
     /// Creates a new instance of PropertyInfo.
     /// </summary>
@@ -80,7 +98,11 @@ namespace Csla.Core
     /// </param>
     /// <param name="relationship">Relationship with
     /// referenced object.</param>
-    PropertyInfo<T> Create<T>(Type containingType, string name, string friendlyName, T defaultValue, RelationshipTypes relationship);
+    PropertyInfo<T> Create<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(Type containingType, string name, string friendlyName, T defaultValue, RelationshipTypes relationship);
 
     /// <summary>
     /// Creates a new instance of PropertyInfo.
@@ -91,7 +113,11 @@ namespace Csla.Core
     /// </param>
     /// <param name="name">Name of the property.</param>
     /// <param name="isSerializable">If property is serializable</param>
-    PropertyInfo<T> Create<T>(Type containingType, string name, bool isSerializable);
+    PropertyInfo<T> Create<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(Type containingType, string name, bool isSerializable);
     /// <summary>
     /// Creates a new instance of PropertyInfo.
     /// </summary>
@@ -104,7 +130,11 @@ namespace Csla.Core
     /// Friendly display name for the property.
     /// </param>
     /// <param name="isSerializable">If property is serializable</param>
-    PropertyInfo<T> Create<T>(Type containingType, string name, string friendlyName, bool isSerializable);
+    PropertyInfo<T> Create<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(Type containingType, string name, string friendlyName, bool isSerializable);
     /// <summary>
     /// Creates a new instance of PropertyInfo.
     /// </summary>
@@ -119,7 +149,11 @@ namespace Csla.Core
     /// <param name="relationship">Relationship with
     /// referenced object.</param>
     /// <param name="isSerializable">If property is serializable</param>
-    PropertyInfo<T> Create<T>(Type containingType, string name, string friendlyName, RelationshipTypes relationship, bool isSerializable);
+    PropertyInfo<T> Create<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(Type containingType, string name, string friendlyName, RelationshipTypes relationship, bool isSerializable);
     /// <summary>
     /// Creates a new instance of PropertyInfo.
     /// </summary>
@@ -135,7 +169,11 @@ namespace Csla.Core
     /// Default value for the property.
     /// </param>
     /// <param name="isSerializable">If property is serializable</param>
-    PropertyInfo<T> Create<T>(Type containingType, string name, string friendlyName, T defaultValue, bool isSerializable);
+    PropertyInfo<T> Create<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(Type containingType, string name, string friendlyName, T defaultValue, bool isSerializable);
     /// <summary>
     /// Creates a new instance of PropertyInfo.
     /// </summary>
@@ -153,6 +191,10 @@ namespace Csla.Core
     /// <param name="relationship">Relationship with
     /// referenced object.</param>
     /// <param name="isSerializable">If property is serializable</param>
-    PropertyInfo<T> Create<T>(Type containingType, string name, string friendlyName, T defaultValue, RelationshipTypes relationship, bool isSerializable);
+    PropertyInfo<T> Create<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(Type containingType, string name, string friendlyName, T defaultValue, RelationshipTypes relationship, bool isSerializable);
   }
 }

--- a/Source/Csla/Core/ManagedObjectBase.cs
+++ b/Source/Csla/Core/ManagedObjectBase.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using Csla.Core.FieldManager;
@@ -20,6 +21,9 @@ namespace Csla.Core
   /// using SerializationFormatterFactory.GetFormatter().
   /// </summary>
   [Serializable]
+#if NET8_0_OR_GREATER
+  [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
+# endif
   public abstract class ManagedObjectBase : MobileObject,
     INotifyPropertyChanged,
     IManageProperties,
@@ -71,7 +75,15 @@ namespace Csla.Core
     /// <returns>
     /// The provided IPropertyInfo object.
     /// </returns>
-    protected static PropertyInfo<P> RegisterProperty<P>(Type objectType, PropertyInfo<P> info)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      Type objectType, PropertyInfo<P> info)
     {
       return PropertyInfoManager.RegisterProperty<P>(objectType, info);
     }
@@ -85,7 +97,15 @@ namespace Csla.Core
     /// <typeparam name="P">Type of property</typeparam>
     /// <param name="propertyLambdaExpression">Property Expression</param>
     /// <returns>The provided IPropertyInfo object.</returns>
-    protected static PropertyInfo<P> RegisterProperty<T, P>(Expression<Func<T, object>> propertyLambdaExpression)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(Expression<Func<T, object>> propertyLambdaExpression)
     {
       PropertyInfo reflectedPropertyInfo = Reflect<T>.GetProperty(propertyLambdaExpression);
 
@@ -100,7 +120,15 @@ namespace Csla.Core
     /// <typeparam name="P">Type of property</typeparam>
     /// <param name="propertyLambdaExpression">Property Expression</param>
     /// <param name="defaultValue">Default Value for the property</param>
-    protected static PropertyInfo<P> RegisterProperty<T, P>(Expression<Func<T, object>> propertyLambdaExpression, P defaultValue)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(Expression<Func<T, object>> propertyLambdaExpression, P defaultValue)
     {
       PropertyInfo reflectedPropertyInfo = Reflect<T>.GetProperty(propertyLambdaExpression);
 
@@ -116,7 +144,15 @@ namespace Csla.Core
     /// <param name="propertyLambdaExpression">Property Expression</param>
     /// <param name="friendlyName">Friendly description for a property to be used in databinding</param>
     /// <returns>The provided IPropertyInfo object.</returns>
-    protected static PropertyInfo<P> RegisterProperty<T, P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName)
     {
       PropertyInfo reflectedPropertyInfo = Reflect<T>.GetProperty(propertyLambdaExpression);
 
@@ -132,7 +168,15 @@ namespace Csla.Core
     /// <param name="propertyLambdaExpression">Property Expression</param>
     /// <param name="friendlyName">Friendly description for a property to be used in databinding</param>
     /// <param name="defaultValue">Default Value for the property</param>
-    protected static PropertyInfo<P> RegisterProperty<T, P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName, P defaultValue)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+    T,
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName, P defaultValue)
     {
       PropertyInfo reflectedPropertyInfo = Reflect<T>.GetProperty(propertyLambdaExpression);
 
@@ -156,7 +200,15 @@ namespace Csla.Core
     /// </typeparam>
     /// <param name="propertyInfo">
     /// PropertyInfo object containing property metadata.</param>
-    protected P ReadPropertyConvert<F, P>(PropertyInfo<F> propertyInfo)
+    protected P ReadPropertyConvert<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      F,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<F> propertyInfo)
     {
       return Utilities.CoerceValue<P>(typeof(F), null, ReadProperty<F>(propertyInfo));
     }
@@ -169,7 +221,11 @@ namespace Csla.Core
     /// </typeparam>
     /// <param name="propertyInfo">
     /// PropertyInfo object containing property metadata.</param>
-    protected P ReadProperty<P>(PropertyInfo<P> propertyInfo)
+    protected P ReadProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo)
     {
       P result = default(P);
       IFieldData data = FieldManager.GetFieldData(propertyInfo);
@@ -233,7 +289,15 @@ namespace Csla.Core
     /// Loading values does not cause validation rules to be
     /// invoked.
     /// </remarks>
-    protected void LoadPropertyConvert<P, F>(PropertyInfo<P> propertyInfo, F newValue)
+    protected void LoadPropertyConvert<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      F>(PropertyInfo<P> propertyInfo, F newValue)
     {
       try
       {
@@ -277,7 +341,11 @@ namespace Csla.Core
     /// Loading values does not cause validation rules to be
     /// invoked.
     /// </remarks>
-    protected void LoadProperty<P>(PropertyInfo<P> propertyInfo, P newValue)
+    protected void LoadProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, P newValue)
     {
       try
       {
@@ -303,7 +371,11 @@ namespace Csla.Core
       }
     }
 
-    private bool LoadPropertyMarkDirty<P>(PropertyInfo<P> propertyInfo, P newValue)
+    private bool LoadPropertyMarkDirty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, P newValue)
     {
       try
       {
@@ -330,7 +402,11 @@ namespace Csla.Core
       }
     }
 
-    private void LoadPropertyValue<P>(PropertyInfo<P> propertyInfo, P oldValue, P newValue)
+    private void LoadPropertyValue<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, P oldValue, P newValue)
     {
       bool valuesDiffer;
       if (oldValue == null)
@@ -462,16 +538,40 @@ namespace Csla.Core
     bool IManageProperties.FieldExists(IPropertyInfo property) => FieldManager.FieldExists(property);
     List<IPropertyInfo> IManageProperties.GetManagedProperties() => FieldManager.GetRegisteredProperties();
     object IManageProperties.GetProperty(IPropertyInfo propertyInfo) => throw new NotImplementedException();
-    object IManageProperties.LazyGetProperty<P>(PropertyInfo<P> propertyInfo, Func<P> valueGenerator) => throw new NotImplementedException();
-    object IManageProperties.LazyGetPropertyAsync<P>(PropertyInfo<P> propertyInfo, Task<P> factory) => throw new NotImplementedException();
+    object IManageProperties.LazyGetProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, Func<P> valueGenerator) => throw new NotImplementedException();
+    object IManageProperties.LazyGetPropertyAsync<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, Task<P> factory) => throw new NotImplementedException();
     object IManageProperties.ReadProperty(IPropertyInfo propertyInfo) => ReadProperty(propertyInfo);
-    P IManageProperties.ReadProperty<P>(PropertyInfo<P> propertyInfo) => ReadProperty(propertyInfo);
-    P IManageProperties.LazyReadProperty<P>(PropertyInfo<P> propertyInfo, Func<P> valueGenerator) => throw new NotImplementedException();
-    P IManageProperties.LazyReadPropertyAsync<P>(PropertyInfo<P> propertyInfo, Task<P> factory) => throw new NotImplementedException();
+    P IManageProperties.ReadProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo) => ReadProperty(propertyInfo);
+    P IManageProperties.LazyReadProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, Func<P> valueGenerator) => throw new NotImplementedException();
+    P IManageProperties.LazyReadPropertyAsync<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, Task<P> factory) => throw new NotImplementedException();
     void IManageProperties.SetProperty(IPropertyInfo propertyInfo, object newValue) => throw new NotImplementedException();
     void IManageProperties.LoadProperty(IPropertyInfo propertyInfo, object newValue) => LoadProperty(propertyInfo, newValue);
     bool IManageProperties.LoadPropertyMarkDirty(IPropertyInfo propertyInfo, object newValue) => throw new NotImplementedException();
-    void IManageProperties.LoadProperty<P>(PropertyInfo<P> propertyInfo, P newValue) => LoadProperty(propertyInfo, newValue);
+    void IManageProperties.LoadProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, P newValue) => LoadProperty(propertyInfo, newValue);
     List<object> IManageProperties.GetChildren() => FieldManager.GetChildren();
     bool IManageProperties.HasManagedProperties => true;
   }

--- a/Source/Csla/Core/MobileDictionary.cs
+++ b/Source/Csla/Core/MobileDictionary.cs
@@ -6,6 +6,7 @@
 // <summary>Defines a dictionary that can be serialized through</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using Csla.Serialization.Mobile;
 
 namespace Csla.Core
@@ -17,7 +18,15 @@ namespace Csla.Core
   /// <typeparam name="K">Key value: any primitive or IMobileObject type.</typeparam>
   /// <typeparam name="V">Value: any primitive or IMobileObject type.</typeparam>
   [Serializable]
-  public class MobileDictionary<K, V> : Dictionary<K, V>, IMobileObject
+  public class MobileDictionary<
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+    K,
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+    V> : Dictionary<K, V>, IMobileObject
   {
     private bool _keyIsMobile;
     private bool _valueIsMobile;

--- a/Source/Csla/Core/MobileList.cs
+++ b/Source/Csla/Core/MobileList.cs
@@ -6,6 +6,7 @@
 // <summary>Implements a list that is serializable using</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using Csla.Serialization.Mobile;
 
 namespace Csla.Core
@@ -18,7 +19,11 @@ namespace Csla.Core
   /// Type of object contained in the list.
   /// </typeparam>
   [Serializable]
-  public class MobileList<T> : List<T>, IMobileObject
+  public class MobileList<
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+    T> : List<T>, IMobileObject
   {
     /// <summary>
     /// Creates an instance of the type.

--- a/Source/Csla/Core/ReadOnlyBindingList.cs
+++ b/Source/Csla/Core/ReadOnlyBindingList.cs
@@ -6,6 +6,7 @@
 // <summary>A readonly version of BindingList(Of T)</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using Csla.Properties;
 
 namespace Csla.Core
@@ -20,10 +21,14 @@ namespace Csla.Core
   /// from the list. Use the IsReadOnly property
   /// to unlock the list for loading/unloading data.
   /// </remarks>
-  [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", 
+  [SuppressMessage("Microsoft.Naming", 
     "CA1710:IdentifiersShouldHaveCorrectSuffix")]
   [Serializable]
-  public abstract class ReadOnlyBindingList<C> :
+  public abstract class ReadOnlyBindingList<
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+    C> :
     ExtendedBindingList<C>, IBusinessObject, IReadOnlyBindingList
   {
     #region Identity

--- a/Source/Csla/CriteriaBase.cs
+++ b/Source/Csla/CriteriaBase.cs
@@ -10,6 +10,7 @@ using Csla.Core;
 using System.Linq.Expressions;
 using Csla.Reflection;
 using System.Reflection;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Csla
 {
@@ -18,7 +19,11 @@ namespace Csla
   /// derived in a business class. 
   /// </summary>
   [Serializable]
-  public abstract class CriteriaBase<T> : ManagedObjectBase
+  public abstract class CriteriaBase<
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+    T> : ManagedObjectBase
     where T : CriteriaBase<T>
   {
     /// <summary>
@@ -44,7 +49,11 @@ namespace Csla
     /// <returns>
     /// The provided IPropertyInfo object.
     /// </returns>
-    protected static PropertyInfo<P> RegisterProperty<P>(PropertyInfo<P> info)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> info)
     {
       return Core.FieldManager.PropertyInfoManager.RegisterProperty<P>(typeof(T), info);
     }
@@ -55,7 +64,11 @@ namespace Csla
     /// </summary>
     /// <typeparam name="P">Type of property</typeparam>
     /// <param name="propertyName">Property name from nameof()</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(string propertyName)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(string propertyName)
     {
       return RegisterProperty(Core.FieldManager.PropertyInfoFactory.Factory.Create<P>(typeof(T), propertyName));
     }
@@ -66,7 +79,11 @@ namespace Csla
     /// </summary>
     /// <typeparam name="P">Type of property</typeparam>
     /// <param name="propertyLambdaExpression">Property Expression</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(Expression<Func<T, object>> propertyLambdaExpression)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(Expression<Func<T, object>> propertyLambdaExpression)
     {
       PropertyInfo reflectedPropertyInfo = Reflect<T>.GetProperty(propertyLambdaExpression);
       return RegisterProperty<P>(reflectedPropertyInfo.Name);
@@ -80,7 +97,11 @@ namespace Csla
     /// <param name="propertyName">Property name from nameof()</param>
     /// <param name="relationship">Relationship with
     /// referenced object.</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(string propertyName, RelationshipTypes relationship)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(string propertyName, RelationshipTypes relationship)
     {
       return RegisterProperty(Core.FieldManager.PropertyInfoFactory.Factory.Create<P>(typeof(T), propertyName, string.Empty, relationship));
     }
@@ -93,7 +114,11 @@ namespace Csla
     /// <param name="propertyLambdaExpression">Property Expression</param>
     /// <param name="relationship">Relationship with
     /// referenced object.</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(Expression<Func<T, object>> propertyLambdaExpression, RelationshipTypes relationship)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(Expression<Func<T, object>> propertyLambdaExpression, RelationshipTypes relationship)
     {
       PropertyInfo reflectedPropertyInfo = Reflect<T>.GetProperty(propertyLambdaExpression);
       return RegisterProperty<P>(reflectedPropertyInfo.Name, relationship);
@@ -106,7 +131,11 @@ namespace Csla
     /// <typeparam name="P">Type of property</typeparam>
     /// <param name="propertyName">Property name from nameof()</param>
     /// <param name="friendlyName">Friendly description for a property to be used in databinding</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(string propertyName, string friendlyName)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(string propertyName, string friendlyName)
     {
       return RegisterProperty(Core.FieldManager.PropertyInfoFactory.Factory.Create<P>(typeof(T), propertyName, friendlyName));
     }
@@ -118,7 +147,11 @@ namespace Csla
     /// <typeparam name="P">Type of property</typeparam>
     /// <param name="propertyLambdaExpression">Property Expression</param>
     /// <param name="friendlyName">Friendly description for a property to be used in databinding</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName)
     {
       PropertyInfo reflectedPropertyInfo = Reflect<T>.GetProperty(propertyLambdaExpression);
       return RegisterProperty<P>(reflectedPropertyInfo.Name, friendlyName);
@@ -132,7 +165,11 @@ namespace Csla
     /// <param name="propertyName">Property name from nameof()</param>
     /// <param name="friendlyName">Friendly description for a property to be used in databinding</param>
     /// <param name="defaultValue">Default Value for the property</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(string propertyName, string friendlyName, P defaultValue)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(string propertyName, string friendlyName, P defaultValue)
     {
       return RegisterProperty(Core.FieldManager.PropertyInfoFactory.Factory.Create<P>(typeof(T), propertyName, friendlyName, defaultValue));
     }
@@ -145,7 +182,11 @@ namespace Csla
     /// <param name="propertyLambdaExpression">Property Expression</param>
     /// <param name="friendlyName">Friendly description for a property to be used in databinding</param>
     /// <param name="defaultValue">Default Value for the property</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName, P defaultValue)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName, P defaultValue)
     {
       PropertyInfo reflectedPropertyInfo = Reflect<T>.GetProperty(propertyLambdaExpression);
       return RegisterProperty(reflectedPropertyInfo.Name, friendlyName, defaultValue);
@@ -161,7 +202,11 @@ namespace Csla
     /// <param name="defaultValue">Default Value for the property</param>
     /// <param name="relationship">Relationship with
     /// referenced object.</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(string propertyName, string friendlyName, P defaultValue, RelationshipTypes relationship)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(string propertyName, string friendlyName, P defaultValue, RelationshipTypes relationship)
     {
       return RegisterProperty(Core.FieldManager.PropertyInfoFactory.Factory.Create<P>(typeof(T), propertyName, friendlyName, defaultValue, relationship));
     }
@@ -176,7 +221,11 @@ namespace Csla
     /// <param name="defaultValue">Default Value for the property</param>
     /// <param name="relationship">Relationship with
     /// referenced object.</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName, P defaultValue, RelationshipTypes relationship)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName, P defaultValue, RelationshipTypes relationship)
     {
       PropertyInfo reflectedPropertyInfo = Reflect<T>.GetProperty(propertyLambdaExpression);
       return RegisterProperty(reflectedPropertyInfo.Name, friendlyName, defaultValue, relationship);

--- a/Source/Csla/Csla.csproj
+++ b/Source/Csla/Csla.csproj
@@ -16,12 +16,12 @@
     <EnableSingleFileAnalyzer Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</EnableSingleFileAnalyzer>
     <EnableAotAnalyzer Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</EnableAotAnalyzer> 
     <!-- This is first priority warnings which should be fixed. They are usually trimming friendly, in a sense that, develop annotate what parts of types should be preserved.  -->
-    <NoWarn>$(NoWarn);IL2067;IL2070;IL2072;IL2075;IL2087;IL2091</NoWarn>
+    <NoWarn>$(NoWarn);IL2070;IL2072;IL2075</NoWarn>
     <!-- 
       This is problematic for NativeAOT pieces of code, which require analysis of API and what can be done to improve situation. 
       Slapping "Here we require dynamic code" means, that we opt-out of supporting NativeAOT for these methods which is undesirable.
     -->
-    <NoWarn>$(NoWarn);IL2026;IL2055;IL2057;IL2060;IL2096;IL3050</NoWarn>
+    <NoWarn>$(NoWarn);IL2026;IL2055;IL2057;IL2060;IL2096;IL2111;IL3050</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Csla/Data/DataMapper.cs
+++ b/Source/Csla/Data/DataMapper.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Csla.Core;
 using Csla.Properties;
 using Csla.Reflection;
@@ -285,9 +286,13 @@ namespace Csla.Data
       }
     }
 
-      private static IList<string> GetPropertyNames(Type sourceType)
+      private static IList<string> GetPropertyNames(
+#if NET8_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+        Type sourceType)
       {
-        List<string> result = [];
+      List<string> result = [];
         PropertyDescriptorCollection props = TypeDescriptor.GetProperties(sourceType);
         foreach (PropertyDescriptor item in props)
             if (item.IsBrowsable)

--- a/Source/Csla/DataPortalClient/DataPortalProxy.cs
+++ b/Source/Csla/DataPortalClient/DataPortalProxy.cs
@@ -6,6 +6,7 @@
 // <summary>Abstract data portal proxy with common data portal proxy behaviour. Implements IDataPortalProxy</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using Csla.Configuration;
 using Csla.Serialization;
 using Csla.Serialization.Mobile;
@@ -57,7 +58,11 @@ namespace Csla.DataPortalClient
     /// <see cref="Server.DataPortalContext" /> object passed to the server.
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public async virtual Task<DataPortalResult> Create(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    public async virtual Task<DataPortalResult> Create(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       DataPortalResult result;
       try
@@ -116,7 +121,11 @@ namespace Csla.DataPortalClient
     /// <see cref="Server.DataPortalContext" /> object passed to the server.
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public async virtual Task<DataPortalResult> Fetch(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    public async virtual Task<DataPortalResult> Fetch(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       DataPortalResult result;
       try
@@ -232,7 +241,11 @@ namespace Csla.DataPortalClient
     /// <see cref="Server.DataPortalContext" /> object passed to the server.
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public async virtual Task<DataPortalResult> Delete(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    public async virtual Task<DataPortalResult> Delete(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       DataPortalResult result;
       try

--- a/Source/Csla/DataPortalClient/LocalProxy.cs
+++ b/Source/Csla/DataPortalClient/LocalProxy.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using Csla.Core;
 using Csla.DataPortalClient;
 using Csla.Runtime;
@@ -176,6 +177,9 @@ namespace Csla.Channels.Local
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
     public override async Task<DataPortalResult> Create(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
       Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       IServiceScope _logicalServerScope = null;
@@ -224,7 +228,11 @@ namespace Csla.Channels.Local
     /// <see cref="Server.DataPortalContext" /> object passed to the server.
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public override async Task<DataPortalResult> Fetch(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    public override async Task<DataPortalResult> Fetch(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       IServiceScope _logicalServerScope = null;
       DataPortalResult result;
@@ -319,7 +327,11 @@ namespace Csla.Channels.Local
     /// <see cref="Server.DataPortalContext" /> object passed to the server.
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public override async Task<DataPortalResult> Delete(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    public override async Task<DataPortalResult> Delete(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       IServiceScope _logicalServerScope = null;
       DataPortalResult result;

--- a/Source/Csla/DataPortalT.cs
+++ b/Source/Csla/DataPortalT.cs
@@ -6,6 +6,7 @@
 // <summary>Client side data portal used for making asynchronous</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Csla.Configuration;
 using Csla.Core;
@@ -21,7 +22,11 @@ namespace Csla
   /// <typeparam name="T">
   /// Type of business object.
   /// </typeparam>
-  public class DataPortal<T> : IDataPortal<T>, IChildDataPortal<T>, IDataPortal, IChildDataPortal
+  public class DataPortal<
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+    T> : IDataPortal<T>, IChildDataPortal<T>, IDataPortal, IChildDataPortal
   {
     /// <summary>
     /// Creates an instance of the type
@@ -96,7 +101,11 @@ namespace Csla
       }
     }
 
-    private async Task<object> DoCreateAsync(Type objectType, object criteria, bool isSync, CancellationToken ct = default)
+    private async Task<object> DoCreateAsync(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, bool isSync, CancellationToken ct = default)
     {
       Server.DataPortalResult result = null;
       Server.DataPortalContext dpContext = null;
@@ -167,7 +176,11 @@ namespace Csla
     /// <param name="criteria">The criteria required to perform the creation operation</param>
     /// <returns>Returns a new, initialised object of the type requested</returns>
 
-    private object Create(Type objectType, object criteria)
+    private object Create(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria)
     {
       try
       {
@@ -193,7 +206,11 @@ namespace Csla
       return (T)await DoCreateAsync(typeof(T), Server.DataPortal.GetCriteriaFromArray(criteria), false);
     }
 
-    private async Task<object> DoFetchAsync(Type objectType, object criteria, bool isSync, CancellationToken ct = default)
+    private async Task<object> DoFetchAsync(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, bool isSync, CancellationToken ct = default)
     {
       if (typeof(Core.ICommandObject).IsAssignableFrom(objectType))
       {
@@ -243,7 +260,11 @@ namespace Csla
       return result.ReturnObject;
     }
 
-    private async Task<object> DoExecuteAsync(Type objectType, object criteria, bool isSync, CancellationToken ct = default)
+    private async Task<object> DoExecuteAsync(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, bool isSync, CancellationToken ct = default)
     {
       Server.DataPortalResult result = null;
       Server.DataPortalContext dpContext = null;
@@ -310,7 +331,11 @@ namespace Csla
     /// <param name="objectType">The type of object to instantiate and load</param>
     /// <param name="criteria">The criteria required to perform the load operation</param>
     /// <returns>Returns a populated object of the type requested</returns>
-    private object Fetch(Type objectType, object criteria)
+    private object Fetch(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria)
     {
       try
       {
@@ -557,7 +582,11 @@ namespace Csla
       return DoUpdateAsync(obj, false);
     }
 
-    internal async Task DoDeleteAsync(Type objectType, object criteria, bool isSync, CancellationToken ct = default)
+    internal async Task DoDeleteAsync(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, bool isSync, CancellationToken ct = default)
     {
       Server.DataPortalResult result = null;
       Server.DataPortalContext dpContext = null;
@@ -619,7 +648,11 @@ namespace Csla
     /// <param name="objectType">The type of object to instantiate and load</param>
     /// <param name="criteria">The criteria required to perform the load operation</param>
     /// <returns>Returns a populated object of the type requested</returns>
-    private void Delete(Type objectType, object criteria)
+    private void Delete(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria)
     {
       try
       {

--- a/Source/Csla/DynamicBindingListBase.cs
+++ b/Source/Csla/DynamicBindingListBase.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Csla.Core;
 using Csla.Serialization.Mobile;
 
@@ -38,7 +39,14 @@ namespace Csla
   /// </para>
   /// </remarks>
   [Serializable]
-  public abstract class DynamicBindingListBase<T> :
+#if NET8_0_OR_GREATER
+  [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+# endif
+  public abstract class DynamicBindingListBase<
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+# endif
+    T> :
     ExtendedBindingList<T>,
     IParent,
     Server.IDataPortalTarget,

--- a/Source/Csla/DynamicListBase.cs
+++ b/Source/Csla/DynamicListBase.cs
@@ -8,6 +8,7 @@
 
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Csla.Core;
 using Csla.Reflection;
 using Csla.Serialization.Mobile;
@@ -40,7 +41,11 @@ namespace Csla
   /// </para>
   /// </remarks>
   [Serializable]
-  public abstract class DynamicListBase<T> :
+  public abstract class DynamicListBase<
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+    T> :
 #if ANDROID || IOS
     ExtendedBindingList<T>,
 #else

--- a/Source/Csla/FilteredBindingList.cs
+++ b/Source/Csla/FilteredBindingList.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Collections;
 using Csla.Properties;
 
@@ -17,7 +18,11 @@ namespace Csla
   /// </summary>
   /// <typeparam name="T">The type of the objects contained
   /// in the original list.</typeparam>
-  public class FilteredBindingList<T> :
+  public class FilteredBindingList<
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+    T> :
     IList<T>, IBindingList, IEnumerable<T>,
     ICancelAddNew
   {

--- a/Source/Csla/LazySingleton.cs
+++ b/Source/Csla/LazySingleton.cs
@@ -1,10 +1,16 @@
-﻿namespace Csla
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Csla
 {
   /// <summary>
   /// An alternative to Lazy&lt;T&gt; 
   /// </summary>
   /// <typeparam name="T"></typeparam>
-  public sealed class LazySingleton<T> : Core.IUseApplicationContext
+  public sealed class LazySingleton<
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+    T> : Core.IUseApplicationContext
     where T : class
   {
     private readonly Lock _syncRoot = LockFactory.Create();

--- a/Source/Csla/NameValueListBase.cs
+++ b/Source/Csla/NameValueListBase.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Csla.Core;
 using Csla.Properties;
 using Csla.Serialization.Mobile;
@@ -22,7 +23,15 @@ namespace Csla
   /// <typeparam name="V">Type of the values.</typeparam>
   [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix")]
   [Serializable]
-  public abstract class NameValueListBase<K, V> :
+  public abstract class NameValueListBase<
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+    K,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+    V> :
     ReadOnlyBindingList<NameValueListBase<K, V>.NameValuePair>,
     ICloneable,
     Server.IDataPortalTarget,

--- a/Source/Csla/PropertyInfo.cs
+++ b/Source/Csla/PropertyInfo.cs
@@ -8,6 +8,7 @@
 
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Csla
 {
@@ -17,7 +18,11 @@ namespace Csla
   /// <typeparam name="T">
   /// Data type of the property.
   /// </typeparam>
-  public class PropertyInfo<T> : Core.IPropertyInfo, IComparable
+  public class PropertyInfo<
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+    T> : Core.IPropertyInfo, IComparable
   {
     /// <summary>
     /// Creates a new instance of this class.

--- a/Source/Csla/ReadOnlyBase.cs
+++ b/Source/Csla/ReadOnlyBase.cs
@@ -10,6 +10,7 @@ using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using Csla.Core;
@@ -35,7 +36,11 @@ namespace Csla
   /// </remarks>
   /// <typeparam name="T">Type of the business object.</typeparam>
   [Serializable]
-  public abstract class ReadOnlyBase<T> : BindableBase,
+  public abstract class ReadOnlyBase<
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+    T> : BindableBase,
     IDataPortalTarget,
     IManageProperties,
     IReadOnlyBase,
@@ -542,7 +547,15 @@ namespace Csla
     /// <returns>
     /// The provided IPropertyInfo object.
     /// </returns>
-    protected static PropertyInfo<P> RegisterProperty<P>(Type objectType, PropertyInfo<P> info)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      Type objectType, PropertyInfo<P> info)
     {
       return PropertyInfoManager.RegisterProperty<P>(objectType, info);
     }
@@ -560,7 +573,11 @@ namespace Csla
     /// <returns>
     /// The provided IPropertyInfo object.
     /// </returns>
-    protected static PropertyInfo<P> RegisterProperty<P>(PropertyInfo<P> info)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> info)
     {
       return PropertyInfoManager.RegisterProperty<P>(typeof(T), info);
     }
@@ -571,7 +588,11 @@ namespace Csla
     /// </summary>
     /// <typeparam name="P">Type of property</typeparam>
     /// <param name="propertyName">Property name from nameof()</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(string propertyName)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(string propertyName)
     {
       return RegisterProperty(PropertyInfoFactory.Factory.Create<P>(typeof(T), propertyName));
     }
@@ -582,7 +603,11 @@ namespace Csla
     /// </summary>
     /// <typeparam name="P">Type of property</typeparam>
     /// <param name="propertyLambdaExpression">Property Expression</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(Expression<Func<T, object>> propertyLambdaExpression)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(Expression<Func<T, object>> propertyLambdaExpression)
     {
       PropertyInfo reflectedPropertyInfo = Reflect<T>.GetProperty(propertyLambdaExpression);
       return RegisterProperty<P>(reflectedPropertyInfo.Name);
@@ -595,7 +620,11 @@ namespace Csla
     /// <typeparam name="P">Type of property</typeparam>
     /// <param name="propertyName">Property name from nameof()</param>
     /// <param name="friendlyName">Friendly description for a property to be used in databinding</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(string propertyName, string friendlyName)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(string propertyName, string friendlyName)
     {
       return RegisterProperty(PropertyInfoFactory.Factory.Create<P>(typeof(T), propertyName, friendlyName));
     }
@@ -607,7 +636,11 @@ namespace Csla
     /// <typeparam name="P">Type of property</typeparam>
     /// <param name="propertyLambdaExpression">Property Expression</param>
     /// <param name="friendlyName">Friendly description for a property to be used in databinding</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName)
     {
       PropertyInfo reflectedPropertyInfo = Reflect<T>.GetProperty(propertyLambdaExpression);
       return RegisterProperty<P>(reflectedPropertyInfo.Name, friendlyName);
@@ -621,7 +654,11 @@ namespace Csla
     /// <param name="propertyName">Property name from nameof()</param>
     /// <param name="friendlyName">Friendly description for a property to be used in databinding</param>
     /// <param name="defaultValue">Default Value for the property</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(string propertyName, string friendlyName, P defaultValue)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(string propertyName, string friendlyName, P defaultValue)
     {
       return RegisterProperty(PropertyInfoFactory.Factory.Create<P>(typeof(T), propertyName, friendlyName, defaultValue));
     }
@@ -634,7 +671,11 @@ namespace Csla
     /// <param name="propertyLambdaExpression">Property Expression</param>
     /// <param name="friendlyName">Friendly description for a property to be used in databinding</param>
     /// <param name="defaultValue">Default Value for the property</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName, P defaultValue)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName, P defaultValue)
     {
       PropertyInfo reflectedPropertyInfo = Reflect<T>.GetProperty(propertyLambdaExpression);
       return RegisterProperty<P>(reflectedPropertyInfo.Name, friendlyName, defaultValue);
@@ -647,7 +688,11 @@ namespace Csla
     /// <typeparam name="P">Type of property</typeparam>
     /// <param name="propertyName">Property name from nameof()</param>
     /// <param name="relationship">Relationship with property value.</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(string propertyName, RelationshipTypes relationship)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(string propertyName, RelationshipTypes relationship)
     {
       return RegisterProperty(PropertyInfoFactory.Factory.Create<P>(typeof(T), propertyName, string.Empty, relationship));
     }
@@ -659,7 +704,11 @@ namespace Csla
     /// <typeparam name="P">Type of property</typeparam>
     /// <param name="propertyLambdaExpression">Property Expression</param>
     /// <param name="relationship">Relationship with property value.</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(Expression<Func<T, object>> propertyLambdaExpression, RelationshipTypes relationship)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(Expression<Func<T, object>> propertyLambdaExpression, RelationshipTypes relationship)
     {
       PropertyInfo reflectedPropertyInfo = Reflect<T>.GetProperty(propertyLambdaExpression);
       return RegisterProperty<P>(reflectedPropertyInfo.Name, relationship);
@@ -674,7 +723,11 @@ namespace Csla
     /// <param name="friendlyName">Friendly description for a property to be used in databinding</param>
     /// <param name="defaultValue">Default Value for the property</param>
     /// <param name="relationship">Relationship with property value.</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(string propertyName, string friendlyName, P defaultValue, RelationshipTypes relationship)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(string propertyName, string friendlyName, P defaultValue, RelationshipTypes relationship)
     {
       return RegisterProperty(PropertyInfoFactory.Factory.Create<P>(typeof(T), propertyName, friendlyName, defaultValue, relationship));
     }
@@ -688,7 +741,11 @@ namespace Csla
     /// <param name="friendlyName">Friendly description for a property to be used in databinding</param>
     /// <param name="defaultValue">Default Value for the property</param>
     /// <param name="relationship">Relationship with property value.</param>
-    protected static PropertyInfo<P> RegisterProperty<P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName, P defaultValue, RelationshipTypes relationship)
+    protected static PropertyInfo<P> RegisterProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(Expression<Func<T, object>> propertyLambdaExpression, string friendlyName, P defaultValue, RelationshipTypes relationship)
     {
       PropertyInfo reflectedPropertyInfo = Reflect<T>.GetProperty(propertyLambdaExpression);
       return RegisterProperty<P>(reflectedPropertyInfo.Name, friendlyName, defaultValue, relationship);
@@ -832,7 +889,11 @@ namespace Csla
     /// value, the defaultValue value is returned as a
     /// result.
     /// </remarks>
-    protected P GetProperty<P>(PropertyInfo<P> propertyInfo, P field)
+    protected P GetProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, P field)
     {
       return GetProperty<P>(propertyInfo.Name, field, propertyInfo.DefaultValue, NoAccessBehavior.SuppressException);
     }
@@ -853,7 +914,11 @@ namespace Csla
     /// <param name="noAccess">
     /// True if an exception should be thrown when the
     /// user is not authorized to read this property.</param>
-    protected P GetProperty<P>(PropertyInfo<P> propertyInfo, P field, P defaultValue, NoAccessBehavior noAccess)
+    protected P GetProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, P field, P defaultValue, NoAccessBehavior noAccess)
     {
       return GetProperty<P>(propertyInfo.Name, field, defaultValue, noAccess);
     }
@@ -870,7 +935,11 @@ namespace Csla
     /// value, the defaultValue value is returned as a
     /// result.
     /// </remarks>
-    protected P LazyGetProperty<P>(PropertyInfo<P> property, Func<P> valueGenerator)
+    protected P LazyGetProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> property, Func<P> valueGenerator)
     {
       if (!(FieldManager.FieldExists(property)))
       {
@@ -909,7 +978,11 @@ namespace Csla
     /// result.
     /// </para>
     /// </remarks>
-    protected P LazyGetPropertyAsync<P>(PropertyInfo<P> property, Task<P> factory)
+    protected P LazyGetPropertyAsync<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> property, Task<P> factory)
     {
       if (!(FieldManager.FieldExists(property)) && !PropertyIsLoading(property))
       {
@@ -937,7 +1010,15 @@ namespace Csla
     /// value, the defaultValue value is returned as a
     /// result.
     /// </remarks>
-    protected P GetPropertyConvert<F, P>(PropertyInfo<F> propertyInfo, F field)
+    protected P GetPropertyConvert<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      F,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<F> propertyInfo, F field)
     {
       return Utilities.CoerceValue<P>(typeof(F), null, GetProperty<F>(propertyInfo.Name, field, propertyInfo.DefaultValue, NoAccessBehavior.SuppressException));
     }
@@ -964,7 +1045,15 @@ namespace Csla
     /// value, the defaultValue value is returned as a
     /// result.
     /// </remarks>
-    protected P GetPropertyConvert<F, P>(PropertyInfo<F> propertyInfo, F field, NoAccessBehavior noAccess)
+    protected P GetPropertyConvert<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      F,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<F> propertyInfo, F field, NoAccessBehavior noAccess)
     {
       return Utilities.CoerceValue<P>(typeof(F), null, GetProperty<F>(propertyInfo.Name, field, propertyInfo.DefaultValue, noAccess));
     }
@@ -983,7 +1072,11 @@ namespace Csla
     /// value, the defaultValue value is returned as a
     /// result.
     /// </remarks>
-    protected P GetProperty<P>(PropertyInfo<P> propertyInfo)
+    protected P GetProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo)
     {
       return GetProperty<P>(propertyInfo, NoAccessBehavior.SuppressException);
     }
@@ -1006,7 +1099,15 @@ namespace Csla
     /// value, the defaultValue value is returned as a
     /// result.
     /// </remarks>
-    protected P GetPropertyConvert<F, P>(PropertyInfo<F> propertyInfo)
+    protected P GetPropertyConvert<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      F,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<F> propertyInfo)
     {
       return Utilities.CoerceValue<P>(typeof(F), null, GetProperty<F>(propertyInfo, NoAccessBehavior.SuppressException));
     }
@@ -1032,7 +1133,15 @@ namespace Csla
     /// value, the defaultValue value is returned as a
     /// result.
     /// </remarks>
-    protected P GetPropertyConvert<F, P>(PropertyInfo<F> propertyInfo, NoAccessBehavior noAccess)
+    protected P GetPropertyConvert<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      F,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<F> propertyInfo, NoAccessBehavior noAccess)
     {
       return Utilities.CoerceValue<P>(typeof(F), null, GetProperty<F>(propertyInfo, noAccess));
     }
@@ -1054,7 +1163,11 @@ namespace Csla
     /// value, the defaultValue value is returned as a
     /// result.
     /// </remarks>
-    protected P GetProperty<P>(PropertyInfo<P> propertyInfo, NoAccessBehavior noAccess)
+    protected P GetProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, NoAccessBehavior noAccess)
     {
       if (((propertyInfo.RelationshipType & RelationshipTypes.LazyLoad) == RelationshipTypes.LazyLoad) && !FieldManager.FieldExists(propertyInfo))
       {
@@ -1113,7 +1226,15 @@ namespace Csla
     /// </typeparam>
     /// <param name="propertyInfo">
     /// PropertyInfo object containing property metadata.</param>
-    protected P ReadPropertyConvert<F, P>(PropertyInfo<F> propertyInfo)
+    protected P ReadPropertyConvert<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      F,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<F> propertyInfo)
     {
       return Utilities.CoerceValue<P>(typeof(F), null, ReadProperty<F>(propertyInfo));
     }
@@ -1126,7 +1247,11 @@ namespace Csla
     /// </typeparam>
     /// <param name="propertyInfo">
     /// PropertyInfo object containing property metadata.</param>
-    protected P ReadProperty<P>(PropertyInfo<P> propertyInfo)
+    protected P ReadProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo)
     {
       if (((propertyInfo.RelationshipType & RelationshipTypes.LazyLoad) == RelationshipTypes.LazyLoad) && !FieldManager.FieldExists(propertyInfo))
       {
@@ -1187,7 +1312,11 @@ namespace Csla
     /// <param name="property">
     /// PropertyInfo object containing property metadata.</param>
     /// <param name="valueGenerator">Method returning the new value.</param>
-    protected P LazyReadProperty<P>(PropertyInfo<P> property, Func<P> valueGenerator)
+    protected P LazyReadProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> property, Func<P> valueGenerator)
     {
       if (!(FieldManager.FieldExists(property)))
       {
@@ -1206,7 +1335,11 @@ namespace Csla
     /// <param name="property">
     /// PropertyInfo object containing property metadata.</param>
     /// <param name="factory">Async method returning the new value.</param>
-    protected P LazyReadPropertyAsync<P>(PropertyInfo<P> property, Task<P> factory)
+    protected P LazyReadPropertyAsync<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> property, Task<P> factory)
     {
       if (!(FieldManager.FieldExists(property)) && !PropertyIsLoading(property))
       {
@@ -1215,12 +1348,20 @@ namespace Csla
       return ReadProperty<P>(property);
     }
 
-    P IManageProperties.LazyReadProperty<P>(PropertyInfo<P> propertyInfo, Func<P> valueGenerator)
+    P IManageProperties.LazyReadProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, Func<P> valueGenerator)
     {
       return LazyReadProperty(propertyInfo, valueGenerator);
     }
 
-    P IManageProperties.LazyReadPropertyAsync<P>(PropertyInfo<P> propertyInfo, Task<P> factory)
+    P IManageProperties.LazyReadPropertyAsync<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, Task<P> factory)
     {
       return LazyReadPropertyAsync(propertyInfo, factory);
     }
@@ -1244,7 +1385,15 @@ namespace Csla
     /// Loading values does not cause validation rules to be
     /// invoked.
     /// </remarks>
-    protected void LoadPropertyConvert<P, F>(PropertyInfo<P> propertyInfo, F newValue)
+    protected void LoadPropertyConvert<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      F>(PropertyInfo<P> propertyInfo, F newValue)
     {
       try
       {
@@ -1276,7 +1425,11 @@ namespace Csla
       }
     }
 
-    void IManageProperties.LoadProperty<P>(PropertyInfo<P> propertyInfo, P newValue)
+    void IManageProperties.LoadProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, P newValue)
     {
       LoadProperty<P>(propertyInfo, newValue);
     }
@@ -1304,7 +1457,11 @@ namespace Csla
     /// Loading values does not cause validation rules to be
     /// invoked.
     /// </remarks>
-    protected void LoadProperty<P>(PropertyInfo<P> propertyInfo, P newValue)
+    protected void LoadProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, P newValue)
     {
       try
       {
@@ -1420,7 +1577,11 @@ namespace Csla
     /// <typeparam name="R"></typeparam>
     /// <param name="property"></param>
     /// <param name="factory"></param>
-    protected void LoadPropertyAsync<R>(PropertyInfo<R> property, Task<R> factory)
+    protected void LoadPropertyAsync<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      R>(PropertyInfo<R> property, Task<R> factory)
     {
       LoadManager.BeginLoad(new TaskLoader<R>(property, factory));
     }
@@ -1654,12 +1815,20 @@ namespace Csla
       return GetProperty(propertyInfo);
     }
 
-    object IManageProperties.LazyGetProperty<P>(PropertyInfo<P> propertyInfo, Func<P> valueGenerator)
+    object IManageProperties.LazyGetProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, Func<P> valueGenerator)
     {
       return LazyGetProperty(propertyInfo, valueGenerator);
     }
 
-    object IManageProperties.LazyGetPropertyAsync<P>(PropertyInfo<P> propertyInfo, Task<P> factory)
+    object IManageProperties.LazyGetPropertyAsync<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo, Task<P> factory)
     {
       return LazyGetPropertyAsync(propertyInfo, factory);
     }
@@ -1669,7 +1838,11 @@ namespace Csla
       return ReadProperty(propertyInfo);
     }
 
-    P IManageProperties.ReadProperty<P>(PropertyInfo<P> propertyInfo)
+    P IManageProperties.ReadProperty<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      P>(PropertyInfo<P> propertyInfo)
     {
       return ReadProperty<P>(propertyInfo);
     }

--- a/Source/Csla/ReadOnlyBindingListBase.cs
+++ b/Source/Csla/ReadOnlyBindingListBase.cs
@@ -6,6 +6,7 @@
 // <summary>This is the base class from which readonly collections</summary>
 //-----------------------------------------------------------------------
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Csla.Core;
 using Csla.Properties;
 
@@ -17,10 +18,14 @@ namespace Csla
   /// </summary>
   /// <typeparam name="T">Type of the list class.</typeparam>
   /// <typeparam name="C">Type of child objects contained in the list.</typeparam>
-  [System.Diagnostics.CodeAnalysis.SuppressMessage(
+  [SuppressMessage(
     "Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix")]
   [Serializable]
-  public abstract class ReadOnlyBindingListBase<T, C> :
+  public abstract class ReadOnlyBindingListBase<T,
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+    C> :
     Core.ReadOnlyBindingList<C>, Csla.Core.IReadOnlyCollection,
     ICloneable, Server.IDataPortalTarget, Core.IUseApplicationContext
     where T : ReadOnlyBindingListBase<T, C>

--- a/Source/Csla/Reflection/LateBoundObject.cs
+++ b/Source/Csla/Reflection/LateBoundObject.cs
@@ -6,6 +6,7 @@
 // <summary>Enables simple invocation of methods</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using Csla.Properties;
 
 namespace Csla.Reflection
@@ -37,7 +38,11 @@ namespace Csla.Reflection
     /// The specified type must implement a
     /// default constructor.
     /// </remarks>
-    public LateBoundObject(Type objectType)
+    public LateBoundObject(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType)
     {
       Instance = _applicationContext.CreateInstanceDI(objectType);
     }

--- a/Source/Csla/Reflection/MethodCaller.cs
+++ b/Source/Csla/Reflection/MethodCaller.cs
@@ -10,6 +10,8 @@ using System.ComponentModel;
 using System.Reflection;
 using System.Globalization;
 using Csla.Properties;
+using System.Diagnostics.CodeAnalysis;
+
 #if NET8_0_OR_GREATER
 using System.Runtime.Loader;
 using Csla.Runtime;
@@ -743,7 +745,11 @@ namespace Csla.Reflection
     /// <param name="method">
     /// Name of the method.
     /// </param>
-    public static System.Reflection.MethodInfo GetMethod(Type objectType, string method)
+    public static System.Reflection.MethodInfo GetMethod(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
+#endif
+      Type objectType, string method)
     {
       return GetMethod(objectType, method, true, false, null);
     }
@@ -761,12 +767,20 @@ namespace Csla.Reflection
     /// <param name="parameters">
     /// Parameters to pass to method.
     /// </param>
-    public static System.Reflection.MethodInfo GetMethod(Type objectType, string method, params object[] parameters)
+    public static System.Reflection.MethodInfo GetMethod(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
+#endif
+      Type objectType, string method, params object[] parameters)
     {
       return GetMethod(objectType, method, true, parameters);
     }
 
-    private static System.Reflection.MethodInfo GetMethod(Type objectType, string method, bool hasParameters, params object[] parameters)
+    private static System.Reflection.MethodInfo GetMethod(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
+#endif
+      Type objectType, string method, bool hasParameters, params object[] parameters)
     {
       System.Reflection.MethodInfo result;
 
@@ -915,7 +929,13 @@ namespace Csla.Reflection
     /// <param name="parameterCount">
     /// Number of parameters to pass to method.
     /// </param>
-    public static System.Reflection.MethodInfo FindMethod(Type objectType, string method, int parameterCount)
+    public static System.Reflection.MethodInfo FindMethod(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
+      [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
+            Justification = "We only walk BaseType chain in this method, so assumption will holds")]
+#endif
+      Type objectType, string method, int parameterCount)
     {
       // walk up the inheritance hierarchy looking
       // for a method with the right number of
@@ -1011,7 +1031,11 @@ namespace Csla.Reflection
     /// </summary>
     /// <param name="t">Type of object containing the property.</param>
     /// <param name="propertyName">Name of the property.</param>
-    public static PropertyDescriptor GetPropertyDescriptor(Type t, string propertyName)
+    public static PropertyDescriptor GetPropertyDescriptor(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      Type t, string propertyName)
     {
       var propertyDescriptors = TypeDescriptor.GetProperties(t);
       PropertyDescriptor result = null;

--- a/Source/Csla/Reflection/ServiceProviderMethodCaller.cs
+++ b/Source/Csla/Reflection/ServiceProviderMethodCaller.cs
@@ -15,6 +15,7 @@ using Csla.Runtime;
 #endif
 using Csla.Properties;
 using Csla.Server;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Csla.Reflection
 {
@@ -61,7 +62,11 @@ namespace Csla.Reflection
     /// <param name="targetType">Type of domain object</param>
     /// <param name="criteria">Data portal criteria values</param>
     /// <param name="throwOnError">Throw exceptions on error</param>
-    public ServiceProviderMethodInfo FindDataPortalMethod<T>(Type targetType, object[] criteria, bool throwOnError = true)
+    public ServiceProviderMethodInfo FindDataPortalMethod<T>(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type targetType, object[] criteria, bool throwOnError = true)
       where T : DataPortalOperationAttribute
     {
       if (targetType == null)

--- a/Source/Csla/Rules/BusinessRules.cs
+++ b/Source/Csla/Rules/BusinessRules.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using Csla.Core;
 using Csla.Serialization.Mobile;
 using Csla.Server;
@@ -320,7 +321,13 @@ namespace Csla.Rules
     /// <param name="applicationContext"></param>
     /// <param name="action">Authorization action.</param>
     /// <param name="objectType">Type of business object.</param>
-    public static bool HasPermission(ApplicationContext applicationContext, AuthorizationActions action, Type objectType)
+    public static bool HasPermission(
+      ApplicationContext applicationContext, 
+      AuthorizationActions action,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType)
     {
       if (applicationContext == null)
         throw new ArgumentNullException(nameof(applicationContext));
@@ -337,7 +344,13 @@ namespace Csla.Rules
     /// <param name="action">Authorization action.</param>
     /// <param name="objectType">Type of business object.</param>
     /// <param name="criteria">The criteria object provided.</param>
-    public static bool HasPermission(ApplicationContext applicationContext, AuthorizationActions action, Type objectType, object[] criteria)
+    public static bool HasPermission(ApplicationContext applicationContext,
+      AuthorizationActions action,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType,
+      object[] criteria)
     {
       if (applicationContext == null)
         throw new ArgumentNullException(nameof(applicationContext));
@@ -357,7 +370,14 @@ namespace Csla.Rules
     /// <returns>
     /// 	<c>true</c> if the specified action has permission; otherwise, <c>false</c>.
     /// </returns>
-    public static bool HasPermission(ApplicationContext applicationContext, AuthorizationActions action, Type objectType, string ruleSet)
+    public static bool HasPermission(
+      ApplicationContext applicationContext, 
+      AuthorizationActions action,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType,
+      string ruleSet)
     {
       if (applicationContext == null)
         throw new ArgumentNullException(nameof(applicationContext));
@@ -446,7 +466,14 @@ namespace Csla.Rules
     /// <param name="objectType">The type of the business object.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>A task representing the asynchronous operation that returns a boolean indicating whether the permission is granted.</returns>
-    public static Task<bool> HasPermissionAsync(ApplicationContext applicationContext, AuthorizationActions action, Type objectType, CancellationToken ct)
+    public static Task<bool> HasPermissionAsync(
+      ApplicationContext applicationContext, 
+      AuthorizationActions action,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, 
+      CancellationToken ct)
     {
       if (applicationContext == null)
         throw new ArgumentNullException(nameof(applicationContext));
@@ -467,7 +494,15 @@ namespace Csla.Rules
     /// <param name="criteria">The criteria object provided.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>A task representing the asynchronous operation. The task result contains a boolean value indicating whether the permission is granted.</returns>
-    public static Task<bool> HasPermissionAsync(ApplicationContext applicationContext, AuthorizationActions action, Type objectType, object[] criteria, CancellationToken ct)
+    public static Task<bool> HasPermissionAsync(
+      ApplicationContext applicationContext, 
+      AuthorizationActions action,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, 
+      object[] criteria, 
+      CancellationToken ct)
     {
       if (applicationContext == null)
         throw new ArgumentNullException(nameof(applicationContext));
@@ -490,7 +525,15 @@ namespace Csla.Rules
     /// <returns>
     /// 	<c>true</c> if the specified action has permission; otherwise, <c>false</c>.
     /// </returns>
-    public static Task<bool> HasPermissionAsync(ApplicationContext applicationContext, AuthorizationActions action, Type objectType, string ruleSet, CancellationToken ct)
+    public static Task<bool> HasPermissionAsync(
+      ApplicationContext applicationContext,
+      AuthorizationActions action,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType,
+      string ruleSet,
+      CancellationToken ct)
     {
       if (applicationContext == null)
         throw new ArgumentNullException(nameof(applicationContext));

--- a/Source/Csla/Rules/IRuleContext.cs
+++ b/Source/Csla/Rules/IRuleContext.cs
@@ -5,6 +5,7 @@
 // </copyright>
 // <summary>Context information provided to a business rule</summary>
 //-----------------------------------------------------------------------
+using System.Diagnostics.CodeAnalysis;
 using Csla.Core;
 
 namespace Csla.Rules
@@ -199,7 +200,11 @@ namespace Csla.Rules
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <param name="propertyInfo">The property info.</param>
-    T GetInputValue<T>(PropertyInfo<T> propertyInfo);
+    T GetInputValue<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(PropertyInfo<T> propertyInfo);
     /// <summary>
     /// Gets the value with explicit cast
     /// </summary>
@@ -213,7 +218,11 @@ namespace Csla.Rules
     /// <param name="propertyInfo">The generic property info.</param>
     /// <param name="value">The value.</param>
     /// <returns>true if value exists else false</returns>
-    bool TryGetInputValue<T>(PropertyInfo<T> propertyInfo, ref T value);
+    bool TryGetInputValue<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(PropertyInfo<T> propertyInfo, ref T value);
     /// <summary>
     /// Tries to get the value with explicit cast. Use this method on LazyLoaded properties to test if value has been provided or not.
     /// </summary>

--- a/Source/Csla/Rules/RuleContext.cs
+++ b/Source/Csla/Rules/RuleContext.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Csla.Core;
 using Csla.Properties;
 
@@ -442,7 +443,11 @@ namespace Csla.Rules
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <param name="propertyInfo">The property info.</param>
-    public  T GetInputValue<T>(PropertyInfo<T> propertyInfo)
+    public  T GetInputValue<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(PropertyInfo<T> propertyInfo)
     {
       return (T)InputPropertyValues[propertyInfo];
     }
@@ -464,7 +469,11 @@ namespace Csla.Rules
     /// <param name="propertyInfo">The generic property info.</param>
     /// <param name="value">The value.</param>
     /// <returns>true if value exists else false</returns>
-    public bool TryGetInputValue<T>(PropertyInfo<T> propertyInfo, ref T value)
+    public bool TryGetInputValue<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(PropertyInfo<T> propertyInfo, ref T value)
     {
       if (!InputPropertyValues.TryGetValue(propertyInfo, out var propertyValue))
       {

--- a/Source/Csla/Security/UsernameCriteria.cs
+++ b/Source/Csla/Security/UsernameCriteria.cs
@@ -6,6 +6,8 @@
 // <summary>Criteria class for passing a</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Csla.Security
 {
   /// <summary>

--- a/Source/Csla/Serialization/Mobile/SerializationInfo.cs
+++ b/Source/Csla/Serialization/Mobile/SerializationInfo.cs
@@ -6,6 +6,7 @@
 // <summary>Object containing the serialization</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 
 namespace Csla.Serialization.Mobile
@@ -285,7 +286,11 @@ namespace Csla.Serialization.Mobile
     /// <param name="name">
     /// Name of the field.
     /// </param>
-    public T GetValue<T>(string name)
+    public T GetValue<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      T>(string name)
     {
       try
       {

--- a/Source/Csla/Server/ChildDataPortal.cs
+++ b/Source/Csla/Server/ChildDataPortal.cs
@@ -6,6 +6,8 @@
 // <summary>Invoke data portal methods on child</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Csla.Server
 {
   /// <summary>
@@ -32,7 +34,11 @@ namespace Csla.Server
     /// Create a new business object.
     /// </summary>
     /// <param name="objectType">Type of business object to create.</param>
-    public object Create(Type objectType)
+    public object Create(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType)
     {
       try
       { 
@@ -51,7 +57,11 @@ namespace Csla.Server
     /// <param name="parameters">
     /// Criteria parameters passed from caller.
     /// </param>
-    public object Create(Type objectType, params object[] parameters)
+    public object Create(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, params object[] parameters)
     {
       try
       { 
@@ -66,7 +76,11 @@ namespace Csla.Server
     /// <summary>
     /// Create a new business object.
     /// </summary>
-    public async Task<T> CreateAsync<T>()
+    public async Task<T> CreateAsync<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      T>()
     {
       return (T) await DoCreateAsync(typeof(T)).ConfigureAwait(false);
     }
@@ -77,12 +91,20 @@ namespace Csla.Server
     /// <param name="parameters">
     /// Criteria parameters passed from caller.
     /// </param>
-    public async Task<T> CreateAsync<T>(params object[] parameters)
+    public async Task<T> CreateAsync<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      T>(params object[] parameters)
     {
       return (T)await DoCreateAsync(typeof(T), parameters).ConfigureAwait(false);
     }
 
-    private async Task<object> DoCreateAsync(Type objectType, params object[] parameters)
+    private async Task<object> DoCreateAsync(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, params object[] parameters)
     {
       DataPortalTarget obj = null;
       var eventArgs = new DataPortalEventArgs(null, objectType, parameters, DataPortalOperations.Create);
@@ -126,7 +148,11 @@ namespace Csla.Server
     /// Get an existing business object.
     /// </summary>
     /// <param name="objectType">Type of business object to retrieve.</param>
-    public object Fetch(Type objectType)
+    public object Fetch(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType)
     {
       try
       {
@@ -145,7 +171,11 @@ namespace Csla.Server
     /// <param name="parameters">
     /// Criteria parameters passed from caller.
     /// </param>
-    public object Fetch(Type objectType, params object[] parameters)
+    public object Fetch(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, params object[] parameters)
     {
       try
       {
@@ -160,7 +190,11 @@ namespace Csla.Server
     /// <summary>
     /// Get an existing business object.
     /// </summary>
-    public async Task<T> FetchAsync<T>()
+    public async Task<T> FetchAsync<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      T>()
     {
       return (T)await DoFetchAsync(typeof(T)).ConfigureAwait(false);
     }
@@ -171,12 +205,20 @@ namespace Csla.Server
     /// <param name="parameters">
     /// Criteria parameters passed from caller.
     /// </param>
-    public async Task<T> FetchAsync<T>(params object[] parameters)
+    public async Task<T> FetchAsync<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      T>(params object[] parameters)
     {
       return (T)await DoFetchAsync(typeof(T), parameters).ConfigureAwait(false);
     }
 
-    private async Task<object> DoFetchAsync(Type objectType, params object[] parameters)
+    private async Task<object> DoFetchAsync(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, params object[] parameters)
     {
       DataPortalTarget obj = null;
       var eventArgs = new DataPortalEventArgs(null, objectType, parameters, DataPortalOperations.Fetch);

--- a/Source/Csla/Server/DataPortal.cs
+++ b/Source/Csla/Server/DataPortal.cs
@@ -6,6 +6,7 @@
 // <summary>Implements the server-side DataPortal </summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Principal;
 using Csla.Configuration;
 using Csla.Properties;
@@ -117,6 +118,9 @@ namespace Csla.Server
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
     public async Task<DataPortalResult> Create(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
       Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       try
@@ -217,7 +221,11 @@ namespace Csla.Server
     /// <see cref="Server.DataPortalContext" /> object passed to the server.
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public async Task<DataPortalResult> Fetch(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    public async Task<DataPortalResult> Fetch(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       if (typeof(Core.ICommandObject).IsAssignableFrom(objectType))
       {
@@ -322,7 +330,11 @@ namespace Csla.Server
     /// <see cref="Server.DataPortalContext" /> object passed to the server.
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    private async Task<DataPortalResult> Execute(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    private async Task<DataPortalResult> Execute(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       try
       {
@@ -561,7 +573,11 @@ namespace Csla.Server
     /// <see cref="Server.DataPortalContext" /> object passed to the server.
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public async Task<DataPortalResult> Delete(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    public async Task<DataPortalResult> Delete(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       try
       {

--- a/Source/Csla/Server/DataPortalBroker.cs
+++ b/Source/Csla/Server/DataPortalBroker.cs
@@ -6,6 +6,8 @@
 // <summary>Allows interception of DataPortal call</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Csla.Server
 {
   /// <summary>
@@ -39,7 +41,11 @@ namespace Csla.Server
     /// <see cref="Server.DataPortalContext" /> object passed to the server.
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public Task<DataPortalResult> Create(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    public Task<DataPortalResult> Create(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       if (DataPortalServer != null)
       {
@@ -60,7 +66,11 @@ namespace Csla.Server
     /// <see cref="Server.DataPortalContext" /> object passed to the server.
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public Task<DataPortalResult> Fetch(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    public Task<DataPortalResult> Fetch(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       if (DataPortalServer != null)
       {
@@ -101,7 +111,11 @@ namespace Csla.Server
     /// <see cref="Server.DataPortalContext" /> object passed to the server.
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public Task<DataPortalResult> Delete(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    public Task<DataPortalResult> Delete(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       if (DataPortalServer != null)
       {

--- a/Source/Csla/Server/DataPortalMethodCache.cs
+++ b/Source/Csla/Server/DataPortalMethodCache.cs
@@ -11,6 +11,7 @@ using System.Runtime.Loader;
 using Csla.Runtime;
 #endif
 using Csla.Reflection;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Csla.Server
 {
@@ -22,7 +23,11 @@ namespace Csla.Server
     private static Dictionary<MethodCacheKey, DataPortalMethodInfo> _cache = [];
 #endif
 
-    public static DataPortalMethodInfo GetMethodInfo(Type objectType, string methodName, params object[] parameters)
+    public static DataPortalMethodInfo GetMethodInfo(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
+#endif
+      Type objectType, string methodName, params object[] parameters)
     {
       var key = new MethodCacheKey(objectType.FullName, methodName, MethodCaller.GetParameterTypes(parameters));
 

--- a/Source/Csla/Server/DataPortalSelector.cs
+++ b/Source/Csla/Server/DataPortalSelector.cs
@@ -6,6 +6,7 @@
 // <summary>Selects the appropriate data portal implementation</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using Csla.Properties;
 
 namespace Csla.Server
@@ -45,7 +46,11 @@ namespace Csla.Server
     /// <see cref="Server.DataPortalContext" /> object passed to the server.
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public async Task<DataPortalResult> Create(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    public async Task<DataPortalResult> Create(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       try
       {
@@ -80,7 +85,11 @@ namespace Csla.Server
     /// <see cref="Server.DataPortalContext" /> object passed to the server.
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public async Task<DataPortalResult> Fetch(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    public async Task<DataPortalResult> Fetch(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       try
       {
@@ -154,7 +163,11 @@ namespace Csla.Server
     /// <see cref="Server.DataPortalContext" /> object passed to the server.
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public async Task<DataPortalResult> Delete(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    public async Task<DataPortalResult> Delete(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       try
       {

--- a/Source/Csla/Server/DefaultDataPortalActivator.cs
+++ b/Source/Csla/Server/DefaultDataPortalActivator.cs
@@ -6,6 +6,7 @@
 // <summary>Defines a type used to activate concrete business instances.</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using Csla.Core;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -31,7 +32,11 @@ namespace Csla.Server
     /// <param name="requestedType">Requested type (class or interface).</param>
     /// <param name="parameters">Param array for the constructor</param>
     /// <returns>Instance of requested type</returns>
-    public virtual object CreateInstance(Type requestedType, params object[] parameters)
+    public virtual object CreateInstance(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type requestedType, params object[] parameters)
     {
       object result;
       var realType = ResolveType(requestedType);
@@ -71,7 +76,14 @@ namespace Csla.Server
     /// requested type (which might be an interface).
     /// </summary>
     /// <param name="requestedType">Type requested from the data portal.</param>
-    public virtual Type ResolveType(Type requestedType)
+#if NET8_0_OR_GREATER
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+    public virtual Type ResolveType(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type requestedType)
     {
       // return requested type by default
       return requestedType;

--- a/Source/Csla/Server/FactoryDataPortal.cs
+++ b/Source/Csla/Server/FactoryDataPortal.cs
@@ -6,6 +6,7 @@
 // <summary>Server-side data portal implementation that</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using Csla.Configuration;
 using Csla.Properties;
 
@@ -110,7 +111,11 @@ namespace Csla.Server
     /// <see cref="Server.DataPortalContext" /> object passed to the server.
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public async Task<DataPortalResult> Create(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    public async Task<DataPortalResult> Create(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       try
       {
@@ -139,7 +144,11 @@ namespace Csla.Server
     /// <see cref="Server.DataPortalContext" /> object passed to the server.
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public async Task<DataPortalResult> Fetch(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    public async Task<DataPortalResult> Fetch(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       if (typeof(Core.ICommandObject).IsAssignableFrom(objectType))
       {
@@ -225,7 +234,11 @@ namespace Csla.Server
     /// <see cref="Server.DataPortalContext" /> object passed to the server.
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public async Task<DataPortalResult> Delete(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    public async Task<DataPortalResult> Delete(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       try
       {

--- a/Source/Csla/Server/Hosts/DataPortalChannel/DataPortalErrorInfo.cs
+++ b/Source/Csla/Server/Hosts/DataPortalChannel/DataPortalErrorInfo.cs
@@ -6,6 +6,8 @@
 // <summary>Message containing details about any</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Csla.Server.Hosts.DataPortalChannel
 {
   /// <summary>

--- a/Source/Csla/Server/IDataPortalActivator.cs
+++ b/Source/Csla/Server/IDataPortalActivator.cs
@@ -6,6 +6,8 @@
 // <summary>Defines a type used to activate concrete business instances.</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Csla.Server
 {
   /// <summary>
@@ -20,7 +22,11 @@ namespace Csla.Server
     /// <param name="requestedType">Requested business type (class or interface).</param>
     /// <param name="parameters">Param array for the constructor</param>
     /// <returns>Business object instance.</returns>
-    object CreateInstance(Type requestedType, params object[] parameters);
+    object CreateInstance(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type requestedType, params object[] parameters);
     /// <summary>
     /// Initializes an existing business object instance.
     /// </summary>
@@ -37,6 +43,13 @@ namespace Csla.Server
     /// requested type (which might be an interface).
     /// </summary>
     /// <param name="requestedType">Type requested from the data portal.</param>
-    Type ResolveType(Type requestedType);
+#if NET8_0_OR_GREATER
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+    Type ResolveType(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+     Type requestedType);
   }
 }

--- a/Source/Csla/Server/IDataPortalServer.cs
+++ b/Source/Csla/Server/IDataPortalServer.cs
@@ -6,6 +6,8 @@
 // <summary>Interface implemented by server-side data portal</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Csla.Server
 {
   /// <summary>
@@ -23,7 +25,11 @@ namespace Csla.Server
     /// <see cref="Server.DataPortalContext" /> object passed to the server.
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    Task<DataPortalResult> Create(Type objectType, object criteria, DataPortalContext context, bool isSync);
+    Task<DataPortalResult> Create(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync);
     /// <summary>
     /// Get an existing business object.
     /// </summary>
@@ -33,7 +39,11 @@ namespace Csla.Server
     /// <see cref="Server.DataPortalContext" /> object passed to the server.
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    Task<DataPortalResult> Fetch(Type objectType, object criteria, DataPortalContext context, bool isSync);
+    Task<DataPortalResult> Fetch(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync);
     /// <summary>
     /// Update a business object.
     /// </summary>
@@ -52,6 +62,10 @@ namespace Csla.Server
     /// <see cref="Server.DataPortalContext" /> object passed to the server.
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    Task<DataPortalResult> Delete(Type objectType, object criteria, DataPortalContext context, bool isSync);
+    Task<DataPortalResult> Delete(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync);
   }
 }

--- a/Source/Csla/Server/ObjectFactory.cs
+++ b/Source/Csla/Server/ObjectFactory.cs
@@ -6,6 +6,7 @@
 // <summary>Base class to be used when creating a data portal</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using Csla.Core;
 using Csla.Properties;
 using Csla.Reflection;
@@ -171,7 +172,11 @@ namespace Csla.Server
         /// Loading values does not cause validation rules to be
         /// invoked.
         /// </remarks>
-        protected void LoadProperty<P>(object obj, PropertyInfo<P> propertyInfo, P newValue)
+        protected void LoadProperty<
+#if NET8_0_OR_GREATER
+          [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+          P>(object obj, PropertyInfo<P> propertyInfo, P newValue)
         {
             if (obj is IManageProperties target)
                 target.LoadProperty<P>(propertyInfo, newValue);
@@ -211,7 +216,11 @@ namespace Csla.Server
         /// <remarks>
         /// No authorization checks occur when this method is called.
         /// </remarks>
-        protected P ReadProperty<P>(object obj, PropertyInfo<P> propertyInfo)
+        protected P ReadProperty<
+#if NET8_0_OR_GREATER
+          [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+          P>(object obj, PropertyInfo<P> propertyInfo)
         {
             if (obj is IManageProperties target)
                 return target.ReadProperty(propertyInfo);
@@ -275,7 +284,11 @@ namespace Csla.Server
         /// </summary>
         /// <typeparam name="C">Type of child objects in the colletion.</typeparam>
         /// <param name="obj">Editable collection object.</param>
-        protected Csla.Core.MobileList<C> GetDeletedList<C>(object obj)
+        protected Csla.Core.MobileList<C> GetDeletedList<
+#if NET8_0_OR_GREATER
+          [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+          C>(object obj)
         {
             if (obj is IEditableCollection target)
                 return (Csla.Core.MobileList<C>)target.GetDeletedList();

--- a/Source/Csla/Server/SimpleDataPortal.cs
+++ b/Source/Csla/Server/SimpleDataPortal.cs
@@ -6,6 +6,7 @@
 // <summary>Implements the server-side DataPortal as discussed</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using Csla.Properties;
 
 namespace Csla.Server
@@ -48,6 +49,9 @@ namespace Csla.Server
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Globalization", "CA1303:DoNotPassLiteralsAsLocalizedParameters", MessageId = "Csla.Server.DataPortalException.#ctor(System.String,System.Exception,Csla.Server.DataPortalResult)")]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
     public async Task<DataPortalResult> Create(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
       Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       DataPortalTarget obj = null;
@@ -100,7 +104,11 @@ namespace Csla.Server
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Globalization", "CA1303:DoNotPassLiteralsAsLocalizedParameters", MessageId = "Csla.Server.DataPortalException.#ctor(System.String,System.Exception,Csla.Server.DataPortalResult)")]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
-    public async Task<DataPortalResult> Fetch(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    public async Task<DataPortalResult> Fetch(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       if (typeof(Core.ICommandObject).IsAssignableFrom(objectType))
       {
@@ -147,7 +155,11 @@ namespace Csla.Server
       }
     }
 
-    private async Task<DataPortalResult> Execute(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    private async Task<DataPortalResult> Execute(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       DataPortalTarget obj = null;
       var eventArgs = new DataPortalEventArgs(context, objectType, criteria, DataPortalOperations.Execute);
@@ -292,7 +304,11 @@ namespace Csla.Server
     /// </param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Globalization", "CA1303:DoNotPassLiteralsAsLocalizedParameters", MessageId = "Csla.Server.DataPortalException.#ctor(System.String,System.Exception,Csla.Server.DataPortalResult)")]
-    public async Task<DataPortalResult> Delete(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    public async Task<DataPortalResult> Delete(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       DataPortalTarget obj = null;
       var eventArgs = new DataPortalEventArgs(context, objectType, criteria, DataPortalOperations.Delete);

--- a/Source/Csla/Server/TransactionalDataPortal.cs
+++ b/Source/Csla/Server/TransactionalDataPortal.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 #if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Versioning;
 #endif
 using System.Transactions;
@@ -58,6 +59,9 @@ namespace Csla.Server
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
     /// <returns>A populated business object.</returns>
     public async Task<DataPortalResult> Create(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
       Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       using TransactionScope tr = CreateTransactionScope();
@@ -116,7 +120,11 @@ namespace Csla.Server
     /// <param name="context">Object containing context data from client.</param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
     /// <returns>A populated business object.</returns>
-    public async Task<DataPortalResult> Fetch(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    public async Task<DataPortalResult> Fetch(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       using TransactionScope tr = CreateTransactionScope();
       var result = await _portal.Fetch(objectType, criteria, context, isSync).ConfigureAwait(false);
@@ -162,7 +170,11 @@ namespace Csla.Server
     /// <param name="criteria">Object-specific criteria.</param>
     /// <param name="context">Context data from the client.</param>
     /// <param name="isSync">True if the client-side proxy should synchronously invoke the server.</param>
-    public async Task<DataPortalResult> Delete(Type objectType, object criteria, DataPortalContext context, bool isSync)
+    public async Task<DataPortalResult> Delete(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+      Type objectType, object criteria, DataPortalContext context, bool isSync)
     {
       using TransactionScope tr = CreateTransactionScope();
       var result = await _portal.Delete(objectType, criteria, context, isSync).ConfigureAwait(false);

--- a/Source/Csla/SortedBindingList.cs
+++ b/Source/Csla/SortedBindingList.cs
@@ -6,6 +6,7 @@
 // <summary>Provides a sorted view into an existing IList(Of T).</summary>
 //-----------------------------------------------------------------------
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Collections;
 using Csla.Properties;
 
@@ -19,7 +20,11 @@ namespace Csla
   /// Type of child object contained by
   /// the original list or collection.
   /// </typeparam>
-  public class SortedBindingList<T> :
+  public class SortedBindingList<
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+    T> :
     IList<T>,
     IBindingList,
     ICancelAddNew

--- a/Source/Csla/Utilities.cs
+++ b/Source/Csla/Utilities.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using Csla.Reflection;
 using System.ComponentModel;
 using Csla.Properties;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Csla
 {
@@ -150,7 +151,15 @@ namespace Csla
     /// result is parsed to convert into the enum value.
     /// </para>
     /// </remarks>
-    public static object CoerceValue(Type desiredType, Type valueType, object oldValue, object value)
+    public static object CoerceValue(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      Type desiredType,
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      Type valueType, object oldValue, object value)
     {
       if (desiredType.IsAssignableFrom(valueType))
       {
@@ -256,7 +265,15 @@ namespace Csla
     /// result is parsed to convert into the enum value.
     /// </para>
     /// </remarks>
-    public static D CoerceValue<D>(Type valueType, object oldValue, object value)
+    public static D CoerceValue<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      D>(
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+#endif
+      Type valueType, object oldValue, object value)
     {
       return (D)(CoerceValue(typeof(D), valueType, oldValue, value));
     }


### PR DESCRIPTION
Other things which cannot be automatically analyzed by the tools, would be dealt later on. This is gives baseline on thinking about code, and can be used for future improvements. Annotation using `DynamicallyAccessedMembers` that's what should be done immdiately after capturing existing warnings.

Given cascading nature of the changes, it's better keep track of class of warnings, and don't allow re-introduce them after you cleanup codebase.

Related to #3347
