### PR TITLE
Enable resetting application context user to null

### DIFF
--- a/Source/Csla.AspNetCore/ApplicationContextManagerHttpContext.cs
+++ b/Source/Csla.AspNetCore/ApplicationContextManagerHttpContext.cs
@@ -118,11 +118,9 @@ namespace Csla.AspNetCore
     /// Sets the current principal.
     /// </summary>
     /// <param name="principal">Principal object.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="principal"/> is <see langword="null"/>.</exception>
     /// <exception cref="InvalidOperationException">The underlying <see cref="HttpContext"/> is <see langword="null"/>.</exception>
     public void SetUser(System.Security.Principal.IPrincipal principal)
     {
-      ArgumentNullException.ThrowIfNull(principal);
       ThrowIfHttpContextIsNull();
       HttpContext.User = (ClaimsPrincipal)principal;
     }

--- a/Source/Csla.AspNetCore/ApplicationContextManagerHttpContext.cs
+++ b/Source/Csla.AspNetCore/ApplicationContextManagerHttpContext.cs
@@ -118,9 +118,11 @@ namespace Csla.AspNetCore
     /// Sets the current principal.
     /// </summary>
     /// <param name="principal">Principal object.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="principal"/> is <see langword="null"/>.</exception>
     /// <exception cref="InvalidOperationException">The underlying <see cref="HttpContext"/> is <see langword="null"/>.</exception>
     public void SetUser(System.Security.Principal.IPrincipal principal)
     {
+      ArgumentNullException.ThrowIfNull(principal);
       ThrowIfHttpContextIsNull();
       HttpContext.User = (ClaimsPrincipal)principal;
     }

--- a/Source/Csla.TestHelpers/ApplicationContextManagerUnitTests.cs
+++ b/Source/Csla.TestHelpers/ApplicationContextManagerUnitTests.cs
@@ -1,9 +1,19 @@
-﻿namespace Csla.TestHelpers
+﻿using System.Security.Principal;
+
+namespace Csla.TestHelpers
 {
   public class ApplicationContextManagerUnitTests : Core.ApplicationContextManagerAsyncLocal
   {
+    public IPrincipal LastSetUserPrincipal { get; private set; }
+
     public Guid InstanceId { get; private set; } = Guid.NewGuid();
 
     public DateTime CreatedAt { get; private set; } = DateTime.Now;
+
+    public override void SetUser(IPrincipal principal)
+    {
+      LastSetUserPrincipal = principal;
+      base.SetUser(principal);
+    }
   }
 }

--- a/Source/Csla.TestHelpers/TestDIContextFactory.cs
+++ b/Source/Csla.TestHelpers/TestDIContextFactory.cs
@@ -74,10 +74,9 @@ namespace Csla.TestHelpers
       var services = new ServiceCollection();
 
       // Add Csla
-      //services.AddSingleton<Core.IContextManager, ApplicationContextManagerUnitTests>();
       services.TryAddSingleton<Server.Dashboard.IDashboard, Server.Dashboard.Dashboard>();
-      services.AddCsla(customCslaOptions);
       services.AddSingleton<Core.IContextManager, ApplicationContextManagerUnitTests>();
+      services.AddCsla(customCslaOptions);
 
       serviceProvider = services.BuildServiceProvider();
 

--- a/Source/Csla.test/DPException/DataPortalExceptionTests.cs
+++ b/Source/Csla.test/DPException/DataPortalExceptionTests.cs
@@ -71,7 +71,7 @@ namespace Csla.Test.DPException
 #if (NETFRAMEWORK)
       Assert.AreEqual(".Net SqlClient Data Provider", exceptionSource);
 #else
-      Assert.AreEqual("Core .Net SqlClient Data Provider", exceptionSource);
+      Assert.AreEqual("Core Microsoft SqlClient Data Provider", exceptionSource);
 #endif
 
       //verify that the implemented method, DataPortal_OnDataPortal 

--- a/Source/Csla.test/DataPortal/DataPortalTests.cs
+++ b/Source/Csla.test/DataPortal/DataPortalTests.cs
@@ -371,37 +371,6 @@ namespace Csla.Test.DataPortal
 
   }
 
