### PR TITLE
Update GRPC and Rabbit MQ Deserialize

### DIFF
--- a/Source/Csla.Channels.Grpc/GrpcPortal.cs
+++ b/Source/Csla.Channels.Grpc/GrpcPortal.cs
@@ -114,7 +114,7 @@ namespace Csla.Channels.Grpc
       var result = new DataPortalResponse();
       try
       {
-        var request = Deserialize<object>(requestData.ToByteArray());
+        var request = DeserializeRequired<object>(requestData.ToByteArray());
         var callResult = await CallPortal(operation, request);
         result.ObjectData = callResult.ObjectData;
       }
@@ -167,7 +167,7 @@ namespace Csla.Channels.Grpc
           true,
           request.ClientCulture,
           request.ClientUICulture,
-          Deserialize<IContextDictionary>(request.ClientContext));
+          DeserializeRequired<IContextDictionary>(request.ClientContext));
         context.OperationName = request.OperationName;
 
         var dpr = await dataPortalServer.Create(objectType, criteria, context, true);
@@ -211,7 +211,7 @@ namespace Csla.Channels.Grpc
           true,
           request.ClientCulture,
           request.ClientUICulture,
-          Deserialize<IContextDictionary>(request.ClientContext));
+          DeserializeRequired<IContextDictionary>(request.ClientContext));
         context.OperationName = request.OperationName;
 
         var dpr = await dataPortalServer.Fetch(objectType, criteria, context, true);
@@ -249,7 +249,7 @@ namespace Csla.Channels.Grpc
           true,
           request.ClientCulture,
           request.ClientUICulture,
-          Deserialize<IContextDictionary>(request.ClientContext));
+          DeserializeRequired<IContextDictionary>(request.ClientContext));
 
         var dpr = await dataPortalServer.Update((ICslaObject)obj, context, true);
 
@@ -293,7 +293,7 @@ namespace Csla.Channels.Grpc
           true,
           request.ClientCulture,
           request.ClientUICulture,
-          Deserialize<IContextDictionary>(request.ClientContext));
+          DeserializeRequired<IContextDictionary>(request.ClientContext));
         context.OperationName = request.OperationName;
 
         var dpr = await dataPortalServer.Delete(objectType, criteria, context, true);
@@ -352,15 +352,15 @@ namespace Csla.Channels.Grpc
 
     #endregion Extention Method for Requests
 
-    private T Deserialize<T>(byte[] data)
+    private T? Deserialize<T>(byte[] data)
     {
-      var deserializedData = _applicationContext.GetRequiredService<ISerializationFormatter>().Deserialize(data) ?? throw new SerializationException(Resources.ServerSideDataPortalRequestDeserializationFailed);
-      if (deserializedData is not T castedData)
-      {
-        throw new SerializationException(string.Format(Resources.DeserializationFailedDueToWrongData, typeof(T).FullName));
-      }
+      var deserializedData = _applicationContext.GetRequiredService<ISerializationFormatter>().Deserialize(data);
+      return (T?)deserializedData;
+    }
 
-      return castedData;
+    private T DeserializeRequired<T>(byte[] data)
+    {
+      return Deserialize<T>(data) ?? throw new SerializationException(Resources.ServerSideDataPortalRequestDeserializationFailed);
     }
   }
 }

--- a/Source/Csla.Channels.RabbitMq/RabbitMqPortal.cs
+++ b/Source/Csla.Channels.RabbitMq/RabbitMqPortal.cs
@@ -92,7 +92,7 @@ namespace Csla.Channels.RabbitMq
       DataPortalResponse result;
       try
       {
-        var request = Deserialize<object>(requestData);
+        var request = DeserializeRequired<object>(requestData);
         result = await CallPortal(ea.BasicProperties.Type ?? throw new InvalidOperationException($"{nameof(BasicDeliverEventArgs.BasicProperties)}.{nameof(IReadOnlyBasicProperties.Type)} == null"), request);
       }
       catch (Exception ex)
@@ -161,7 +161,7 @@ namespace Csla.Channels.RabbitMq
           true,
           request.ClientCulture,
           request.ClientUICulture,
-          Deserialize<IContextDictionary>(request.ClientContext));
+          DeserializeRequired<IContextDictionary>(request.ClientContext));
         context.OperationName = request.OperationName;
 
         var dpr = await _dataPortalServer.Create(objectType, criteria, context, true);
@@ -201,7 +201,7 @@ namespace Csla.Channels.RabbitMq
           true,
           request.ClientCulture,
           request.ClientUICulture,
-          Deserialize<IContextDictionary>(request.ClientContext));
+          DeserializeRequired<IContextDictionary>(request.ClientContext));
         context.OperationName = request.OperationName;
 
         var dpr = await _dataPortalServer.Fetch(objectType, criteria, context, true);
@@ -235,7 +235,7 @@ namespace Csla.Channels.RabbitMq
           true,
           request.ClientCulture,
           request.ClientUICulture,
-          Deserialize<IContextDictionary>(request.ClientContext));
+          DeserializeRequired<IContextDictionary>(request.ClientContext));
 
         var dpr = await _dataPortalServer.Update((ICslaObject)obj, context, true);
 
@@ -275,7 +275,7 @@ namespace Csla.Channels.RabbitMq
           true,
           request.ClientCulture,
           request.ClientUICulture,
-          Deserialize<IContextDictionary>(request.ClientContext));
+          DeserializeRequired<IContextDictionary>(request.ClientContext));
         context.OperationName = request.OperationName;
 
         var dpr = await _dataPortalServer.Delete(objectType, criteria, context, true);
@@ -334,15 +334,15 @@ namespace Csla.Channels.RabbitMq
 
     #endregion Conversion methods
 
-    private T Deserialize<T>(byte[] data)
+    private T? Deserialize<T>(byte[] data)
     {
-      var deserializedData = _applicationContext.GetRequiredService<ISerializationFormatter>().Deserialize(data) ?? throw new SerializationException(Resources.ServerSideDataPortalRequestDeserializationFailed);
-      if (deserializedData is not T castedData)
-      {
-        throw new SerializationException(string.Format(Resources.DeserializationFailedDueToWrongData, typeof(T).FullName));
-      }
+      var deserializedData = _applicationContext.GetRequiredService<ISerializationFormatter>().Deserialize(data);
+      return (T?)deserializedData;
+    }
 
-      return castedData;
+    private T DeserializeRequired<T>(byte[] data)
+    {
+      return Deserialize<T>(data) ?? throw new SerializationException(Resources.ServerSideDataPortalRequestDeserializationFailed);
     }
 
     /// <summary>


### PR DESCRIPTION
Updated GRPC and Rabbit MQ portal deserialize methods to match the behavior of the HTTP portal deserialize methods in order to fix an issue that occurs when attempting to deserialize a `null` `IPrincipal` object from a data portal request.

See https://github.com/MarimerLLC/csla/discussions/4840 for discussion related to this topic.