### PR TITLE
Add Option to disable RevalidationInterceptor for Delete operation

### DIFF
--- a/Source/Csla.TestHelpers/TestDIContextFactory.cs
+++ b/Source/Csla.TestHelpers/TestDIContextFactory.cs
@@ -25,7 +25,7 @@ namespace Csla.TestHelpers
     /// Create a test DI context for testing with a default authenticated user
     /// </summary>
     /// <returns>A TestDIContext that can be used to perform testing dependent upon DI</returns>
-    public static TestDIContext CreateDefaultContext()
+    public static TestDIContext CreateDefaultContext(Action<IServiceCollection> configureServices = null)
     {
       ClaimsPrincipal principal;
 
@@ -33,7 +33,7 @@ namespace Csla.TestHelpers
       principal = CreateDefaultClaimsPrincipal();
 
       // Delegate to the other overload to create the context
-      return CreateContext(principal);
+      return CreateContext(principal, configureServices);
     }
 
     /// <summary>
@@ -41,9 +41,9 @@ namespace Csla.TestHelpers
     /// </summary>
     /// <param name="principal">The principal which is to be set as the security context for Csla operations</param>
     /// <returns>A TestDIContext that can be used to perform testing dependent upon DI</returns>
-    public static TestDIContext CreateContext(ClaimsPrincipal principal)
+    public static TestDIContext CreateContext(ClaimsPrincipal principal, Action<IServiceCollection> configureServices = null)
     {
-      return CreateContext(null, principal);
+      return CreateContext(null, principal, configureServices);
     }
 
     /// <summary>
@@ -65,7 +65,7 @@ namespace Csla.TestHelpers
     /// <param name="customCslaOptions">The options action that is used by the consumer to configure Csla</param>
     /// <param name="principal">The principal which is to be set as the security context for Csla operations</param>
     /// <returns>A TestDIContext that can be used to perform testing dependent upon DI</returns>
