### PR TITLE
remove redundant sealed keywords

### DIFF
--- a/Source/Csla.Analyzers/Csla.Analyzers/AsynchronousBusinessRuleInheritingFromBusinessRuleChangeToBusinessRuleAsyncCodeFix.cs
+++ b/Source/Csla.Analyzers/Csla.Analyzers/AsynchronousBusinessRuleInheritingFromBusinessRuleChangeToBusinessRuleAsyncCodeFix.cs
@@ -27,7 +27,7 @@ namespace Csla.Analyzers
     /// 
     /// </summary>
     /// <returns></returns>
-    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
     /// <summary>
     /// 
     /// </summary>

--- a/Source/Csla.Analyzers/Csla.Analyzers/CheckConstructorsAnalyzerPublicConstructorCodeFix.cs
+++ b/Source/Csla.Analyzers/Csla.Analyzers/CheckConstructorsAnalyzerPublicConstructorCodeFix.cs
@@ -27,7 +27,7 @@ namespace Csla.Analyzers
     /// <summary>
     /// 
     /// </summary>
-    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
     /// <summary>
     /// 

--- a/Source/Csla.Analyzers/Csla.Analyzers/DoesChildOperationHaveRunLocalRemoveAttributeCodeFix.cs
+++ b/Source/Csla.Analyzers/Csla.Analyzers/DoesChildOperationHaveRunLocalRemoveAttributeCodeFix.cs
@@ -25,7 +25,7 @@ namespace Csla.Analyzers
     /// <summary>
     /// 
     /// </summary>
-    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
     /// <summary>
     /// 

--- a/Source/Csla.Analyzers/Csla.Analyzers/DoesOperationHaveAttributeAddAttributeCodeFix.cs
+++ b/Source/Csla.Analyzers/Csla.Analyzers/DoesOperationHaveAttributeAddAttributeCodeFix.cs
@@ -42,7 +42,7 @@ namespace Csla.Analyzers
     /// <summary>
     /// 
     /// </summary>
-    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
     /// <summary>
     /// 

--- a/Source/Csla.Analyzers/Csla.Analyzers/EvaluateManagedBackingFieldsCodeFix.cs
+++ b/Source/Csla.Analyzers/Csla.Analyzers/EvaluateManagedBackingFieldsCodeFix.cs
@@ -23,7 +23,7 @@ namespace Csla.Analyzers
     /// <summary>
     /// 
     /// </summary>
-    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
     /// <summary>
     /// 

--- a/Source/Csla.Analyzers/Csla.Analyzers/FindOperationsWithIncorrectReturnTypeResolveCorrectTypeCodeFix.cs
+++ b/Source/Csla.Analyzers/Csla.Analyzers/FindOperationsWithIncorrectReturnTypeResolveCorrectTypeCodeFix.cs
@@ -25,7 +25,7 @@ namespace Csla.Analyzers
     /// <summary>
     /// 
     /// </summary>
-    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
     /// <summary>
     /// 

--- a/Source/Csla.Analyzers/Csla.Analyzers/FindSaveAssignmentIssueAnalyzerAddAssignmentCodeFix.cs
+++ b/Source/Csla.Analyzers/Csla.Analyzers/FindSaveAssignmentIssueAnalyzerAddAssignmentCodeFix.cs
@@ -24,7 +24,7 @@ namespace Csla.Analyzers
     /// <summary>
     /// 
     /// </summary>
-    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
     /// <summary>
     /// 

--- a/Source/Csla.Analyzers/Csla.Analyzers/FindSaveAssignmentIssueAnalyzerAddAsyncAssignmentCodeFix.cs
+++ b/Source/Csla.Analyzers/Csla.Analyzers/FindSaveAssignmentIssueAnalyzerAddAsyncAssignmentCodeFix.cs
@@ -25,7 +25,7 @@ namespace Csla.Analyzers
     /// <summary>
     /// 
     /// </summary>
-    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
     /// <summary>
     /// 

--- a/Source/Csla.Analyzers/Csla.Analyzers/IsCompleteCalledInAsynchronousBusinessRuleRemoveCallCodeFix.cs
+++ b/Source/Csla.Analyzers/Csla.Analyzers/IsCompleteCalledInAsynchronousBusinessRuleRemoveCallCodeFix.cs
@@ -27,7 +27,7 @@ namespace Csla.Analyzers
     /// <summary>
     /// 
     /// </summary>
-    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
     /// <summary>
     /// 

--- a/Source/Csla.Analyzers/Csla.Analyzers/IsOperationMethodPublicMakeNonPublicCodeFix.cs
+++ b/Source/Csla.Analyzers/Csla.Analyzers/IsOperationMethodPublicMakeNonPublicCodeFix.cs
@@ -24,7 +24,7 @@ namespace Csla.Analyzers
     /// <summary>
     /// 
     /// </summary>
-    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
     /// <summary>
     /// 


### PR DESCRIPTION
sealing members is redundant on sealed types

![canada-raises-quota-for-controversial-seal-hunt-80400438-5d20f981be8049bc954f8d986170c64d](https://github.com/user-attachments/assets/a5939a8d-c71d-4e28-b39d-bc267b4f721b)
