### PR TITLE
Add ICslaObject constraint to IDataPortal<T> and IChildDataPortal<T>

### DIFF
--- a/Source/Csla/DataPortalClient/DataPortalFactory.cs
+++ b/Source/Csla/DataPortalClient/DataPortalFactory.cs
@@ -9,6 +9,7 @@
 using Microsoft.Extensions.DependencyInjection;
 
 using System.Diagnostics.CodeAnalysis;
+using Csla.Core;
 
 namespace Csla.DataPortalClient
 {
@@ -35,6 +36,7 @@ namespace Csla.DataPortalClient
     /// </summary>
     /// <typeparam name="T">Root business object type</typeparam>
     public IDataPortal<T> GetPortal<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>()
+      where T : ICslaObject
     {
       return (IDataPortal<T>)_serviceProvider.GetRequiredService(typeof(IDataPortal<T>));
     }

--- a/Source/Csla/IChildDataPortalFactory.cs
+++ b/Source/Csla/IChildDataPortalFactory.cs
@@ -6,6 +6,7 @@
 // <summary>Implements a data portal service</summary>
 //-----------------------------------------------------------------------
 using System.Diagnostics.CodeAnalysis;
+using Csla.Core;
 
 namespace Csla
 {
@@ -20,6 +21,7 @@ namespace Csla
     /// Get a child data portal instance.
     /// </summary>
     /// <typeparam name="T">Child business object type</typeparam>
-    IChildDataPortal<T> GetPortal<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>();
+    IChildDataPortal<T> GetPortal<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>()
+      where T : ICslaObject;
   }
 }

