### PR TITLE
Abstract out session store from SessionManager

### DIFF
--- a/Source/Csla.Blazor/ConfigurationExtensions.cs
+++ b/Source/Csla.Blazor/ConfigurationExtensions.cs
@@ -6,6 +6,7 @@
 // <summary>Implement extension methods for .NET Core configuration</summary>
 //-----------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using Csla.Blazor;
 using Csla.Blazor.State;
 using Csla.Core;
@@ -63,6 +64,7 @@ namespace Csla.Configuration
         // use Blazor state management
         config.Services.AddTransient(typeof(ISessionIdManager), blazorOptions.SessionIdManagerType);
         config.Services.AddSingleton(typeof(ISessionManager), blazorOptions.SessionManagerType);
+        config.Services.TryAddTransient(typeof(ISessionStore), blazorOptions.SessionStoreType);
         config.Services.AddTransient<StateManager>();
       }
 
@@ -105,5 +107,27 @@ namespace Csla.Configuration
     /// Gets or sets the type of the ISessionIdManager service.
     /// </summary>
     public Type SessionIdManagerType { get; set; } = Type.GetType("Csla.Blazor.State.SessionIdManager, Csla.AspNetCore", true);
+
+    /// <summary>
+    /// Gets or sets the type of the SessionStore.
+    /// </summary>
+#if NET8_0_OR_GREATER
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+    internal Type SessionStoreType { get; set; } = typeof(DefaultSessionStore);
+
+    /// <summary>
+    /// Sets the type of the SessionStore.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public BlazorServerConfigurationOptions RegisterSessionStore<
+#if NET8_0_OR_GREATER
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+    T>() where T: ISessionStore
+    {
+      SessionStoreType = typeof(T);
+      return this;
+    }
   }
 }

--- a/Source/Csla.Blazor/State/DefaultSessionStore.cs
+++ b/Source/Csla.Blazor/State/DefaultSessionStore.cs
@@ -1,0 +1,71 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="StateManager.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>Default implementation of session storage.</summary>
+//-----------------------------------------------------------------------
+#nullable enable
+
+using System.Collections.Concurrent;
+using Csla.State;
+
+namespace Csla.Blazor.State
+{
+  /// <summary>
+  /// Default implementation of <see cref="ISessionStore"/>
+  /// </summary>
+  public class DefaultSessionStore : ISessionStore
+  {
+    private readonly ConcurrentDictionary<string, Session> _store = new();
+
+    /// <inheritdoc />
+    public Session? GetSession(string key)
+    {
+      _store.TryGetValue(key, out var item);
+      return item;
+    }
+
+    /// <inheritdoc />
+    public void CreateSession(string key, Session session)
+    {
+      if (!_store.TryAdd(key, session))
+      {
+        throw new Exception("Key already exists");
+      }
+    }
+
+    /// <inheritdoc />
+    public void UpdateSession(string key, Session session)
+    {
+      ArgumentNullException.ThrowIfNull(session);
+      _store[key] = session;
+    }
+
+    /// <inheritdoc />
+    public void DeleteSession(string key)
+    {
+      _store.TryRemove(key, out _);
+    }
+
+    /// <inheritdoc />
+    public void DeleteSessions(SessionsFilter filter)
+    {
+      filter.Validate();
+
+      var query = _store.AsQueryable();
+      if (filter.Expiration.HasValue)
+      {
+        var expirationTime = DateTimeOffset.UtcNow.ToUnixTimeSeconds() - filter.Expiration.Value.TotalSeconds;
+        query = query.Where(x => x.Value.LastTouched < expirationTime);
+      }
+
+      var keys = query.Select(x => x.Key).ToArray();
+
+      foreach (var key in keys)
+      {
+        _store.TryRemove(key, out _);
+      }
+    }
+  }
+}

--- a/Source/Csla/State/ISessionStore.cs
+++ b/Source/Csla/State/ISessionStore.cs
@@ -1,0 +1,50 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ISessionStore.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>Manages session storage</summary>
+//-----------------------------------------------------------------------
+#nullable enable
+
+namespace Csla.State
+{
+  /// <summary>
+  /// Session store
+  /// </summary>
+  public interface ISessionStore
+  {
+    /// <summary>
+    /// Retrieves a session
+    /// </summary>
+    /// <param name="key"></param>
+    /// <returns>The session for the given key, or default if not found</returns>
+    Session? GetSession(string key);
+
+    /// <summary>
+    /// Creates a session
+    /// </summary>
+    /// <param name="key"></param>
+    /// <param name="session"></param>
+    void CreateSession(string key, Session session);
+
+    /// <summary>
+    /// Updates a session
+    /// </summary>
+    /// <param name="key"></param>
+    /// <param name="session"></param>
+    void UpdateSession(string key, Session session);
+
+    /// <summary>
+    /// Deletes a session
+    /// </summary>
+    /// <param name="key"></param>
+    void DeleteSession(string key);
+
+    /// <summary>
+    /// Deletes sessions based on the filter.
+    /// </summary>
+    /// <param name="filter"></param>
+    void DeleteSessions(SessionsFilter filter);
+  }
+}

--- a/Source/Csla/State/SessionsFilter.cs
+++ b/Source/Csla/State/SessionsFilter.cs
@@ -1,0 +1,33 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SessionsFilter.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>Filter for querying session storage</summary>
+//-----------------------------------------------------------------------
+#nullable enable
+
+namespace Csla.State
+{
+  /// <summary>
+  /// Filter to query sessions
+  /// </summary>
+  public class SessionsFilter
+  {
+    /// <summary>
+    /// A timespan to filter sessions last touched after the expiration
+    /// </summary>
+    public TimeSpan? Expiration { get; set; }
+
+    /// <summary>
+    /// Validates
+    /// </summary>
+    public void Validate()
+    {
+      if (!Expiration.HasValue)
+      {
+        throw new ArgumentNullException("Expiration is required.");
+      }
+    }
+  }
+}


### PR DESCRIPTION
#4565 Added abstractions and a default implementation for a session store to be used with the Blazor state SessionManager. The default implementation continues to use in-memory persistence in a ConcurrentDictionary.