### PR TITLE
Remove Backport.System.Threading.Lock dependency

### DIFF
--- a/Source/Csla.Analyzers/Csla.Analyzers/Csla.Analyzers.csproj
+++ b/Source/Csla.Analyzers/Csla.Analyzers/Csla.Analyzers.csproj
@@ -41,11 +41,4 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Backport.System.Threading.Lock" Version="3.1.4" />
-    <Using Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Alias="Lock" Include="System.Threading.Lock" />
-    <Using Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Alias="Lock" Include="Backport.System.Threading.Lock" />
-    <Using Alias="LockFactory" Include="Backport.System.Threading.LockFactory" />
-  </ItemGroup>
-
 </Project>

--- a/Source/Csla.Channels.RabbitMq/Csla.Channels.RabbitMq.csproj
+++ b/Source/Csla.Channels.RabbitMq/Csla.Channels.RabbitMq.csproj
@@ -26,11 +26,4 @@
     <ProjectReference Include="..\Csla\Csla.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Backport.System.Threading.Lock" Version="3.1.4" />
-    <Using Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Alias="Lock" Include="System.Threading.Lock" />
-    <Using Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Alias="Lock" Include="Backport.System.Threading.Lock" />
-    <Using Alias="LockFactory" Include="Backport.System.Threading.LockFactory" />
-  </ItemGroup>
-
 </Project>

--- a/Source/Csla.Channels.RabbitMq/ProxyListener.cs
+++ b/Source/Csla.Channels.RabbitMq/ProxyListener.cs
@@ -109,7 +109,11 @@ namespace Csla.Channels.RabbitMq
     }
 
     private volatile bool IsListening;
