### PR TITLE
ServiceProviderMethodCaller.TryFindDataPortalMethod must not throw

### DIFF
--- a/Source/Csla.Analyzers/Csla.Analyzers.Tests/Csla.Analyzers.Tests.csproj
+++ b/Source/Csla.Analyzers/Csla.Analyzers.Tests/Csla.Analyzers.Tests.csproj
@@ -20,9 +20,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Csla.Blazor.Test/Csla.Blazor.Test.csproj
+++ b/Source/Csla.Blazor.Test/Csla.Blazor.Test.csproj
@@ -11,9 +11,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/Csla.Blazor.WebAssembly.Tests/Csla.Blazor.WebAssembly.Tests.csproj
+++ b/Source/Csla.Blazor.WebAssembly.Tests/Csla.Blazor.WebAssembly.Tests.csproj
@@ -11,9 +11,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/Csla.Generators/cs/AutoImplementProperties/Csla.Generator.AutoImplementProperties.CSharp.Tests/Csla.Generator.AutoImplementProperties.CSharp.Tests.csproj
+++ b/Source/Csla.Generators/cs/AutoImplementProperties/Csla.Generator.AutoImplementProperties.CSharp.Tests/Csla.Generator.AutoImplementProperties.CSharp.Tests.csproj
@@ -17,10 +17,10 @@
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.14.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
-    <PackageReference Include="Verify.MSTest" Version="29.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.1" />
+    <PackageReference Include="Verify.MSTest" Version="30.3.1" />
     <PackageReference Include="Verify.SourceGenerators" Version="2.5.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>

--- a/Source/Csla.Generators/cs/AutoSerialization/Csla.Generator.AutoSerialization.CSharp.Tests/Csla.Generator.AutoSerialization.CSharp.Tests.csproj
+++ b/Source/Csla.Generators/cs/AutoSerialization/Csla.Generator.AutoSerialization.CSharp.Tests/Csla.Generator.AutoSerialization.CSharp.Tests.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -24,7 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Verify.MSTest" Version="30.1.0" />
+    <PackageReference Include="Verify.MSTest" Version="30.3.1" />
     <PackageReference Include="Verify.SourceGenerators" Version="2.5.0" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.14.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />

--- a/Source/Csla.Windows.Tests/Csla.Windows.Tests.csproj
+++ b/Source/Csla.Windows.Tests/Csla.Windows.Tests.csproj
@@ -11,9 +11,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Csla.Windows\Csla.Windows.csproj" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.1" />
   </ItemGroup>
 
 </Project>

--- a/Source/Csla.test/Csla.Tests.csproj
+++ b/Source/Csla.test/Csla.Tests.csproj
@@ -49,9 +49,9 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="8.0.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.1" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageReference Include="System.Resources.Extensions" Version="8.0.0" />

--- a/Source/Csla/Server/ObjectFactoryLoader.cs
+++ b/Source/Csla/Server/ObjectFactoryLoader.cs
@@ -38,12 +38,13 @@ namespace Csla.Server
     /// on the business object.
     /// </param>
     /// <exception cref="ArgumentException"><paramref name="factoryName"/> is <see langword="null"/>, <see cref="string.Empty"/> or only consists of white spaces.</exception>
+    /// <exception cref="InvalidOperationException"><see cref="Type"/> for <paramref name="factoryName"/> could not be loaded.</exception>
     public Type GetFactoryType(string factoryName)
     {
       if (factoryName is null)
         throw new ArgumentException(string.Format(Resources.StringNotNullOrWhiteSpaceException, nameof(factoryName)), nameof(factoryName));
 
-      return Type.GetType(factoryName) ?? throw new InvalidOperationException(Resources.FactoryTypeNotFoundException);
+      return Type.GetType(factoryName) ?? throw new InvalidOperationException(string.Format(Resources.FactoryTypeNotFoundException, factoryName));
     }
 
     /// <summary>
@@ -61,6 +62,7 @@ namespace Csla.Server
     /// type name parameter.
     /// </returns>
     /// <exception cref="ArgumentException"><paramref name="factoryName"/> is <see langword="null"/>, <see cref="string.Empty"/> or only consists of white spaces.</exception>
