### PR TITLE
Use TotalMilliseconds instead of Milliseconds for WebClient request timeouts.

### DIFF
--- a/Source/Csla/DataPortalClient/HttpProxy.cs
+++ b/Source/Csla/DataPortalClient/HttpProxy.cs
@@ -265,12 +265,12 @@ namespace Csla.Channels.Http
         {
           if (readWriteTimeout > TimeSpan.Zero)
           {
-            httpWebRequest.ReadWriteTimeout = readWriteTimeout.Milliseconds;
+            httpWebRequest.ReadWriteTimeout = (int)readWriteTimeout.TotalMilliseconds;
           }
         }
         if (timeout > TimeSpan.Zero)
         {
-          req.Timeout = timeout.Milliseconds;
+          req.Timeout = (int)timeout.TotalMilliseconds;
         }
         return req;
       }


### PR DESCRIPTION
Fixes #4433

I was thinking about adding a test. But the only solution I see is to make the class internal and visible to the test project.
Don't know if we should to that?