### PR TITLE
Improve testing (MSTST0040 fixed, Csla.Windows.Tests fixed)

### DIFF
--- a/Source/Csla.Windows.Tests/test.runsettings
+++ b/Source/Csla.Windows.Tests/test.runsettings
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <MSTest>
+    <Parallelize>
+      <Scope>ClassLevel</Scope>
+    </Parallelize>
+  </MSTest>
+</RunSettings>

--- a/Source/Csla.test/DataPortal/AsynchDataPortalTest.cs
+++ b/Source/Csla.test/DataPortal/AsynchDataPortalTest.cs
@@ -97,28 +97,19 @@ namespace Csla.Test.DataPortal
 
 
     [TestMethod]
-    public void CreateAsync_WithException()
+    public async Task CreateAsync_WithException()
     {
-      var lck = new AutoResetEvent(false);
-      new Action(async () =>
-      {
-        IDataPortal<Single2> dataPortal = _testDIContext.CreateDataPortal<Single2>();
+      IDataPortal<Single2> dataPortal = _testDIContext.CreateDataPortal<Single2>();
         
-        try
-        {
-          var result = await dataPortal.CreateAsync(9999);
-          Assert.Fail("Expected exception not thrown");
-        }
-        catch (Exception ex)
-        {
-          Assert.IsInstanceOfType(ex, typeof(DataPortalException));
-        }
-        finally
-        {
-          lck.Set();
-        }
-      }).Invoke();
-      lck.WaitOne();
+      try
+      {
+        var result = await dataPortal.CreateAsync(9999);
+        Assert.Fail("Expected exception not thrown");
+      }
+      catch (Exception ex)
+      {
+        Assert.IsInstanceOfType(ex, typeof(DataPortalException));
+      }
     }
 
     [TestMethod]
@@ -164,28 +155,19 @@ namespace Csla.Test.DataPortal
 
 
     [TestMethod]
-    public void FetchAsync_WithException()
+    public async Task FetchAsync_WithException()
     {
-      var lck = new AutoResetEvent(false);
-      new Action(async () =>
-      {
-        IDataPortal<Single2> dataPortal = _testDIContext.CreateDataPortal<Single2>();
+      IDataPortal<Single2> dataPortal = _testDIContext.CreateDataPortal<Single2>();
 
-        try
-        {
-          var result = await dataPortal.FetchAsync(9999);
-          Assert.Fail("Expected exception not thrown");
-        }
-        catch (Exception ex)
-        {
-          Assert.IsInstanceOfType(ex, typeof(DataPortalException));
-        }
-        finally
-        {
-          lck.Set();
-        }
-      }).Invoke();
-      lck.WaitOne();
+      try
+      {
+        var result = await dataPortal.FetchAsync(9999);
+        Assert.Fail("Expected exception not thrown");
+      }
+      catch (Exception ex)
+      {
+        Assert.IsInstanceOfType(ex, typeof(DataPortalException));
+      } 
     }
 
     [TestMethod]
@@ -236,24 +218,17 @@ namespace Csla.Test.DataPortal
         Assert.AreEqual(555, result.Id);
         Assert.IsTrue(result.IsNew);
         Assert.IsTrue(result.IsDirty);
-        var lck = new AutoResetEvent(false);
-        new Action(async () =>
+        
+        try
         {
-          try
-          {
-            result = await result.SaveAsync();
-            Assert.Fail("Expected exception not thrown");
-          }
-          catch (Exception ex)
-          {
-            context.Assert.IsTrue(ex.GetType() == typeof(DataPortalException));
-          }
-          finally
-          {
-            lck.Set();
-          }
-        }).Invoke();
-        lck.WaitOne();
+          result = await result.SaveAsync();
+          Assert.Fail("Expected exception not thrown");
+        }
+        catch (Exception ex)
+        {
+          context.Assert.IsTrue(ex.GetType() == typeof(DataPortalException));
+        }
+
         context.Assert.Success();
       });
       context.Complete();
@@ -285,29 +260,20 @@ namespace Csla.Test.DataPortal
     }
 
     [TestMethod]
-    public void ExecuteAsyncWithException()
+    public async Task ExecuteAsyncWithException()
     {
-      var lck = new AutoResetEvent(false);
-      new Action(async () =>
-      {
-        IDataPortal<SingleCommand> dataPortal = _testDIContext.CreateDataPortal<SingleCommand>();
+      IDataPortal<SingleCommand> dataPortal = _testDIContext.CreateDataPortal<SingleCommand>();
 
-        try
-        {
-          var cmd = dataPortal.Create(555);
-          var result = await dataPortal.ExecuteAsync(cmd);
-          Assert.Fail("Expected exception not thrown");
-        }
-        catch (Exception ex)
-        {
-          Assert.IsInstanceOfType(ex, typeof(DataPortalException));
-        }
-        finally
-        {
-          lck.Set();
-        }
-      }).Invoke();
-      lck.WaitOne();
+      try
+      {
+        var cmd = dataPortal.Create(555);
+        var result = await dataPortal.ExecuteAsync(cmd);
+        Assert.Fail("Expected exception not thrown");
+      }
+      catch (Exception ex)
+      {
+        Assert.IsInstanceOfType(ex, typeof(DataPortalException));
+      }
     }
     #endregion
 


### PR DESCRIPTION
Address MSTEST0040 warnings
Fixes Csla.Windows.Tests project which can't be executed due to a missing test.runsettings-file.

We should port the `Csla.Windows.Tests` fix to v9