### PR TITLE
Make ToCancellationToken and containing class obsolete 

### DIFF
--- a/Source/Csla.Blazor/ViewModel.cs
+++ b/Source/Csla.Blazor/ViewModel.cs
@@ -233,7 +233,8 @@ namespace Csla.Blazor
     {
       try
       {
-        await SaveAsync(BusyTimeout.ToCancellationToken());
+        using var cts = BusyTimeout.ToCancellationTokenSource();
+        await SaveAsync(cts.Token);
       }
       catch (TaskCanceledException tcex)
       {

--- a/Source/Csla/Core/BusinessBase.cs
+++ b/Source/Csla/Core/BusinessBase.cs
@@ -1242,9 +1242,9 @@ namespace Csla.Core
     /// Await this method to ensure business object is not busy.
     /// </summary>
     /// <param name="timeout">Timeout duration</param>
-    public Task WaitForIdle(TimeSpan timeout)
+    public async Task WaitForIdle(TimeSpan timeout)
     {
-      return BusyHelper.WaitForIdleAsTimeout(() => WaitForIdle(timeout.ToCancellationToken()), GetType(), nameof(WaitForIdle), timeout);
+      await BusyHelper.WaitForIdleAsTimeout(WaitForIdle, GetType(), nameof(WaitForIdle), timeout);
     }
 
     /// <summary>

--- a/Source/Csla/Core/BusinessBase.cs
+++ b/Source/Csla/Core/BusinessBase.cs
@@ -1242,9 +1242,9 @@ namespace Csla.Core
     /// Await this method to ensure business object is not busy.
     /// </summary>
     /// <param name="timeout">Timeout duration</param>
-    public async Task WaitForIdle(TimeSpan timeout)
+    public Task WaitForIdle(TimeSpan timeout)
     {
-      await BusyHelper.WaitForIdleAsTimeout(WaitForIdle, GetType(), nameof(WaitForIdle), timeout);
+      return BusyHelper.WaitForIdleAsTimeout(WaitForIdle, GetType(), nameof(WaitForIdle), timeout);
     }
 
     /// <summary>

--- a/Source/Csla/Core/BusyHelper.cs
+++ b/Source/Csla/Core/BusyHelper.cs
@@ -15,11 +15,12 @@ namespace Csla.Core
   /// </summary>
   public static class BusyHelper 
   {
-    internal static async Task WaitForIdleAsTimeout(Func<Task> operation, Type source, string methodName, TimeSpan timeout)
+    internal static async Task WaitForIdleAsTimeout(Func<CancellationToken, Task> operation, Type source, string methodName, TimeSpan timeout)
     {
       try
       {
-        await operation();
+        using var cts = timeout.ToCancellationTokenSource();
+        await operation(cts.Token);
       }
       catch (TaskCanceledException tcex)
       {
@@ -39,7 +40,8 @@ namespace Csla.Core
     {
       try
       {
-        await WaitForIdle(source, timeout.ToCancellationToken(), methodName);
+        using var cts = timeout.ToCancellationTokenSource();
+        await WaitForIdle(source, cts.Token, methodName);
       }
       catch (TaskCanceledException tcex)
       {

--- a/Source/Csla/Core/ExtendedBindingList.cs
+++ b/Source/Csla/Core/ExtendedBindingList.cs
@@ -170,7 +170,7 @@ namespace Csla.Core
     /// <param name="timeout">Timeout duration</param>
     public Task WaitForIdle(TimeSpan timeout)
     {
-      return BusyHelper.WaitForIdleAsTimeout(() => WaitForIdle(timeout.ToCancellationToken()), GetType(), nameof(WaitForIdle), timeout);
+      return BusyHelper.WaitForIdleAsTimeout(WaitForIdle, GetType(), nameof(WaitForIdle), timeout);
     }
 
     /// <summary>

--- a/Source/Csla/Core/ObservableBindingList.cs
+++ b/Source/Csla/Core/ObservableBindingList.cs
@@ -253,7 +253,7 @@ namespace Csla.Core
     /// <param name="timeout">Timeout duration</param>
     public Task WaitForIdle(TimeSpan timeout)
     {
-      return BusyHelper.WaitForIdleAsTimeout(() => WaitForIdle(timeout.ToCancellationToken()), GetType(), nameof(WaitForIdle), timeout);
+      return BusyHelper.WaitForIdleAsTimeout(WaitForIdle, GetType(), nameof(WaitForIdle), timeout);
     }
 
     /// <summary>

--- a/Source/Csla/Server/ObjectFactory.cs
+++ b/Source/Csla/Server/ObjectFactory.cs
@@ -83,7 +83,8 @@ namespace Csla.Server
         protected async Task WaitForIdle(object obj)
         {
             var cslaOptions = ApplicationContext.GetRequiredService<Configuration.CslaOptions>();
-            await WaitForIdle(obj, TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds).ToCancellationToken()).ConfigureAwait(false);
+            using var cts = TimeSpan.FromSeconds(cslaOptions.DefaultWaitForIdleTimeoutInSeconds).ToCancellationTokenSource();
+            await WaitForIdle(obj, cts.Token).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Source/Csla/TimeSpanExtensions.cs
+++ b/Source/Csla/TimeSpanExtensions.cs
@@ -3,6 +3,7 @@ namespace System;
 /// <summary>
 /// Provides extension methods for <see cref="TimeSpan"/>.
 /// </summary>
+[Obsolete("The extensions type will become internal with CSLA 10.")]
 public static class TimeSpanExtensions
 {
   /// <summary>
@@ -10,9 +11,17 @@ public static class TimeSpanExtensions
   /// </summary>
   /// <param name="timeout">The timeout duration.</param>
   /// <returns>The <see cref="CancellationToken"/> with the specified timeout.</returns>
+  [Obsolete($"This extension method will be removed with CSLA 10. You should write your own extension with proper disposal handling for the underlying {nameof(CancellationTokenSource)}.")]
   public static CancellationToken ToCancellationToken(this TimeSpan timeout)
   {
     var cts = new CancellationTokenSource(timeout);
     return cts.Token;
   }
+
+  /// <summary>
+  /// Creates a <see cref="CancellationTokenSource"/> with the given <paramref name="timeout"/>.
+  /// </summary>
+  /// <param name="timeout">The timeout duration.</param>
+  /// <returns>The <see cref="CancellationTokenSource"/> with the specified timeout.</returns>
+  public static CancellationTokenSource ToCancellationTokenSource(this TimeSpan timeout) => new(timeout);
 }


### PR DESCRIPTION
Make ToCancellationToken and containing class obsolete  (so we can int…ernalize them in v10)
Add new method ToCancellationTokenSource and dispose the source correctly.

Fixes #4611