-    private readonly Lock ListeningLock = LockFactory.Create();
+#if NET9_0_OR_GREATER
+    private readonly Lock ListeningLock = new();
+#else
+    private readonly object ListeningLock = new();
+#endif
 
     public async Task StartListening()
     {

--- a/Source/Csla.Generators/cs/AutoImplementProperties/Csla.Generator.AutoImplementProperties.Attributes.CSharp/Csla.Generator.AutoImplementProperties.Attributes.CSharp.csproj
+++ b/Source/Csla.Generators/cs/AutoImplementProperties/Csla.Generator.AutoImplementProperties.Attributes.CSharp/Csla.Generator.AutoImplementProperties.Attributes.CSharp.csproj
@@ -18,11 +18,4 @@
     <DelaySign>false</DelaySign>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Backport.System.Threading.Lock" Version="3.1.4" />
-    <Using Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Alias="Lock" Include="System.Threading.Lock" />
-    <Using Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Alias="Lock" Include="Backport.System.Threading.Lock" />
-    <Using Alias="LockFactory" Include="Backport.System.Threading.LockFactory" />
-  </ItemGroup>
 </Project>

--- a/Source/Csla.Generators/cs/AutoImplementProperties/Csla.Generator.AutoImplementProperties.CSharp/Csla.Generator.AutoImplementProperties.CSharp.csproj
+++ b/Source/Csla.Generators/cs/AutoImplementProperties/Csla.Generator.AutoImplementProperties.CSharp/Csla.Generator.AutoImplementProperties.CSharp.csproj
@@ -39,8 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Csla.Generator.AutoImplementProperties.Attributes.CSharp\Csla.Generator.AutoImplementProperties.Attributes.CSharp.csproj" 
-                      PrivateAssets="All"/>
+    <ProjectReference Include="..\Csla.Generator.AutoImplementProperties.Attributes.CSharp\Csla.Generator.AutoImplementProperties.Attributes.CSharp.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
@@ -48,10 +47,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Backport.System.Threading.Lock" Version="3.1.4" />
-    <Using Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Alias="Lock" Include="System.Threading.Lock" />
-    <Using Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Alias="Lock" Include="Backport.System.Threading.Lock" />
-    <Using Alias="LockFactory" Include="Backport.System.Threading.LockFactory" />
   </ItemGroup>
 
 </Project>

--- a/Source/Csla.Generators/cs/AutoSerialization/Csla.Generator.AutoSerialization.Attributes.CSharp/Csla.Generator.AutoSerialization.Attributes.CSharp.csproj
+++ b/Source/Csla.Generators/cs/AutoSerialization/Csla.Generator.AutoSerialization.Attributes.CSharp/Csla.Generator.AutoSerialization.Attributes.CSharp.csproj
@@ -17,11 +17,4 @@
     <DelaySign>false</DelaySign>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Backport.System.Threading.Lock" Version="3.1.4" />
-    <Using Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Alias="Lock" Include="System.Threading.Lock" />
-    <Using Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Alias="Lock" Include="Backport.System.Threading.Lock" />
-    <Using Alias="LockFactory" Include="Backport.System.Threading.LockFactory" />
-  </ItemGroup>
 </Project>

--- a/Source/Csla.Generators/cs/AutoSerialization/Csla.Generator.AutoSerialization.CSharp/Csla.Generator.AutoSerialization.CSharp.csproj
+++ b/Source/Csla.Generators/cs/AutoSerialization/Csla.Generator.AutoSerialization.CSharp/Csla.Generator.AutoSerialization.CSharp.csproj
@@ -38,8 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Csla.Generator.AutoSerialization.Attributes.CSharp\Csla.Generator.AutoSerialization.Attributes.CSharp.csproj" 
-                      PrivateAssets="All" />
+    <ProjectReference Include="..\Csla.Generator.AutoSerialization.Attributes.CSharp\Csla.Generator.AutoSerialization.Attributes.CSharp.csproj" PrivateAssets="All" />
   </ItemGroup>
   
   <ItemGroup>
@@ -47,10 +46,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Backport.System.Threading.Lock" Version="3.1.4" />    
-    <Using Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Alias="Lock" Include="System.Threading.Lock" />
-    <Using Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Alias="Lock" Include="Backport.System.Threading.Lock" />
-    <Using Alias="LockFactory" Include="Backport.System.Threading.LockFactory" />
   </ItemGroup>
 
 </Project>

--- a/Source/Csla/ApplicationContext.cs
+++ b/Source/Csla/ApplicationContext.cs
@@ -106,7 +106,11 @@ namespace Csla
       }
     }
 
-    private readonly Lock _syncContext = LockFactory.Create();
+#if NET9_0_OR_GREATER
+    private readonly Lock _syncContext = new();
+#else
+    private readonly object _syncContext = new();
+#endif
 
     /// <summary>
     /// Returns the application-specific context data provided

