### PR TITLE
Fix: Deleted childs in a list lose their parents after being deserialized

### DIFF
--- a/Source/Csla/BusinessBindingListBase.cs
+++ b/Source/Csla/BusinessBindingListBase.cs
@@ -690,6 +690,17 @@ namespace Csla
       base.OnSetChildren(info, formatter);
     }
 
+    /// <inheritdoc/>
+    protected override void Deserialized()
+    {
+      base.Deserialized();
+
+      foreach (var item in DeletedList)
+      {
+        item.SetParent(this);
+      }
+    }
+
     #endregion
 
     #region IsChild

--- a/Source/Csla/BusinessListBase.cs
+++ b/Source/Csla/BusinessListBase.cs
@@ -734,6 +734,17 @@ namespace Csla
       base.OnSetChildren(info, formatter);
     }
 
+    /// <inheritdoc/>
+    protected override void Deserialized()
+    {
+      base.Deserialized();
+
+      foreach (var item in DeletedList)
+      {
+        item.SetParent(this);
+      }
+    }
+
     #endregion
 
     #region IsChild

--- a/Source/tests/Csla.test/Basic/Children.cs
+++ b/Source/tests/Csla.test/Basic/Children.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.Data;
+using Csla.Core;
 
 namespace Csla.Test.Basic
 {
@@ -37,6 +38,8 @@ namespace Csla.Test.Basic
     {
       get { return DeletedList.Count; }
     }
+
+    public MobileList<Child> DeletedItems => DeletedList;
 
     [Create]
     private void Create()

--- a/Source/tests/Csla.test/BusinessListBase/BusinessBindingListBaseTests.cs
+++ b/Source/tests/Csla.test/BusinessListBase/BusinessBindingListBaseTests.cs
@@ -1,0 +1,65 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="BusinessBindingListBaseTests.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>no summary</summary>
+//-----------------------------------------------------------------------
+
+using Csla.Serialization;
+using Csla.TestHelpers;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Csla.Test.BusinessListBase
+{
+  [TestClass]
+  public class BusinessBindingListBaseTests
+  {
+    private static TestDIContext _testDIContext;
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext context)
+    {
+      _testDIContext = TestDIContextFactory.CreateDefaultContext();
+    }
+
+    [TestMethod]
+    public async Task Parent_LocationTransferWithDeletedItemsMustSetParentOnDeletedItems()
+    {
+      var root = CreateRoot();
+
+      for (int i = 0; i < 5; i++)
+      {
+        root.Children.AddNew();
+      }
+
+      root = await root.SaveAsync();
+      root.Children.Clear();
+
+      var transferredGraph = SimulateLocationTransfer(root);
+
+      using (new AssertionScope())
+      {
+        transferredGraph.Children.Parent.Should().BeSameAs(transferredGraph);
+        transferredGraph.Children.DeletedItems.Should().AllSatisfy(c => c.Parent.Should().BeSameAs(transferredGraph.Children));
+      }
+
+
+      static Basic.Root SimulateLocationTransfer(Basic.Root original)
+      {
+        var serializer = _testDIContext.ServiceProvider.GetRequiredService<ISerializationFormatter>();
+        return (Basic.Root)serializer.Deserialize(serializer.Serialize(original));
+      }
+    }
+
+    private static Basic.Root CreateRoot()
+    {
+      var dataPortal = _testDIContext.CreateDataPortal<Basic.Root>();
+
+      return dataPortal.Create(new Basic.Root.Criteria("Random"));
+    }
+  }
+}

--- a/Source/tests/Csla.test/BusinessListBase/ChildList.cs
+++ b/Source/tests/Csla.test/BusinessListBase/ChildList.cs
@@ -6,8 +6,13 @@
 // <summary>no summary</summary>
 //-----------------------------------------------------------------------
 
+using Csla.Core;
+
 namespace Csla.Test.BusinessListBase
 {
   [Serializable]
-  public class ChildList : BusinessListBase<ChildList, Child>;
+  public class ChildList : BusinessListBase<ChildList, Child>
+  {
+    public MobileList<Child> DeletedItems => DeletedList;
+  }
 }


### PR DESCRIPTION
Ensure parent is set for deleted items in BusinessListBase and BusinessBindingListBase.
I reverted some changes done in #3955 

Fixes #4761

