### PR TITLE
#3785 update MAUI package version

### DIFF
--- a/Samples/MauiExample/BusinessLibrary/BusinessLibrary.csproj
+++ b/Samples/MauiExample/BusinessLibrary/BusinessLibrary.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Csla" Version="9.0.0-rc1-gb7b53fbc46" />
+    <PackageReference Include="Csla" Version="9.0.0-rc3-g44c5640a07" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/MauiExample/MauiExample/MauiExample.csproj
+++ b/Samples/MauiExample/MauiExample/MauiExample.csproj
@@ -98,7 +98,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Csla.Maui" Version="9.0.0-rc1-gb7b53fbc46" />
+    <PackageReference Include="Csla.Maui" Version="9.0.0-rc3-g44c5640a07" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.21" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
   </ItemGroup>


### PR DESCRIPTION
This PR simply updates the CSLA and CSLA.XAML package references in the sample project to the latest .Net 9 versions that work with MAUI.

Tested the sample app on Windows, iOS, MacOS and Android. All run the sample as expected.