+    /// <exception cref="InvalidOperationException"><see cref="Type"/> for <paramref name="factoryName"/> could not be loaded.</exception>
     public object GetFactory(string factoryName)
     {
       if (factoryName is null)

--- a/Source/GraphMergerTest/GraphMergerTest.BusinessTests/GraphMergerTest.BusinessTests.csproj
+++ b/Source/GraphMergerTest/GraphMergerTest.BusinessTests/GraphMergerTest.BusinessTests.csproj
@@ -15,8 +15,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.1" />
   </ItemGroup>
 </Project>

--- a/Source/csla.netcore.test/DataPortal/ServiceProviderMethodCallerTests.cs
+++ b/Source/csla.netcore.test/DataPortal/ServiceProviderMethodCallerTests.cs
@@ -1,679 +1,671 @@
-////-----------------------------------------------------------------------
-//// <copyright file="ServiceProviderMethodCallerTests.cs" company="Marimer LLC">
-////     Copyright (c) Marimer LLC. All rights reserved.
-////     Website: https://cslanet.com
-//// </copyright>
-//// <summary>no summary</summary>
-////-----------------------------------------------------------------------
-//using System;
-//using System.Collections.Generic;
-//using System.Linq;
-//using System.Text;
-//using System.Threading.Tasks;
-//using Csla;
-//using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-//namespace Csla.Test.DataPortal
-//{
-//  [TestClass]
-//  public class ServiceProviderMethodCallerTests
-//  {
-//    [TestMethod]
-//    [ExpectedException(typeof(ArgumentNullException))]
-//    public void NoTarget()
-//    {
-//      Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<CreateAttribute>(null, null);
-//    }
-
-//    [TestMethod]
-//    public void FindMethodInterfaceCriteria()
-//    {
-//      var obj = new InterfaceCriteria();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<CreateAttribute>(
-//        obj, new object[] { new MyCriteria() });
-//      Assert.IsNotNull(method);
-//    }
-
-//    [TestMethod]
-//    public void FindMethodNullableCriteria()
-//    {
-//      var obj = new NullableCriteria();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<CreateAttribute>(obj, new object[] { 123 });
-//      Assert.IsNotNull(method, "with int");
-//      method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<CreateAttribute>(obj, new object[] { null });
-//      Assert.IsNotNull(method, "with null");
-//    }
-
-//    [TestMethod]
-//    public async Task FindMethodNullableCriteriaWithValueViaDataPortal()
-//    {
-//      var obj = await Csla.DataPortal.CreateAsync<NullableCriteria>(123);
-//      Assert.IsNotNull(obj);
-//    }
-
-//    [TestMethod]
-//    public async Task FindMethodNullableCriteriaWithNullViaDataPortal()
-//    {
-//      var obj = await Csla.DataPortal.CreateAsync<NullableCriteria>(null);
-//      Assert.IsNotNull(obj);
-//    }
-
-//    [TestMethod]
-//    public void FindMethodNoCriteriaNoDI()
-//    {
-//      var obj = new SimpleNoCriteriaCreate();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<CreateAttribute>(obj, new object[] { null });
-//      Assert.IsNotNull(method);
-//    }
-
-//    [TestMethod]
-//    public void FindMethodCriteriaDI()
-//    {
-//      var obj = new CriteriaCreateWithDI();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<CreateAttribute>(obj, new object[] { 123 });
-//      Assert.IsNotNull(method);
-//    }
-
-//    [TestMethod]
-//    [ExpectedException(typeof(System.Reflection.TargetParameterCountException))]
-//    public void FindMethodBadCriteriaDI()
-//    {
-//      var obj = new CriteriaCreateWithDI();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<CreateAttribute>(obj, new object[] { "hi" });
-//      Assert.IsNotNull(method);
-//    }
-
-//    [TestMethod]
-//    public void FindMethodMultipleCriteriaDI()
-//    {
-//      var obj = new MultipleCriteriaCreateWithDI();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<CreateAttribute>(obj, new object[] { 123, "hi" });
-//      Assert.IsNotNull(method);
-//    }
-
-//    [TestMethod]
-//    public void FindMethodMultipleCriteriaDIInterleaved()
-//    {
-//      var obj = new MultipleCriteriaCreateWithDIInterleaved();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<CreateAttribute>(obj, new object[] { 123, "hi" });
-//      Assert.IsNotNull(method);
-//    }
-
-//    [TestMethod]
-//    public void FindMethodCriteriaMultipleDI()
-//    {
-//      var obj = new CriteriaCreateWithMultipleDI();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<CreateAttribute>(obj, new object[] { 123 });
-//      method.PrepForInvocation();
-//      Assert.IsNotNull(method);
-//      Assert.AreEqual(3, method.Parameters.Count());
-//    }
-
-//    [TestMethod]
-//    [ExpectedException(typeof(System.Reflection.AmbiguousMatchException))]
-//    public void FindMethodCriteriaMultipleAmbiguousDI()
-//    {
-//      var obj = new CriteriaCreateWithMultipleAmbiguousDI();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<CreateAttribute>(obj, new object[] { 123 });
-//    }
-
-//    [TestMethod]
-//    [ExpectedException(typeof(System.Reflection.TargetParameterCountException))]
-//    public void FindMethodSingleCriteriaInvalid()
-//    {
-//      var obj = new SimpleNoCriteriaCreate();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<CreateAttribute>(obj, new object[] { 123 });
-//      Assert.IsNotNull(method);
-//    }
-
-//    [TestMethod]
-//    public void FindMethodSingleCriteriaValid()
-//    {
-//      var obj = new SimpleCriteriaCreate();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<CreateAttribute>(obj, new object[] { 123 });
-//      Assert.IsNotNull(method);
-//    }
-
-//    [TestMethod]
-//    public void FindMethodObjectCriteriaValid()
-//    {
-//      var obj = new ObjectCriteriaCreate();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<CreateAttribute>(obj, new object[] { 123 });
-//      Assert.IsNotNull(method);
-//    }
-
-//    [TestMethod]
-//    public void FindMethodObjectCriteriaSubtype()
-//    {
-//      var obj = new ObjectCriteriaCreateSubtype();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<CreateAttribute>(obj, new object[] { 123 });
-//      Assert.IsNotNull(method);
-//    }
-
-//    [TestMethod]
-//    [ExpectedException(typeof(System.Reflection.TargetParameterCountException))]
-//    public void FindMethodSingleCriteriaBadType()
-//    {
-//      var obj = new SimpleCriteriaCreate();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<CreateAttribute>(obj, new object[] { "hi" });
-//      Assert.IsNotNull(method);
-//    }
-
-//    [TestMethod]
-//    public void FindMethod_PrivateBase()
-//    {
-//      var obj = new PrivateMethod();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<ExecuteAttribute>(obj, null);
-//      Assert.IsNotNull(method);
-//      Assert.AreEqual("Execute", method.MethodInfo.Name, "Method name should match");
-//    }
-
-//    [TestMethod]
-//    public void FindMethod_PrivateBase_Invoke()
-//    {
-//      var obj = Csla.DataPortal.Create<PrivateMethod>();
-//      obj = Csla.DataPortal.Execute(obj);
-//      Assert.IsNotNull(obj);
-//    }
-
-//    [TestMethod]
-//    public void FindMethodDataPortal_CreateBase()
-//    {
-//      var obj = new OldStyleNoOverride();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<CreateAttribute>(obj, null);
-//      Assert.IsNotNull(method);
-//    }
-
-//    [TestMethod]
-//    public void FindMethodDataPortal_CreateCriteria()
-//    {
-//      var obj = new OldStyleCreate();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<CreateAttribute>(obj, new object[] { 123 });
-//      Assert.IsNotNull(method);
-//    }
-
-//    [TestMethod]
-//    public void FindMethodDataPortal_CreateCriteriaBase()
-//    {
-//      var obj = new OldStyleCriteriaBase();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<CreateAttribute>(obj, new object[] { 123 });
-//      Assert.IsNotNull(method);
-//    }
-
-//    [TestMethod]
-//    public void FindMethodDataPortal_Create()
-//    {
-//      var obj = new OldStyleCreate();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<CreateAttribute>(obj, null);
-//      Assert.IsNotNull(method);
-//    }
-
-//    [TestMethod]
-//    public void FindMethodDataPortal_Create_Criteria()
-//    {
-//      var obj = new OldStyleCreate();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<CreateAttribute>(obj, new object[] { 123 });
-//      Assert.IsNotNull(method);
-//    }
-
-//    [TestMethod]
-//    public void FindMethodAmbiguousCriteria()
-//    {
-//      var obj = new AmbiguousNoCriteriaCreate();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<CreateAttribute>(obj, null);
-//      method.PrepForInvocation();
-//      Assert.IsNotNull(method);
-//      Assert.AreEqual(1, method.Parameters.Count());
-//    }
-
-//    [TestMethod]
-//    public void FindChildLegacyUpdate()
-//    {
-//      var obj = new BasicChild();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<UpdateChildAttribute>(obj, null);
-//      Assert.IsNotNull(method);
-//    }
-
-//    [TestMethod]
-//    public void FindChildParamsUpdate()
-//    {
-//      var obj = new ParamsChild();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<UpdateChildAttribute>(obj, null);
-//      Assert.IsNotNull(method);
-//    }
-
-//    [TestMethod]
-//    public void FindChildIntUpdate()
-//    {
-//      var obj = new ModernChild();
-//      object[] paramsArray = Server.DataPortal.GetCriteriaArray(123);
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<UpdateChildAttribute>(obj, paramsArray);
-//      Assert.IsNotNull(method);
-
-//      var dp = new Csla.Server.ChildDataPortal();
-//      dp.Update(obj, 42);
-//      Assert.AreEqual(42, obj.Id);
-//      obj = new ModernChild();
-//      dp.Update(obj, 123);
-//      Assert.AreEqual(123, obj.Id);
-//    }
-
-//    [TestMethod]
-//    public void FindOverlappingCriteriaInt()
-//    {
-//      var obj = new MultipleOverlappingCriteria();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<FetchAttribute>(obj, new object[] { 1 });
-//      Assert.IsNotNull(method);
-//    }
-
-//    [TestMethod]
-//    public void Issue2109()
-//    {
-//      var obj = new Issue2109List();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<FetchAttribute>(obj, new object[] { new string[] { "a" } });
-//      Assert.IsNotNull(method, "string[]");
-//      var criteria = new My2109Criteria();
-//      method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<FetchAttribute>(obj, new object[] { criteria });
-//      Assert.IsNotNull(method, "ICriteriaBase");
-
-//      obj = Csla.DataPortal.Fetch<Issue2109List>(new My2109Criteria());
-//      Assert.IsNotNull(obj, "Fetch via criteria");
-//      Assert.AreEqual("Csla.Test.DataPortal.My2109Criteria", obj[0].Name);
-//      obj = Csla.DataPortal.Fetch<Issue2109List>(new string[] { "a" });
-//      Assert.IsNotNull(obj, "Fetch via string array");
-//      Assert.AreEqual("a", obj[0].Name);
-//    }
-
-//    [TestMethod]
-//    public void Issue2287BusinessBindingListFetch()
-//    {
-//      var obj = new Issue2287List();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<FetchAttribute>(obj, new object[] { new Issue2287List.Criteria() });
-//      Assert.IsNotNull(method);
-//      Assert.AreEqual(obj.GetType().BaseType, method.MethodInfo.DeclaringType);
-//    }
-
-//    [TestMethod]
-//    public void Issue2287BusinessBaseFetch()
-//    {
-//      var obj = new Issue2287Edit();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<CreateAttribute>(obj, new object[] { });
-//      Assert.IsNotNull(method);
-//    }
-
-//    [TestMethod]
-//    public void Issue2396DeleteSelfChildNoParams()
-//    {
-//      var obj = new Issue2396Edit();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<DeleteSelfChildAttribute>(obj, new object[] { });
-//      Assert.IsNotNull(method);
-//      Assert.AreEqual(0, method.MethodInfo.GetParameters().Count());
-//    }
-
-//    [TestMethod]
-//    public void Issue2396DeleteSelfChildWithParams()
-//    {
-//      var obj = new Issue2396EditParams();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<DeleteSelfChildAttribute>(obj, new object[] { 1, 2 });
-//      Assert.IsNotNull(method);
-//      Assert.AreEqual(2, method.MethodInfo.GetParameters().Count());
-//    }
-
-//    [TestMethod]
-//    public void Issue2396DeleteSelfChildFallbackToNoParams()
-//    {
-//      var obj = new Issue2396Edit();
-//      var method = Csla.Reflection.ServiceProviderMethodCaller.FindDataPortalMethod<DeleteSelfChildAttribute>(obj, new object[] { 1, 2 });
-//      Assert.IsNotNull(method);
-//      Assert.AreEqual(0, method.MethodInfo.GetParameters().Count());
-//    }
-//  }
-
-//  //
-//  // End of test methods, start of support classes
-//  //
-
-//  [Serializable]
-//  public class OldStyleNoOverride : BusinessBase<OldStyleNoOverride>
-//  {
-//    [Create]
-//    private void DataPortal_Create()
-//    {
-//      BusinessRules.CheckRules();
-//    }
-//  }
-
-//  [Serializable]
-//  public class PrivateMethodBase<T> : CommandBase<T>
-//  where T : CommandBase<T>
-//  {
-//    [Create]
-//    private void Create()
-//    { }
-
-//    [Execute]
-//    private void Execute()
-//    { }
-//  }
-
-//  [Serializable]
-//  public class PrivateMethod : PrivateMethodBase<PrivateMethod>
-//  {
-
-//  }
-
-//  [Serializable]
-//  public class OldStyleCreate : BusinessBase<OldStyleCreate>
-//  {
-//    [Create]
-//    protected void DataPortal_Create()
-//    {
-//      BusinessRules.CheckRules();
-//    }
-
-//    [Create]
-//    private void DataPortal_Create(int id)
-//    {
-//      BusinessRules.CheckRules();
-//    }
-//  }
-
-//  [Serializable]
-//  public class OldStyleCriteria : BusinessBase<OldStyleCriteria>
-//  {
-//    [Create]
-//    private void DataPortal_Create(int id)
-//    {
-//      BusinessRules.CheckRules();
-//    }
-//  }
-
-//  [Serializable]
-//  public class OldStyleCriteriaBase : OldStyleCriteria
-//  {
-//  }
-
-//  public interface ICriteria : IReadOnlyBase
-//  {
-//    int Id { get; }
-//  }
-
-//  public class MyCriteria : ReadOnlyBase<MyCriteria>, ICriteria
-//  {
-//    public int Id => 123;
-//  }
-
-//  [Serializable]
-//  public class InterfaceCriteria : BusinessBase<InterfaceCriteria>
-//  {
-//    [Create]
-//    private void Create(ICriteria criteria) { }
-//  }
-
-//  [Serializable]
-//  public class SimpleNoCriteriaCreate : BusinessBase<SimpleNoCriteriaCreate>
-//  {
-//    [Create]
-//    private void Create() { }
-
-//    [Create]
-//    private void Create(ICloneable x) { }
-//  }
-
-//  [Serializable]
-//  public class SimpleCriteriaCreate : BusinessBase<SimpleCriteriaCreate>
-//  {
-//    [Create]
-//    private void Create(int id) { }
-//  }
-
-//  [Serializable]
-//  public class ObjectCriteriaCreate : BusinessBase<ObjectCriteriaCreate>
-//  {
-//    [Create]
-//    private void Create(object id) { }
-//  }
-
-//  [Serializable]
-//  public class ObjectCriteriaCreateSubtype : ObjectCriteriaCreate
-//  { }
-
-//  [Serializable]
-//  public class AmbiguousNoCriteriaCreate : BusinessBase<AmbiguousNoCriteriaCreate>
-//  {
-//    [Create]
-//    private void Create() { }
-
-//    [Create]
-//    private void Create([Inject] ICloneable x) { }
-//  }
-
-//  [Serializable]
-//  public class CriteriaCreateWithDI : BusinessBase<CriteriaCreateWithDI>
-//  {
-//    [Create]
-//    private void Create() { }
-
-//    [Create]
-//    private void Create(int id, [Inject] ICloneable x) { }
-//  }
-
-//  [Serializable]
-//  public class MultipleCriteriaCreateWithDI : BusinessBase<MultipleCriteriaCreateWithDI>
-//  {
-//    [Create]
-//    private void Create() { }
-
-//    [Create]
-//    private void Create(int id, string foo, [Inject] ICloneable x) { }
-//  }
-
-//  [Serializable]
-//  public class CriteriaCreateWithMultipleDI : BusinessBase<CriteriaCreateWithMultipleDI>
-//  {
-//    [Create]
-//    private void Create(int id, [Inject] ICloneable x) { }
-
-//    [Create]
-//    private void Create(int id, [Inject] ICloneable x, [Inject] IAsyncResult y) { }
-//  }
-
-//  [Serializable]
-//  public class CriteriaCreateWithMultipleAmbiguousDI : BusinessBase<CriteriaCreateWithMultipleAmbiguousDI>
-//  {
-//    [Create]
-//    private void Create(int id, [Inject] ICloneable x) { }
-
-//    [Create]
-//    private void Create(int id, [Inject] ICloneable x, [Inject] IAsyncResult y) { }
-
-//    [Create]
-//    private void Create(int id, [Inject] ICloneable x, [Inject] IFormattable y) { }
-//  }
-
-//  [Serializable]
-//  public class MultipleCriteriaCreateWithDIInterleaved : BusinessBase<MultipleCriteriaCreateWithDIInterleaved>
-//  {
-//    [Create]
-//    private void Create() { }
-
-//    [Create]
-//    private void Create(int id, [Inject] ICloneable x, string foo) { }
-//  }
-
-//  [Serializable]
-//  public class BasicChild : BusinessBase<BasicChild>
-//  {
-//    private void Child_Update()
-//    {
-//      // nada
-//    }
-//  }
-
-//  [Serializable]
-//  public class ParamsChild : BusinessBase<ParamsChild>
-//  {
-//    private void Child_Update(params object[] parameters)
-//    {
-//      // nada
-//    }
-//  }
-
-//  [Serializable]
-//  public class ModernChild : BusinessBase<ModernChild>
-//  {
-//    public static readonly PropertyInfo<int> IdProperty = RegisterProperty<int>(nameof(Id));
-//    public int Id
-//    {
-//      get { return GetProperty(IdProperty); }
-//      set { SetProperty(IdProperty, value); }
-//    }
-
-//    [UpdateChild]
-//    [InsertChild]
-//    private void UpdateOrInsert(int id)
-//    {
-//      using (BypassPropertyChecks)
-//        Id = id;
-//    }
-//  }
-
-//  [Serializable]
-//  public class NullableCriteria : BusinessBase<NullableCriteria>
-//  {
-//    [Create]
-//    private void Create(int? c)
-//    { }
-//  }
-
-//  [Serializable]
-//  public class MultipleOverlappingCriteria : BusinessBase<MultipleOverlappingCriteria>
-//  {
-//    [Fetch]
-//    private void Fetch(int id)
-//    {
-//    }
-
-//    [Fetch]
-//    private void Fetch(int id, bool? value)
-//    {
-//    }
-
-//    [Fetch]
-//    private void Fetch(int id, int? value)
-//    {
-//    }
-
-//    [Fetch]
-//    private void Fetch(List<int?> values)
-//    {
-//    }
-
-//    [Fetch]
-//    private void Fetch(List<DateTime?> values)
-//    {
-//    }
-//  }
-
-//  [Serializable]
-//  public class Issue2109List : ReadOnlyListBase<Issue2109List, Issue2109>
-//  {
-//    private void DataPortal_Fetch(ICriteriaBase criteria)
-//    {
-//      using (LoadListMode)
-//      {
-//        Add(Csla.DataPortal.Fetch<Issue2109>(criteria.ToString()));
-//      }
-//    }
-
-//    private void DataPortal_Fetch(IEnumerable<string> criteria)
-//    {
-//      using (LoadListMode)
-//      {
-//        Add(Csla.DataPortal.Fetch<Issue2109>(criteria.First().ToString()));
-//      }
-//    }
-//  }
-
-//  [Serializable]
-//  public class Issue2109 : BusinessBase<Issue2109>
-//  {
-//    public static readonly PropertyInfo<string> NameProperty = RegisterProperty<string>(nameof(Name));
-//    public string Name
-//    {
-//      get => GetProperty(NameProperty);
-//      set => SetProperty(NameProperty, value);
-//    }
-
-//    private void DataPortal_Fetch(string name)
-//    {
-//      using (BypassPropertyChecks)
-//      {
-//        Name = name;
-//      }
-//    }
-//  }
-
-//  public interface ICriteriaBase
-//  { }
-
-//  [Serializable]
-//  public class My2109Criteria : ICriteriaBase
-//  {
-//  }
-
-//  [Serializable]
-//  public class Issue2287List : Issue2287ListBase
-//  {
-//    public static Issue2287List FetchIssue2287List()
-//    {
-//      return Csla.DataPortal.Fetch<Issue2287List>(new Criteria());
-//    }
-//  }
-
-//  [Serializable]
-//  public class Issue2287ListBase : Csla.BusinessBindingListBase<Issue2287List, Issue2287Edit>
-//  {
-//    private void DataPortal_Fetch(Criteria criteria)
-//    {
-//    }
-
-//    [Serializable()]
-//    public class Criteria : Csla.CriteriaBase<Criteria>
-//    {
-//    }
-//  }
-
-//  [Serializable]
-//  public class Issue2287Edit : Issue2287EditBase<Issue2287Edit>
-//  {
-//    private new void DataPortal_Create()
-//    {
-//      BusinessRules.CheckRules();
-//    }
-//  }
-
-//  [Serializable]
-//  public class Issue2287EditBase<T> : BusinessBase<Issue2287EditBase<T>>
-//  {
-//    protected void DataPortal_Create()
-//    {
-//    }
-//  }
-
-//  [Serializable]
-//  public class Issue2396Edit : BusinessBase<Issue2396Edit>
-//  {
-//    [DeleteSelfChild]
-//    private void DeleteSelf()
-//    { }
-//  }
-
-//  [Serializable]
-//  public class Issue2396EditParams : BusinessBase<Issue2396EditParams>
-//  {
-//    [DeleteSelfChild]
-//    private void DeleteSelf(int x, int y)
-//    { }
-//  }
-//}
+//-----------------------------------------------------------------------
+// <copyright file="ServiceProviderMethodCallerTests.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>no summary</summary>
+//-----------------------------------------------------------------------
+using System.Reflection;
+using Csla.Reflection;
+using Csla.TestHelpers;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Csla.Test.DataPortal
+{
+  [TestClass]
+  public class ServiceProviderMethodCallerTests
+  {
+    private static TestDIContext _diContext = default!;
+    private ServiceProviderMethodCaller _systemUnderTest = default!;
+
+    [ClassInitialize]
+    public static void ClassSetup(TestContext context)
+    {
+      _ = context;
+      _diContext = TestDIContextFactory.CreateDefaultContext();
+    }
+
+    [TestInitialize]
+    public void TestSetup()
+    {
+      _systemUnderTest = _diContext.CreateTestApplicationContext().CreateInstanceDI<ServiceProviderMethodCaller>();
+    }
+
+    [TestMethod]
+    public void NoTarget()
+    {
+      FluentActions.Invoking(() => _systemUnderTest.FindDataPortalMethod<CreateAttribute>(null, null)).Should().Throw<ArgumentNullException>();
+    }
+
+    [TestMethod]
+    public void FindMethodInterfaceCriteria()
+    {
+      var obj = new InterfaceCriteria();
+      var method = _systemUnderTest.FindDataPortalMethod<CreateAttribute>(obj, [new MyCriteria()]);
+
+      method.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    [DataRow(123)]
+    [DataRow(null)]
+    public void FindMethodNullableIntCriteria(int? data)
+    {
+      var obj = new NullableCriteria();
+      var method = _systemUnderTest.FindDataPortalMethod<CreateAttribute>(obj, [data]);
+
+      method.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    [DataRow(123)]
+    [DataRow(null)]
+    public async Task FindMethodNullableCriteriaWithValueViaDataPortal(int? data)
+    {
+      var obj = await _diContext.CreateDataPortal<NullableCriteria>().CreateAsync(data);
+
+      obj.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public void FindMethodNoCriteriaNoDI()
+    {
+      var obj = new SimpleNoCriteriaCreate();
+      var method = _systemUnderTest.FindDataPortalMethod<CreateAttribute>(obj, [null]);
+
+      method.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public void FindMethodCriteriaDI()
+    {
+      var obj = new CriteriaCreateWithDI();
+      var method = _systemUnderTest.FindDataPortalMethod<CreateAttribute>(obj, [123]);
+
+      method.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(System.Reflection.TargetParameterCountException))]
+    public void FindMethodBadCriteriaDI()
+    {
+      var obj = new CriteriaCreateWithDI();
+      var method = _systemUnderTest.FindDataPortalMethod<CreateAttribute>(obj, ["hi"]);
+
+      method.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public void FindMethodMultipleCriteriaDI()
+    {
+      var obj = new MultipleCriteriaCreateWithDI();
+      var method = _systemUnderTest.FindDataPortalMethod<CreateAttribute>(obj, [123, "hi"]);
+
+      method.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public void FindMethodMultipleCriteriaDIInterleaved()
+    {
+      var obj = new MultipleCriteriaCreateWithDIInterleaved();
+      var method = _systemUnderTest.FindDataPortalMethod<CreateAttribute>(obj, [123, "hi"]);
+
+      method.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public void FindMethodCriteriaMultipleDI()
+    {
+      var obj = new CriteriaCreateWithMultipleDI();
+      var method = _systemUnderTest.FindDataPortalMethod<CreateAttribute>(obj, [123]);
+      method.PrepForInvocation();
+
+      method.Parameters.Should().HaveCount(3);
+    }
+
+    [TestMethod]
+    public void FindMethodCriteriaMultipleAmbiguousDI()
+    {
+      var obj = new CriteriaCreateWithMultipleAmbiguousDI();
+      FluentActions.Invoking(() => _ = _systemUnderTest.FindDataPortalMethod<CreateAttribute>(obj, [123])).Should().Throw<AmbiguousMatchException>();
+    }
+
+    [TestMethod]
+    public void FindMethodSingleCriteriaInvalid()
+    {
+      var obj = new SimpleNoCriteriaCreate();
+      FluentActions.Invoking(() => _ = _systemUnderTest.FindDataPortalMethod<CreateAttribute>(obj, [123])).Should().Throw<TargetParameterCountException>();
+    }
+
+    [TestMethod]
+    public void FindMethodSingleCriteriaValid()
+    {
+      var obj = new SimpleCriteriaCreate();
+      var method = _systemUnderTest.FindDataPortalMethod<CreateAttribute>(obj, [123]);
+
+      method.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public void FindMethodObjectCriteriaValid()
+    {
+      var obj = new ObjectCriteriaCreate();
+      var method = _systemUnderTest.FindDataPortalMethod<CreateAttribute>(obj, [123]);
+
+      method.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public void FindMethodObjectCriteriaSubtype()
+    {
+      var obj = new ObjectCriteriaCreateSubtype();
+      var method = _systemUnderTest.FindDataPortalMethod<CreateAttribute>(obj, [123]);
+
+      method.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(System.Reflection.TargetParameterCountException))]
+    public void FindMethodSingleCriteriaBadType()
+    {
+      var obj = new SimpleCriteriaCreate();
+      var method = _systemUnderTest.FindDataPortalMethod<CreateAttribute>(obj, ["hi"]);
+      Assert.IsNotNull(method);
+    }
+
+    [TestMethod]
+    public void FindMethod_PrivateBase()
+    {
+      var obj = new PrivateMethod();
+      var method = _systemUnderTest.FindDataPortalMethod<ExecuteAttribute>(obj, null);
+      Assert.IsNotNull(method);
+      Assert.AreEqual("Execute", method.MethodInfo.Name, "Method name should match");
+    }
+
+    [TestMethod]
+    public async Task FindMethod_PrivateBase_Invoke()
+    {
+      var portal = _diContext.CreateDataPortal<PrivateMethod>();
+      var obj = await portal.CreateAsync();
+      obj = await portal.ExecuteAsync(obj);
+
+      obj.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public void FindMethodDataPortal_CreateBase()
+    {
+      var obj = new OldStyleNoOverride();
+      var method = _systemUnderTest.FindDataPortalMethod<CreateAttribute>(obj, null);
+
+      method.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public void FindMethodDataPortal_CreateCriteria()
+    {
+      var obj = new OldStyleCreate();
+      var method = _systemUnderTest.FindDataPortalMethod<CreateAttribute>(obj, [123]);
+
+      method.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public void FindMethodDataPortal_CreateCriteriaBase()
+    {
+      var obj = new OldStyleCriteriaBase();
+      var method = _systemUnderTest.FindDataPortalMethod<CreateAttribute>(obj, [123]);
+
+      method.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public void FindMethodDataPortal_Create()
+    {
+      var obj = new OldStyleCreate();
+      var method = _systemUnderTest.FindDataPortalMethod<CreateAttribute>(obj, null);
+
+      method.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public void FindMethodDataPortal_Create_Criteria()
+    {
+      var obj = new OldStyleCreate();
+      var method = _systemUnderTest.FindDataPortalMethod<CreateAttribute>(obj, [123]);
+
+      method.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public void FindMethodAmbiguousCriteria()
+    {
+      var obj = new AmbiguousNoCriteriaCreate();
+      var method = _systemUnderTest.FindDataPortalMethod<CreateAttribute>(obj, null);
+      method.PrepForInvocation();
+
+      Assert.AreEqual(1, method.Parameters.Count());
+    }
+
+    [TestMethod]
+    public void FindChildLegacyUpdate()
+    {
+      var obj = new BasicChild();
+      var method = _systemUnderTest.FindDataPortalMethod<UpdateChildAttribute>(obj, null);
+
+      method.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public void FindChildParamsUpdate()
+    {
+      var obj = new ParamsChild();
+      var method = _systemUnderTest.FindDataPortalMethod<UpdateChildAttribute>(obj, null);
+
+      method.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public async Task FindChildIntUpdate()
+    {
+      var obj = await _diContext.CreateChildDataPortal<ModernChild>().CreateChildAsync();
+      object[] paramsArray = [123];
+      var method = _systemUnderTest.FindDataPortalMethod<UpdateChildAttribute>(obj, paramsArray);
+
+      method.Should().NotBeNull();
+
+      var dp = _diContext.CreateChildDataPortal<ModernChild>();
+      await dp.UpdateChildAsync(obj, 42);
+
+      obj.Id.Should().Be(42);
+
+      obj = await _diContext.CreateChildDataPortal<ModernChild>().CreateChildAsync();
+      await dp.UpdateChildAsync(obj, 123);
+
+      obj.Id.Should().Be(123);
+    }
+
+    [TestMethod]
+    public void FindOverlappingCriteriaInt()
+    {
+      var obj = new MultipleOverlappingCriteria();
+      var method = _systemUnderTest.FindDataPortalMethod<FetchAttribute>(obj, [1]);
+      Assert.IsNotNull(method);
+    }
+
+    [TestMethod]
+    public async Task Issue2109()
+    {
+      var obj = new Issue2109List();
+      var method = _systemUnderTest.FindDataPortalMethod<FetchAttribute>(obj, [new string[] { "a" }]);
+      Assert.IsNotNull(method, "string[]");
+      var criteria = new My2109Criteria();
+      method = _systemUnderTest.FindDataPortalMethod<FetchAttribute>(obj, [criteria]);
+      Assert.IsNotNull(method, "ICriteriaBase");
+
+      var portal = _diContext.CreateDataPortal<Issue2109List>();
+
+      obj = await portal.FetchAsync(new My2109Criteria());
+      obj.Should().NotBeNull("Fetch with criteria.").And.Subject.First().Name.Should().Be("Csla.Test.DataPortal.My2109Criteria");
+
+      obj = await portal.FetchAsync(new string[] { "a" });
+      obj.Should().NotBeNull("Fetch with array.").And.Subject.First().Name.Should().Be("a");
+    }
+
+    [TestMethod]
+    public void Issue2287BusinessBindingListFetch()
+    {
+      var obj = new Issue2287List();
+      var method = _systemUnderTest.FindDataPortalMethod<FetchAttribute>(obj, [new Issue2287List.Criteria()]);
+      Assert.IsNotNull(method);
+      Assert.AreEqual(obj.GetType().BaseType, method.MethodInfo.DeclaringType);
+    }
+
+    [TestMethod]
+    public void Issue2287BusinessBaseFetch()
+    {
+      var obj = new Issue2287Edit();
+      var method = _systemUnderTest.FindDataPortalMethod<CreateAttribute>(obj, []);
+      Assert.IsNotNull(method);
+    }
+
+    [TestMethod]
+    public void Issue2396DeleteSelfChildNoParams()
+    {
+      var obj = new Issue2396Edit();
+      var method = _systemUnderTest.FindDataPortalMethod<DeleteSelfChildAttribute>(obj, []);
+      Assert.IsNotNull(method);
+      Assert.AreEqual(0, method.MethodInfo.GetParameters().Count());
+    }
+
+    [TestMethod]
+    public void Issue2396DeleteSelfChildWithParams()
+    {
+      var obj = new Issue2396EditParams();
+      var method = _systemUnderTest.FindDataPortalMethod<DeleteSelfChildAttribute>(obj, [1, 2]);
+      Assert.IsNotNull(method);
+      Assert.AreEqual(2, method.MethodInfo.GetParameters().Count());
+    }
+
+    [TestMethod]
+    public void Issue2396DeleteSelfChildFallbackToNoParams()
+    {
+      var obj = new Issue2396Edit();
+      var method = _systemUnderTest.FindDataPortalMethod<DeleteSelfChildAttribute>(obj, [1, 2]);
+      Assert.IsNotNull(method);
+      Assert.AreEqual(0, method.MethodInfo.GetParameters().Count());
+    }
+  }
+
+  //
+  // End of test methods, start of support classes
+  //
+
+  public class OldStyleNoOverride : BusinessBase<OldStyleNoOverride>
+  {
+    [Create]
+    private void DataPortal_Create()
+    {
+      BusinessRules.CheckRules();
+    }
+  }
+
+  public class PrivateMethodBase<T> : CommandBase<T>
+  where T : CommandBase<T>
+  {
+    [Create]
+    private void Create()
+    { }
+
+    [Execute]
+    private void Execute()
+    { }
+  }
+
+  public class PrivateMethod : PrivateMethodBase<PrivateMethod>
+  {
+
+  }
+
+  public class OldStyleCreate : BusinessBase<OldStyleCreate>
+  {
+    [Create]
+    protected void DataPortal_Create()
+    {
+      BusinessRules.CheckRules();
+    }
+
+    [Create]
+    private void DataPortal_Create(int id)
+    {
+      BusinessRules.CheckRules();
+    }
+  }
+
+  public class OldStyleCriteria : BusinessBase<OldStyleCriteria>
+  {
+    [Create]
+    private void DataPortal_Create(int id)
+    {
+      BusinessRules.CheckRules();
+    }
+  }
+
+  public class OldStyleCriteriaBase : OldStyleCriteria
+  {
+  }
+
+  public interface ICriteria : IReadOnlyBase
+  {
+    int Id { get; }
+  }
+
+  public class MyCriteria : ReadOnlyBase<MyCriteria>, ICriteria
+  {
+    public int Id => 123;
+  }
+
+  public class InterfaceCriteria : BusinessBase<InterfaceCriteria>
+  {
+    [Create]
+    private void Create(ICriteria criteria) { _ = criteria; }
+  }
+
+  public class SimpleNoCriteriaCreate : BusinessBase<SimpleNoCriteriaCreate>
+  {
+    [Create]
+    private void Create() { }
+
+    [Create]
+    private void Create(ICloneable x) { }
+  }
+
+  public class SimpleCriteriaCreate : BusinessBase<SimpleCriteriaCreate>
+  {
+    [Create]
+    private void Create(int id) { }
+  }
+
+  public class ObjectCriteriaCreate : BusinessBase<ObjectCriteriaCreate>
+  {
+    [Create]
+    private void Create(object id) { }
+  }
+
+  public class ObjectCriteriaCreateSubtype : ObjectCriteriaCreate
+  { }
+
+  public class AmbiguousNoCriteriaCreate : BusinessBase<AmbiguousNoCriteriaCreate>
+  {
+    [Create]
+    private void Create() { }
+
+    [Create]
+    private void Create([Inject] ICloneable x) { }
+  }
+
+  public class CriteriaCreateWithDI : BusinessBase<CriteriaCreateWithDI>
+  {
+    [Create]
+    private void Create() { }
+
+    [Create]
+    private void Create(int id, [Inject] ICloneable x) { }
+  }
+
+  public class MultipleCriteriaCreateWithDI : BusinessBase<MultipleCriteriaCreateWithDI>
+  {
+    [Create]
+    private void Create() { }
+
+    [Create]
+    private void Create(int id, string foo, [Inject] ICloneable x) { }
+  }
+
+  public class CriteriaCreateWithMultipleDI : BusinessBase<CriteriaCreateWithMultipleDI>
+  {
+    [Create]
+    private void Create(int id, [Inject] ICloneable x) { }
+
+    [Create]
+    private void Create(int id, [Inject] ICloneable x, [Inject] IAsyncResult y) { }
+  }
+
+  public class CriteriaCreateWithMultipleAmbiguousDI : BusinessBase<CriteriaCreateWithMultipleAmbiguousDI>
+  {
+    [Create]
+    private void Create(int id, [Inject] ICloneable x) { }
+
+    [Create]
+    private void Create(int id, [Inject] ICloneable x, [Inject] IAsyncResult y) { }
+
+    [Create]
+    private void Create(int id, [Inject] ICloneable x, [Inject] IFormattable y) { }
+  }
+
+  public class MultipleCriteriaCreateWithDIInterleaved : BusinessBase<MultipleCriteriaCreateWithDIInterleaved>
+  {
+    [Create]
+    private void Create() { }
+
+    [Create]
+    private void Create(int id, [Inject] ICloneable x, string foo) { }
+  }
+
+  public class BasicChild : BusinessBase<BasicChild>
+  {
+    private void Child_Update()
+    {
+      // nada
+    }
+  }
+
+  public class ParamsChild : BusinessBase<ParamsChild>
+  {
+    private void Child_Update(params object[] parameters)
+    {
+      // nada
+    }
+  }
+
+  public class ModernChild : BusinessBase<ModernChild>
+  {
+    public static readonly PropertyInfo<int> IdProperty = RegisterProperty<int>(nameof(Id));
+    public int Id
+    {
+      get { return GetProperty(IdProperty); }
+      set { SetProperty(IdProperty, value); }
+    }
+
+    [UpdateChild]
+    [InsertChild]
+    private void UpdateOrInsert(int id)
+    {
+      using (BypassPropertyChecks)
+        Id = id;
+    }
+  }
+
+  public class NullableCriteria : BusinessBase<NullableCriteria>
+  {
+    [Create]
+    private void Create(int? c) { _ = c; }
+  }
+
+  public class MultipleOverlappingCriteria : BusinessBase<MultipleOverlappingCriteria>
+  {
+    [Fetch]
+    private void Fetch(int id)
+    {
+    }
+
+    [Fetch]
+    private void Fetch(int id, bool? value)
+    {
+    }
+
+    [Fetch]
+    private void Fetch(int id, int? value)
+    {
+    }
+
+    [Fetch]
+    private void Fetch(List<int?> values)
+    {
+    }
+
+    [Fetch]
+    private void Fetch(List<DateTime?> values)
+    {
+    }
+  }
+
+  public class Issue2109List : ReadOnlyListBase<Issue2109List, Issue2109>
+  {
+    private void DataPortal_Fetch(ICriteriaBase criteria, [Inject] IDataPortal<Issue2109> dp)
+    {
+      using (LoadListMode)
+      {
+        Add(dp.Fetch(criteria.ToString()));
+      }
+    }
+
+    private void DataPortal_Fetch(IEnumerable<string> criteria, [Inject] IDataPortal<Issue2109> dp)
+    {
+      using (LoadListMode)
+      {
+        Add(dp.Fetch(criteria.First().ToString()));
+      }
+    }
+  }
+
+  public class Issue2109 : BusinessBase<Issue2109>
+  {
+    public static readonly PropertyInfo<string> NameProperty = RegisterProperty<string>(nameof(Name));
+    public string Name
+    {
+      get => GetProperty(NameProperty);
+      set => SetProperty(NameProperty, value);
+    }
+
+    private void DataPortal_Fetch(string name)
+    {
+      using (BypassPropertyChecks)
+      {
+        Name = name;
+      }
+    }
+  }
+
+  public interface ICriteriaBase
+  { }
+
+  public class My2109Criteria : ICriteriaBase
+  {
+  }
+
+  public class Issue2287List : Issue2287ListBase
+  {
+  }
+
+  public class Issue2287ListBase : Csla.BusinessBindingListBase<Issue2287List, Issue2287Edit>
+  {
+    private void DataPortal_Fetch(Criteria criteria)
+    {
+    }
+
+    public class Criteria : Csla.CriteriaBase<Criteria>
+    {
+    }
+  }
+
+  public class Issue2287Edit : Issue2287EditBase<Issue2287Edit>
+  {
+    private new void DataPortal_Create()
+    {
+      BusinessRules.CheckRules();
+    }
+  }
+
+  public class Issue2287EditBase<T> : BusinessBase<Issue2287EditBase<T>>
+  {
+    protected void DataPortal_Create()
+    {
+    }
+  }
+
+  public class Issue2396Edit : BusinessBase<Issue2396Edit>
+  {
+    [DeleteSelfChild]
+    private void DeleteSelf()
+    { }
+  }
+
+  public class Issue2396EditParams : BusinessBase<Issue2396EditParams>
+  {
+    [DeleteSelfChild]
+    private void DeleteSelf(int x, int y)
+    { }
+  }
+}

--- a/Source/csla.netcore.test/DataPortal/ServiceProviderMethodCallerTests.cs
+++ b/Source/csla.netcore.test/DataPortal/ServiceProviderMethodCallerTests.cs
@@ -356,11 +356,21 @@ namespace Csla.Test.DataPortal
       Assert.IsNotNull(method);
       Assert.AreEqual(0, method.MethodInfo.GetParameters().Count());
     }
+
+    [TestMethod($"{nameof(ServiceProviderMethodCaller.TryFindDataPortalMethod)} must not throw when the business object is attributed with an object factory which is not loaded/known in the current environment."), GitHubWorkItem("https://github.com/MarimerLLC/csla/issues/4681")]
+    public void TryFindDataPortalMethod_Testcase1()
+    {
+      FluentActions.Invoking(() => _systemUnderTest.TryFindDataPortalMethod<FetchAttribute>(typeof(NotKnownObjectFactoryInCurrentEnvironment), null, out var _)).Should().NotThrow();
+    }
   }
 
-  //
-  // End of test methods, start of support classes
-  //
+  #region Classes for testing various scenarios of loading/finding data portal methods
+
+  [Csla.Server.ObjectFactory("NotLoadedAssembly.NotKnownObjectFactoryInCurrentEnvironmentFactory, NotLoadedAssembly")]
+  public class NotKnownObjectFactoryInCurrentEnvironment : BusinessBase<NotKnownObjectFactoryInCurrentEnvironment>
+  {
+
+  }
 
   public class OldStyleNoOverride : BusinessBase<OldStyleNoOverride>
   {
@@ -668,4 +678,6 @@ namespace Csla.Test.DataPortal
     private void DeleteSelf(int x, int y)
     { }
   }
+
+  #endregion
 }

--- a/Source/csla.netcore.test/csla.netcore.test.csproj
+++ b/Source/csla.netcore.test/csla.netcore.test.csproj
@@ -16,6 +16,11 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.9.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.9.1" />
+    <PackageReference Include="AwesomeAssertions" Version="8.2.0" />
+    <PackageReference Include="AwesomeAssertions.Analyzers" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/csla.netcore.test/csla.netcore.test.csproj
+++ b/Source/csla.netcore.test/csla.netcore.test.csproj
@@ -13,9 +13,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`TryFind*` method must not throw and instead return `false`.

Closes #4681 