### PR TITLE
Add csproj property to enable building .net framework projects on linux.

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -4,6 +4,7 @@
    <ImplicitUsings>enable</ImplicitUsings>
    <Nullable>enable</Nullable>
    <WarningsAsErrors>nullable</WarningsAsErrors>
+   <EnableWindowsTargeting>true</EnableWindowsTargeting>
  </PropertyGroup>
  
  <!-- Common Package Settings -->


### PR DESCRIPTION
Add csproj property to enable building .net framework projects on linux.
c.f. https://learn.microsoft.com/en-us/dotnet/core/tools/sdk-errors/netsdk1100