### PR TITLE
avoid ToImmutableArray in AnalyzePropertyGetterWithExpressionBody

### DIFF
--- a/Source/Csla.Analyzers/Csla.Analyzers/EvaluatePropertiesForSimplicityAnalyzer.cs
+++ b/Source/Csla.Analyzers/Csla.Analyzers/EvaluatePropertiesForSimplicityAnalyzer.cs
@@ -86,7 +86,7 @@ namespace Csla.Analyzers
     private static void AnalyzePropertyGetterWithExpressionBody(PropertyDeclarationSyntax propertyNode, SyntaxNodeAnalysisContext context)
     {
       var getterExpression = propertyNode.ExpressionBody.Expression;
-      var getterChildren = getterExpression.DescendantNodes(_ => true).ToImmutableArray();
+      var getterChildren = getterExpression.DescendantNodes(_ => true).ToArray();
 
       if (getterChildren.Length > 1)
       {


### PR DESCRIPTION
internally ToImmutableArray  does a ToArray, in addition to redundant type checks for this context.

and the instance never gets out of the method context, so no need for immutability