-  public class UserLoggingContextManagerDecorator : IContextManager
-  {
-    private readonly IContextManager _decorated;
-    public IPrincipal LastSetPrincipal
-    {
-      get; private set;
-    }
-
-    public UserLoggingContextManagerDecorator(IContextManager contextManager)
-    {
-      _decorated = contextManager;
-    }
-
-    public bool IsStatefulContext => _decorated.IsStatefulContext;
-
-    public bool IsValid => _decorated.IsValid;
-
-    public ApplicationContext ApplicationContext { get => _decorated.ApplicationContext; set => _decorated.ApplicationContext = value; }
-
-    public IContextDictionary GetClientContext(ApplicationContext.ExecutionLocations executionLocation) => _decorated.GetClientContext(executionLocation);
-    public IContextDictionary GetLocalContext() => _decorated.GetLocalContext();
-    public IPrincipal GetUser() => _decorated.GetUser();
-    public void SetClientContext(IContextDictionary clientContext, ApplicationContext.ExecutionLocations executionLocation) => _decorated.SetClientContext(clientContext, executionLocation);
-    public void SetLocalContext(IContextDictionary localContext) => _decorated.SetLocalContext(localContext);
-    public void SetUser(IPrincipal principal)
-    {
-      LastSetPrincipal = principal;
-      _decorated.SetUser(principal);
-    }
-  }
-
   [Serializable]
   public class EncapsulatedBusy : BusinessBase<EncapsulatedBusy>
   {

--- a/Source/Csla/ApplicationContext.cs
+++ b/Source/Csla/ApplicationContext.cs
@@ -47,8 +47,8 @@ namespace Csla
     /// </summary>
     public ClaimsPrincipal Principal
     {
-      get { return (ClaimsPrincipal)ContextManager.GetUser(); }
-      set { ContextManager.SetUser(value); }
+      get { return (ClaimsPrincipal)User; }
+      set { User = value; }
     }
 
     /// <summary>
@@ -64,7 +64,7 @@ namespace Csla
     public IPrincipal User
     {
       get { return ContextManager.GetUser(); }
-      set { ContextManager.SetUser(value); }
+      set { ContextManager.SetUser(value ?? new ClaimsPrincipal(new ClaimsIdentity())); }
     }
 
     /// <summary>

--- a/Source/Csla/Server/DataPortal.cs
+++ b/Source/Csla/Server/DataPortal.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.Diagnostics.CodeAnalysis;
+using System.Security.Claims;
 using System.Security.Principal;
 using Csla.Configuration;
 using Csla.Properties;
@@ -774,7 +775,7 @@ namespace Csla.Server
       if (!context.IsRemotePortal) return;
       _applicationContext.Clear();
       if (SecurityOptions.FlowSecurityPrincipalFromClient)
-        _applicationContext.User = null;
+        _applicationContext.User = new ClaimsPrincipal(new ClaimsIdentity());
     }
 
     #endregion

--- a/Source/Csla/Server/DataPortal.cs
+++ b/Source/Csla/Server/DataPortal.cs
@@ -775,7 +775,7 @@ namespace Csla.Server
       if (!context.IsRemotePortal) return;
       _applicationContext.Clear();
       if (SecurityOptions.FlowSecurityPrincipalFromClient)
-        _applicationContext.User = null;
+        _applicationContext.User = new ClaimsPrincipal(new ClaimsIdentity());
     }
 
     #endregion

--- a/Source/Csla/Server/DataPortal.cs
+++ b/Source/Csla/Server/DataPortal.cs
@@ -775,7 +775,7 @@ namespace Csla.Server
       if (!context.IsRemotePortal) return;
       _applicationContext.Clear();
       if (SecurityOptions.FlowSecurityPrincipalFromClient)
-        _applicationContext.User = new ClaimsPrincipal(new ClaimsIdentity());
+        _applicationContext.User = null;
     }
 
     #endregion

--- a/docs/Upgrading to CSLA 9.md
+++ b/docs/Upgrading to CSLA 9.md
@@ -191,6 +191,8 @@ Supporting nullable types means that some APIs have changed to support nullable 
 * Type `Csla.Serialization.SerializationFormatterFactory` was removed. To get the serializer resolve an instance of type `ISerializationFormatter`. For example `ApplicationContext.GetRequiredService<ISerializationFormatter>()`(from within a business object)
 * `Csla.Core.IParent`
   * `ApplyEditChild` and `RemoveChild` changed from `void` to `Task` return type
+* `void Csla.Core.IContextManager.SetUser(IPrincipal principal)` does not accept `null` anymore
+  * This change only affects you when you use the `IContextManager` directly. If you use `ApplicationContext.User` CSLA will take care of translating it into a non-null IPrincipal.
 
 #### Using Timeout in `HttpProxy` and `HttpCompressionProxy`
 


### PR DESCRIPTION
Set application context user to an unauthenticated claims principal when `FlowSecurityPrincipalFromClient` is enabled.

Fixes #4410