--- a/Source/Csla/IChildDataPortalT.cs
+++ b/Source/Csla/IChildDataPortalT.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.Diagnostics.CodeAnalysis;
+using Csla.Core;
 
 namespace Csla
 {
@@ -15,6 +16,7 @@ namespace Csla
   /// </summary>
   /// <typeparam name="T"></typeparam>
   public interface IChildDataPortal<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>
+    where T : ICslaObject
   {
     /// <summary>
     /// Starts an asynchronous data portal operation to

--- a/Source/Csla/IDataPortalFactory.cs
+++ b/Source/Csla/IDataPortalFactory.cs
@@ -6,6 +6,7 @@
 // <summary>Implements a data portal service</summary>
 //-----------------------------------------------------------------------
 using System.Diagnostics.CodeAnalysis;
+using Csla.Core;
 
 namespace Csla
 {
@@ -20,6 +21,7 @@ namespace Csla
     /// Get a client-side data portal instance.
     /// </summary>
     /// <typeparam name="T">Root business object type</typeparam>
-    IDataPortal<T> GetPortal<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>();
+    IDataPortal<T> GetPortal<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>()
+      where T : ICslaObject;
   }
 }

--- a/Source/Csla/IDataPortalT.cs
+++ b/Source/Csla/IDataPortalT.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.Diagnostics.CodeAnalysis;
+using Csla.Core;
 
 namespace Csla
 {
@@ -15,6 +16,7 @@ namespace Csla
   /// </summary>
   /// <typeparam name="T"></typeparam>
   public interface IDataPortal<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>
+    where T : ICslaObject
   {
     /// <summary>
     /// Starts an asynchronous data portal operation to

--- a/Source/Csla/Server/ChildDataPortalFactory.cs
+++ b/Source/Csla/Server/ChildDataPortalFactory.cs
@@ -7,7 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.Diagnostics.CodeAnalysis;
-
+using Csla.Core;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Csla.Server
@@ -35,6 +35,7 @@ namespace Csla.Server
     /// </summary>
     /// <typeparam name="T">Root business object type</typeparam>
     public IChildDataPortal<T> GetPortal<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]T>()
+      where T : ICslaObject
     {
       return _serviceProvider.GetRequiredService<IChildDataPortal<T>>();
     }

--- a/Source/tests/Csla.TestHelpers/DataPortalFactory.cs
+++ b/Source/tests/Csla.TestHelpers/DataPortalFactory.cs
@@ -6,6 +6,7 @@
 // <summary>Factory for dataportal instances for use in tests</summary>
 //-----------------------------------------------------------------------
 
+using Csla.Core;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Csla.TestHelpers
@@ -19,7 +20,7 @@ namespace Csla.TestHelpers
     /// <typeparam name="T">The type which the data portal is to service</typeparam>
     /// <param name="context">The context from which configuration can be retrieved</param>
     /// <returns>An instance of IDataPortal<typeparamref name="T"/> for use in data access during tests</returns>
-    public static IDataPortal<T> CreateDataPortal<T>(TestDIContext context)
+    public static IDataPortal<T> CreateDataPortal<T>(TestDIContext context) where T : ICslaObject
     {
       IDataPortal<T> dataPortal;
 
@@ -33,7 +34,7 @@ namespace Csla.TestHelpers
     /// <typeparam name="T">The type which the child data portal is to service</typeparam>
     /// <param name="context">The context from which configuration can be retrieved</param>
     /// <returns>An instance of IChildDataPortal<typeparamref name="T"/> for use in data access during tests</returns>
-    public static IChildDataPortal<T> CreateChildDataPortal<T>(TestDIContext context)
+    public static IChildDataPortal<T> CreateChildDataPortal<T>(TestDIContext context) where T : ICslaObject
     {
       IChildDataPortal<T> dataPortal;
 

--- a/Source/tests/Csla.TestHelpers/TestDIContextExtensions.cs
+++ b/Source/tests/Csla.TestHelpers/TestDIContextExtensions.cs
@@ -6,6 +6,8 @@
 // <summary>Extension methods for the TestDIContext type</summary>
 //-----------------------------------------------------------------------
 
+using Csla.Core;
+
 namespace Csla.TestHelpers
 {
 
@@ -30,7 +32,7 @@ namespace Csla.TestHelpers
     /// </summary>
     /// <param name="context">The context from which configuration can be retrieved</param>
     /// <returns>An instance of IDataPortal<typeparamref name="T"/> for use in testing</returns>
-    public static IDataPortal<T> CreateDataPortal<T>(this TestDIContext context)
+    public static IDataPortal<T> CreateDataPortal<T>(this TestDIContext context) where T : ICslaObject
     {
       return DataPortalFactory.CreateDataPortal<T>(context);
     }
@@ -40,7 +42,7 @@ namespace Csla.TestHelpers
     /// </summary>
     /// <param name="context">The context from which configuration can be retrieved</param>
     /// <returns>An instance of IChildDataPortal<typeparamref name="T"/> for use in testing</returns>
-    public static IChildDataPortal<T> CreateChildDataPortal<T>(this TestDIContext context)
+    public static IChildDataPortal<T> CreateChildDataPortal<T>(this TestDIContext context) where T : ICslaObject
     {
       return DataPortalFactory.CreateChildDataPortal<T>(context);
     }

--- a/Source/tests/Csla.test/BusinessBase/BusynessTests.cs
+++ b/Source/tests/Csla.test/BusinessBase/BusynessTests.cs
@@ -6,6 +6,7 @@
 // <summary>no summary</summary>
 //-----------------------------------------------------------------------
 using Csla;
+using Csla.Core;
 using Csla.TestHelpers;
 using Csla.Test;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -97,7 +98,7 @@ namespace cslalighttest.BusyStatus
       }
     }
 
-    private T CreateWithoutCriteria<T>()
+    private T CreateWithoutCriteria<T>() where T : ICslaObject
     {
       IDataPortal<T> dataPortal = _testDIContext.CreateDataPortal<T>();
 

--- a/Source/tests/Csla.test/PropertyGetSet/EditableGetSet.cs
+++ b/Source/tests/Csla.test/PropertyGetSet/EditableGetSet.cs
@@ -6,6 +6,7 @@
 // <summary>no summary</summary>
 //-----------------------------------------------------------------------
 
+using Csla.Core;
 using Csla.Serialization.Mobile;
 
 namespace Csla.Test.PropertyGetSet
@@ -294,7 +295,7 @@ namespace Csla.Test.PropertyGetSet
     /// </summary>
     /// <typeparam name="T">The type which is to be accessed</typeparam>
     /// <returns>An instance of IDataPortal for use in data access</returns>
-    private IDataPortal<T> GetDataPortal<T>() where T:class
+    private IDataPortal<T> GetDataPortal<T>() where T : ICslaObject
     {
       return ApplicationContext.GetRequiredService<IDataPortal<T>>();
     }

--- a/Source/tests/Csla.test/ValidationRules/HasChildren.cs
+++ b/Source/tests/Csla.test/ValidationRules/HasChildren.cs
@@ -75,7 +75,7 @@ namespace Csla.Test.ValidationRules
     /// </summary>
     /// <typeparam name="T">The type which is to be accessed</typeparam>
     /// <returns>An instance of IDataPortal for use in data access</returns>
-    private IDataPortal<T> GetDataPortal<T>() where T : class
+    private IDataPortal<T> GetDataPortal<T>() where T : ICslaObject
     {
       return ApplicationContext.GetRequiredService<IDataPortal<T>>();
     }

--- a/Source/tests/Csla.test/ValidationRules/ValidationTests.cs
+++ b/Source/tests/Csla.test/ValidationRules/ValidationTests.cs
@@ -463,21 +463,21 @@ namespace Csla.Test.ValidationRules
       Assert.AreEqual("Check capitalization", root.BrokenRulesCollection.GetFirstBrokenRule("Name").Description, "'Check capitalization' should be broken (GetFirstBrokenRule)");
     }
 
-    private T CreateWithoutCriteria<T>()
+    private T CreateWithoutCriteria<T>() where T : ICslaObject
     {
       IDataPortal<T> dataPortal = _testDIContext.CreateDataPortal<T>();
 
       return dataPortal.Create();
     }
 
-    private async Task<T> CreateWithoutCriteriaAsync<T>()
+    private async Task<T> CreateWithoutCriteriaAsync<T>() where T : ICslaObject
     {
       IDataPortal<T> dataPortal = _testDIContext.CreateDataPortal<T>();
 
       return await dataPortal.CreateAsync();
     }
 
-    private T CreateChildWithoutCriteria<T>()
+    private T CreateChildWithoutCriteria<T>() where T : ICslaObject
     {
       IChildDataPortal<T> dataPortal = _testDIContext.CreateChildDataPortal<T>();
 

--- a/Source/tests/GraphMergerTest/GraphMergerTest.Business/Factory/FactoryBase.cs
+++ b/Source/tests/GraphMergerTest/GraphMergerTest.Business/Factory/FactoryBase.cs
@@ -1,8 +1,10 @@
 ﻿using Csla;
+using Csla.Core;
 
 namespace GraphMergerTest.Business
 {
   public abstract class FactoryBase<T>
+    where T : ICslaObject
   {
     protected IDataPortal<T> DataPortal { get; set; }
 


### PR DESCRIPTION
Add constraint to IDataPortal<T> and IChildDataPortal<T> to satisfy the constraint on the actual implementations.

The actual implementations `DataPortal<T>` or `IChildDataPortal` have these constraints. So we have to propagate them through the interfaces to avoid the runtime exception where T does not satisfy the constraint and instead make it a compile time error.