--- a/Source/Csla/Core/BusinessBase.cs
+++ b/Source/Csla/Core/BusinessBase.cs
@@ -3849,7 +3849,11 @@ namespace Csla.Core
     protected internal class BypassPropertyChecksObject : IDisposable
     {
       private BusinessBase? _businessObject;
-      private static Lock _lock = LockFactory.Create();
+#if NET9_0_OR_GREATER
+      private static Lock _lock = new();
+#else
+      private static object _lock = new();
+#endif
 
       internal BypassPropertyChecksObject(BusinessBase businessObject)
       {

--- a/Source/Csla/Core/FieldManager/PropertyInfoManager.cs
+++ b/Source/Csla/Core/FieldManager/PropertyInfoManager.cs
@@ -36,7 +36,11 @@ namespace Csla.Core.FieldManager
   /// </summary>
   public static class PropertyInfoManager
   {
-    private static readonly Lock _cacheLock = LockFactory.Create();
+#if NET9_0_OR_GREATER
+    private static readonly Lock _cacheLock = new();
+#else
+    private static readonly object _cacheLock = new();
+#endif
 
 #if NET8_0_OR_GREATER
     private static ConcurrentDictionary<Type, Tuple<string?, PropertyInfoList>>? _propertyInfoCache;

--- a/Source/Csla/Core/LoadManager/AsyncLoadManager.cs
+++ b/Source/Csla/Core/LoadManager/AsyncLoadManager.cs
@@ -23,7 +23,12 @@ namespace Csla.Core.LoadManager
 
     }
 
-    private Lock _syncRoot = LockFactory.Create();
+#if NET9_0_OR_GREATER
+    private Lock _syncRoot = new();
+#else
+    private object _syncRoot = new();
+#endif
+
     private readonly ObservableCollection<IAsyncLoader> _loading = [];
 
     public bool IsLoading

--- a/Source/Csla/Csla.csproj
+++ b/Source/Csla/Csla.csproj
@@ -138,11 +138,5 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Backport.System.Threading.Lock" Version="3.1.4" />    
-    <Using Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Alias="Lock" Include="System.Threading.Lock" />
-    <Using Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Alias="Lock" Include="Backport.System.Threading.Lock" />
-    <Using Alias="LockFactory" Include="Backport.System.Threading.LockFactory" />
-  </ItemGroup>
 
 </Project>

--- a/Source/Csla/LazySingleton.cs
+++ b/Source/Csla/LazySingleton.cs
@@ -9,7 +9,11 @@ namespace Csla
   public sealed class LazySingleton<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T> : Core.IUseApplicationContext
     where T : class
   {
-    private readonly Lock _syncRoot = LockFactory.Create();
+#if NET9_0_OR_GREATER
+    private readonly Lock _syncRoot = new();
+#else
+    private readonly object _syncRoot = new();
+#endif
     private T? _value;
     private readonly Func<T> _delegate;
 

--- a/Source/Csla/Rules/BrokenRulesCollection.cs
+++ b/Source/Csla/Rules/BrokenRulesCollection.cs
@@ -23,7 +23,11 @@ namespace Csla.Rules
   [Serializable]
   public class BrokenRulesCollection : Core.ReadOnlyObservableBindingList<BrokenRule>
   {
-    private Lock _syncRoot = LockFactory.Create();
+#if NET9_0_OR_GREATER
+    private Lock _syncRoot = new();
+#else
+    private object _syncRoot = new();
+#endif
 
 
     /// <summary>

--- a/Source/Csla/Rules/BusinessRules.cs
+++ b/Source/Csla/Rules/BusinessRules.cs
@@ -42,8 +42,13 @@ namespace Csla.Rules
       _target = target ?? throw new ArgumentNullException(nameof(target));
     }
 
+#if NET9_0_OR_GREATER
     [NonSerialized]
-    private Lock _syncRoot = LockFactory.Create();
+    private Lock _syncRoot = new();
+#else
+    [NonSerialized]
+    private object _syncRoot = new();
+#endif
 
     private ApplicationContext _applicationContext;
 
@@ -1306,7 +1311,7 @@ namespace Csla.Rules
     [System.Runtime.Serialization.OnDeserialized]
     private void OnDeserializedHandler(System.Runtime.Serialization.StreamingContext context)
     {
-      _syncRoot = LockFactory.Create();
+      _syncRoot = new();
     }
 
     #endregion

--- a/Source/tests/GraphMergerTest/GraphMergerTest.Dal/GraphMergerTest.Dal.csproj
+++ b/Source/tests/GraphMergerTest/GraphMergerTest.Dal/GraphMergerTest.Dal.csproj
@@ -8,11 +8,4 @@
     <PackageReference Include="System.Memory.Data" Version="8.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Backport.System.Threading.Lock" Version="3.1.4" />
-    <Using Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Alias="Lock" Include="System.Threading.Lock" />
-    <Using Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Alias="Lock" Include="Backport.System.Threading.Lock" />
-    <Using Alias="LockFactory" Include="Backport.System.Threading.LockFactory" />
-  </ItemGroup>  
 </Project>


### PR DESCRIPTION
Removes the `Backport.System.Threading.Lock` dependency from `Csla` to avoid shipping it as a source generator to consumers.

Closes #4450 