### PR TITLE
Replace duplicate dictionary lookups with TryGetValue and cached locals

### DIFF
--- a/Source/Csla/Core/FieldManager/FieldDataManager.cs
+++ b/Source/Csla/Core/FieldManager/FieldDataManager.cs
@@ -792,9 +792,9 @@ namespace Csla.Core.FieldManager
       if (mode == StateMode.Serialization)
       {
         _stateStack.Clear();
-        if (info.Values.ContainsKey("_stateStack"))
+        if (info.Values.TryGetValue("_stateStack", out var stateStackField))
         {
-          var stackArray = (IEnumerable<byte[]>)info.GetRequiredValue<byte[][]>("_stateStack");
+          var stackArray = (IEnumerable<byte[]>)stateStackField.Value!;
           foreach (var item in stackArray.Reverse())
             _stateStack.Push(item);
         }
@@ -824,7 +824,8 @@ namespace Csla.Core.FieldManager
           IFieldData? data = GetFieldData(property);
           if (data != null)
           {
-            if (!info.Values.ContainsKey("child_" + property.Name) || !info.GetValue<bool>("child_" + property.Name))
+            var childKey = "child_" + property.Name;
+            if (!info.Values.TryGetValue(childKey, out var childField) || childField.Value is not true)
               _fieldData[property.Index] = null;
 
             // We don't want to reset children during an undo.

--- a/Source/Csla/Core/UndoableBase.cs
+++ b/Source/Csla/Core/UndoableBase.cs
@@ -263,19 +263,23 @@ namespace Csla.Core
                 ((IUndoableObject?) value)?.UndoChanges(EditLevel, BindingEdit);
               }
             }
-            else if (value is IMobileObject && state[fieldName] != null)
-            {
-              // this is a mobile object, deserialize the value
-              using MemoryStream buffer = new MemoryStream((byte[])state[fieldName]!);
-              buffer.Position = 0;
-              var formatter = ApplicationContext.GetRequiredService<ISerializationFormatter>();
-              var obj = formatter.Deserialize(buffer);
-              h.MemberSetOrNotSupportedException(this, obj);
-            }
             else
             {
-              // this is a regular field, restore its value
-              h.MemberSetOrNotSupportedException(this, state[fieldName]);
+              var stateValue = state[fieldName];
+              if (value is IMobileObject && stateValue != null)
+              {
+                // this is a mobile object, deserialize the value
+                using MemoryStream buffer = new MemoryStream((byte[])stateValue);
+                buffer.Position = 0;
+                var formatter = ApplicationContext.GetRequiredService<ISerializationFormatter>();
+                var obj = formatter.Deserialize(buffer);
+                h.MemberSetOrNotSupportedException(this, obj);
+              }
+              else
+              {
+                // this is a regular field, restore its value
+                h.MemberSetOrNotSupportedException(this, stateValue);
+              }
             }
           }
 
@@ -412,9 +416,9 @@ namespace Csla.Core
       if (mode != StateMode.Undo)
       {
         _bindingEdit = info.GetValue<bool>("_bindingEdit");
-        if (info.Values.ContainsKey("_stateStack"))
+        if (info.Values.TryGetValue("_stateStack", out var stateStackField))
         {
-          var stackArray = (IEnumerable<byte[]>)info.GetRequiredValue<byte[][]>("_stateStack");
+          var stackArray = (IEnumerable<byte[]>)stateStackField.Value!;
           _stateStack.Clear();
           foreach (var item in stackArray.Reverse())
             _stateStack.Push(item);


### PR DESCRIPTION
  - UndoableBase: cache state[fieldName] in a local variable instead of looking it up three times during undo operations
  - UndoableBase/FieldDataManager: replace ContainsKey + GetRequiredValue with single TryGetValue call for _stateStack deserialization
  - FieldDataManager: replace ContainsKey + GetValue with single TryGetValue for child property lookup, also caching the concatenated key to avoid redundant string allocation
  - Remove unnecessary double cast in _stateStack deserialization