-    public static TestDIContext CreateContext(Action<CslaOptions> customCslaOptions, ClaimsPrincipal principal)
+    public static TestDIContext CreateContext(Action<CslaOptions> customCslaOptions, ClaimsPrincipal principal, Action<IServiceCollection> configureServices = null)
     {
       IServiceProvider serviceProvider;
       ApplicationContext context;
@@ -77,6 +77,7 @@ namespace Csla.TestHelpers
       services.TryAddSingleton<Server.Dashboard.IDashboard, Server.Dashboard.Dashboard>();
       services.AddSingleton<Core.IContextManager, ApplicationContextManagerUnitTests>();
       services.AddCsla(customCslaOptions);
+      configureServices?.Invoke(services);
 
       serviceProvider = services.BuildServiceProvider();
 

--- a/Source/Csla/Configuration/Fluent/DataPortalConfigurationExtensions.cs
+++ b/Source/Csla/Configuration/Fluent/DataPortalConfigurationExtensions.cs
@@ -8,6 +8,7 @@
 
 using Csla.DataPortalClient;
 using Csla.Server;
+using Csla.Server.Interceptors.ServerSide;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -100,6 +101,7 @@ namespace Csla.Configuration
       services.TryAddTransient(typeof(IChildDataPortal<>), typeof(DataPortal<>));
       services.TryAddTransient<IDataPortalFactory, DataPortalFactory>();
       services.TryAddTransient<IChildDataPortalFactory, ChildDataPortalFactory>();
+      services.AddOptions<RevalidatingInterceptorOptions>();
 
       services.TryAddScoped(typeof(IAuthorizeDataPortal), config.DataPortalOptions.DataPortalServerOptions.AuthorizerProviderType);
       foreach (Type interceptorType in config.DataPortalOptions.DataPortalServerOptions.InterceptorProviders)

--- a/Source/Csla/Csla.csproj
+++ b/Source/Csla/Csla.csproj
@@ -61,6 +61,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />
@@ -85,6 +86,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+  <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net8.0'">
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
@@ -94,6 +96,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+  <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
@@ -103,6 +106,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="Polyfill" Version="7.4.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Source/Csla/Server/Interceptors/ServerSide/RevalidatingInterceptorOptions.cs
+++ b/Source/Csla/Server/Interceptors/ServerSide/RevalidatingInterceptorOptions.cs
@@ -1,0 +1,21 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RevalidatingInterceptorOptions.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>Initiates revalidation on business objects during data portal operations</summary>
+//-----------------------------------------------------------------------
+
+namespace Csla.Server.Interceptors.ServerSide
+{
+  /// <summary>
+  /// Options for <see cref="RevalidatingInterceptor"/>.
+  /// </summary>
+  public class RevalidatingInterceptorOptions
+  {
+    /// <summary>
+    /// Indicates whether the <see cref="RevalidatingInterceptor"/> should not re-validate business objects during a <see cref="DataPortalOperations.Delete"/> operation.
+    /// </summary>
+    public bool IgnoreDeleteOperation { get; set; }
+  }
+}

--- a/docs/Upgrading to CSLA 10.md
+++ b/docs/Upgrading to CSLA 10.md
@@ -12,7 +12,7 @@ TBD
 
 ## RevalidatingInterceptor
 
-The constructor has changed and now expects an `IOptions<IOptions<RevalidatingInterceptorOptions>>` instance. With this new options object it is now possible to skip the revalidation of business rules during a `Delete` operation.
+The constructor has changed and now expects an `IOptions<RevalidatingInterceptorOptions>` instance. With this new options object it is now possible to skip the revalidation of business rules during a `Delete` operation.
 To configure the new options we are using the .Net [Options pattern](https://learn.microsoft.com/en-us/dotnet/core/extensions/options).
 ```csharp
 services.Configure<RevalidatingInterceptorOptions>(opts =>

--- a/docs/Upgrading to CSLA 10.md
+++ b/docs/Upgrading to CSLA 10.md
@@ -13,7 +13,7 @@ TBD
 ## RevalidatingInterceptor
 
 The constructor has changed and now expects an `IOptions<IOptions<RevalidatingInterceptorOptions>>` instance. With this new options object it is now possible to skip the revalidation of business rules during a `Delete` operation.
-To configure the new options we are using the .Net [Options pattern](https://learn.microsoft.com/en-us/dotnet/core/extensions/options) (it's not ASP.Net core specific!).
+To configure the new options we are using the .Net [Options pattern](https://learn.microsoft.com/en-us/dotnet/core/extensions/options).
 ```csharp
 services.Configure<RevalidatingInterceptorOptions>(opts =>
 {

--- a/docs/Upgrading to CSLA 10.md
+++ b/docs/Upgrading to CSLA 10.md
@@ -13,7 +13,7 @@ TBD
 ## RevalidatingInterceptor
 
 The constructor has changed and now expects an `IOptions<IOptions<RevalidatingInterceptorOptions>>` instance. With this new options object it is now possible to skip the revalidation of business rules during a `Delete` operation.
-To configure the new options we are using the .Net [Options pattern](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/options?view=aspnetcore-9.0) (it's not ASP.Net core specific!).
+To configure the new options we are using the .Net [Options pattern](https://learn.microsoft.com/en-us/dotnet/core/extensions/options) (it's not ASP.Net core specific!).
 ```csharp
 services.Configure<RevalidatingInterceptorOptions>(opts =>
 {

--- a/docs/Upgrading to CSLA 10.md
+++ b/docs/Upgrading to CSLA 10.md
@@ -10,6 +10,18 @@ If you are upgrading from a version of CSLA prior to 8, you should review the [U
 
 TBD
 
+## RevalidatingInterceptor
+
+The constructor has changed and now expects an `IOptions<IOptions<RevalidatingInterceptorOptions>>` instance. With this new options object it is now possible to skip the revalidation of business rules during a `Delete` operation.
+To configure the new options we are using the .Net [Options pattern](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/options?view=aspnetcore-9.0) (it's not ASP.Net core specific!).
+```csharp
+services.Configure<RevalidatingInterceptorOptions>(opts =>
+{
+  opts.IgnoreDeleteOperation = true;
+});
+```
+
+
 ## Nullable Reference Types
 
 CSLA 10 supports the use of nullable reference types in your code. This means that you can use the `#nullable enable` directive in your code and the compiler will now tell you where CSLA does not expect any `null` values or returns `null`.


### PR DESCRIPTION
Adds a new option class `RevalidatingInterceptorOptions` which can be configured through the [Options pattern](https://learn.microsoft.com/en-us/dotnet/core/extensions/options).

With this new option it's possible to suppress/avoid the revalidation of objects when performing a `Delete` operation.