### PR TITLE
Changed: Child DataPortalException uses inner exception?

### DIFF
--- a/Source/Csla/Reflection/ServiceProviderMethodCaller.cs
+++ b/Source/Csla/Reflection/ServiceProviderMethodCaller.cs
@@ -595,12 +595,7 @@ namespace Csla.Reflection
       }
       catch (Exception ex)
       {
-        Exception? inner;
-        if (ex.InnerException == null)
-          inner = ex;
-        else
-          inner = ex.InnerException;
-        throw new CallMethodException(obj.GetType().Name + "." + info.Name + " " + Resources.MethodCallFailed, inner);
+        throw new CallMethodException(obj.GetType().Name + "." + info.Name + " " + Resources.MethodCallFailed, ex);
       }
     }
 #if NET8_0_OR_GREATER


### PR DESCRIPTION
I added a test to verify the top most exception is used as BusinessException.

Remove exception unpacking in ServiceProviderMethodCaller
Add test to verify the top most customer exception is not discarded and replaced by the inner exception.

Fixes #4748