### PR TITLE
#4616 Make legacy DataPortal_XYZ method resolution optional

### DIFF
--- a/Source/Csla/Configuration/Fluent/DataPortalOptions.cs
+++ b/Source/Csla/Configuration/Fluent/DataPortalOptions.cs
@@ -60,6 +60,13 @@ namespace Csla.Configuration
     /// </summary>
     internal DataPortalServerOptions DataPortalServerOptions { get; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether legacy DataPortal_XYZ and
+    /// Child_XYZ method names are used as a fallback when no attributed
+    /// data portal operation methods are found. Default is true.
+    /// </summary>
+    public bool UseLegacyOperationMethods { get; set; } = true;
+
     internal CslaOptions CslaOptions { get; }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `UseLegacyOperationMethods` property to `DataPortalOptions` (default `true`) so users can opt out of legacy `DataPortal_XYZ` / `Child_XYZ` method name fallback
- Guards the legacy method resolution block in `ServiceProviderMethodCaller` with the new option
- Updates the method cache key to include the flag, preventing stale cache when the option differs

Fixes #4616

## Test plan
- [x] New test: default behavior (legacy enabled) finds `DataPortal_Execute` via legacy fallback
- [x] New test: with legacy disabled, finds the attributed `Execute` method via recursion instead
- [x] New test: legacy-only class returns no method when legacy is disabled
- [x] All 57 `ServiceProviderMethodCallerTests` pass
- [x] Full test suite passes (573 passed, 57 skipped, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)