### PR TITLE
ProjectTracker: lift TimeStamp into intermediate base classes

### DIFF
--- a/Samples/ProjectTracker/ProjectTracker.BusinessLibrary/Admin/RoleEdit.cs
+++ b/Samples/ProjectTracker/ProjectTracker.BusinessLibrary/Admin/RoleEdit.cs
@@ -7,7 +7,7 @@ using ProjectTracker.Dal;
 namespace ProjectTracker.Library.Admin
 {
   [CslaImplementProperties]
-  public partial class RoleEdit : BusinessBase<RoleEdit>
+  public partial class RoleEdit : CslaBaseTypes.BusinessBase<RoleEdit>
   {
     public RoleEdit()
     {
@@ -18,10 +18,6 @@ namespace ProjectTracker.Library.Admin
 
     [Required]
     public partial string Name { get; set; }
-
-    [Browsable(false)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public partial byte[] TimeStamp { get; set; }
 
     protected override void AddBusinessRules()
     {

--- a/Samples/ProjectTracker/ProjectTracker.BusinessLibrary/CslaBaseTypes/BusinessBase.cs
+++ b/Samples/ProjectTracker/ProjectTracker.BusinessLibrary/CslaBaseTypes/BusinessBase.cs
@@ -1,10 +1,23 @@
-﻿using System;
+using System;
+using System.ComponentModel;
+using Csla;
 
 namespace ProjectTracker.Library.CslaBaseTypes
 {
   [Serializable]
   public abstract class BusinessBase<T> : Csla.BusinessBase<T> where T : Csla.BusinessBase<T>
   {
+    public static readonly PropertyInfo<byte[]> TimeStampProperty =
+      RegisterProperty<byte[]>(nameof(TimeStamp));
 
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+#pragma warning disable CSLA0007 // null-forgiving on GetProperty matches framework convention for non-nullable managed properties
+    public byte[] TimeStamp
+    {
+      get => GetProperty(TimeStampProperty)!;
+      set => SetProperty(TimeStampProperty, value);
+    }
+#pragma warning restore CSLA0007
   }
 }

--- a/Samples/ProjectTracker/ProjectTracker.BusinessLibrary/CslaBaseTypes/BusinessDocumentBase.cs
+++ b/Samples/ProjectTracker/ProjectTracker.BusinessLibrary/CslaBaseTypes/BusinessDocumentBase.cs
@@ -1,4 +1,6 @@
 using System;
+using System.ComponentModel;
+using Csla;
 
 namespace ProjectTracker.Library.CslaBaseTypes
 {
@@ -7,6 +9,17 @@ namespace ProjectTracker.Library.CslaBaseTypes
     where T : Csla.BusinessDocumentBase<T, C>
     where C : notnull, Csla.Core.IEditableBusinessObject
   {
+    public static readonly PropertyInfo<byte[]> TimeStampProperty =
+      RegisterProperty<byte[]>(nameof(TimeStamp));
 
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+#pragma warning disable CSLA0007 // null-forgiving on GetProperty matches framework convention for non-nullable managed properties
+    public byte[] TimeStamp
+    {
+      get => GetProperty(TimeStampProperty)!;
+      set => SetProperty(TimeStampProperty, value);
+    }
+#pragma warning restore CSLA0007
   }
 }

--- a/Samples/ProjectTracker/ProjectTracker.BusinessLibrary/ProjectEdit.cs
+++ b/Samples/ProjectTracker/ProjectTracker.BusinessLibrary/ProjectEdit.cs
@@ -10,10 +10,6 @@ namespace ProjectTracker.Library
   [CslaImplementProperties]
   public partial class ProjectEdit : CslaBaseTypes.BusinessDocumentBase<ProjectEdit, ProjectResourceEdit>
   {
-    [Browsable(false)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public partial byte[] TimeStamp { get; private set; }
-
     [Display(Name = "Project id")]
     public partial int Id { get; private set; }
 

--- a/Samples/ProjectTracker/ProjectTracker.BusinessLibrary/ProjectResourceEdit.cs
+++ b/Samples/ProjectTracker/ProjectTracker.BusinessLibrary/ProjectResourceEdit.cs
@@ -9,12 +9,8 @@ using System.Linq;
 namespace ProjectTracker.Library
 {
   [CslaImplementProperties]
-  public partial class ProjectResourceEdit : BusinessBase<ProjectResourceEdit>
+  public partial class ProjectResourceEdit : CslaBaseTypes.BusinessBase<ProjectResourceEdit>
   {
-    [Browsable(false)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public partial byte[] TimeStamp { get; set; }
-
     [Display(Name = "Resource id")]
     public partial int ResourceId { get; private set; }
 

--- a/Samples/ProjectTracker/ProjectTracker.BusinessLibrary/ResourceAssignmentEdit.cs
+++ b/Samples/ProjectTracker/ProjectTracker.BusinessLibrary/ResourceAssignmentEdit.cs
@@ -7,12 +7,8 @@ using ProjectTracker.Dal;
 namespace ProjectTracker.Library
 {
   [CslaImplementProperties]
-  public partial class ResourceAssignmentEdit : BusinessBase<ResourceAssignmentEdit>
+  public partial class ResourceAssignmentEdit : CslaBaseTypes.BusinessBase<ResourceAssignmentEdit>
   {
-    [Browsable(false)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public partial byte[] TimeStamp { get; set; }
-
     [Display(Name = "Project id")]
     public partial int ProjectId { get; private set; }
 

--- a/Samples/ProjectTracker/ProjectTracker.BusinessLibrary/ResourceEdit.cs
+++ b/Samples/ProjectTracker/ProjectTracker.BusinessLibrary/ResourceEdit.cs
@@ -10,10 +10,6 @@ namespace ProjectTracker.Library
   [CslaImplementProperties]
   public partial class ResourceEdit : CslaBaseTypes.BusinessDocumentBase<ResourceEdit, ResourceAssignmentEdit>
   {
-    [Browsable(false)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public partial byte[] TimeStamp { get; set; }
-
     [Display(Name = "Resource id")]
     public partial int Id { get; set; }
 


### PR DESCRIPTION
## Summary

- Demonstrates the pattern of an intermediate subclass between `Csla.BusinessBase<T>` / `Csla.BusinessDocumentBase<T,C>` and concrete BOs, where the intermediate **declares its own registered properties** that are inherited by every concrete BO.
- Lifts the `TimeStamp` (`byte[]`) concurrency token — present in all five candidate BOs — into `ProjectTracker.Library.CslaBaseTypes.BusinessBase<T>` and `BusinessDocumentBase<T,C>`. These two intermediate types existed previously but were empty shells.
- Fixes a latent bug: `ResourceAssignmentEdit`, `ProjectResourceEdit`, and `RoleEdit` wrote `: BusinessBase<X>` which (under `using Csla;`) silently bound to **`Csla.BusinessBase<T>`**, not the local intermediate. The intermediate was unused even where it looked otherwise. Now qualified to `CslaBaseTypes.BusinessBase<X>`.

## Why this is useful as a sample

The CSLA documentation discusses application-wide intermediate base classes, but no sample demonstrated *declaring registered properties* on the intermediate. This change makes ProjectTracker a working reference for that pattern.

## Notes

- The intermediate uses `GetProperty(TimeStampProperty)!` (null-forgiving) — the same pattern used inside the CSLA framework (e.g. `DataPortalErrorInfo.cs`). The CSLA0007 analyzer false-positives on this so a `#pragma warning disable` is applied with a comment explaining why.
- MobileFormatter handles inherited registered properties automatically — no extra serialization work needed.
- The Csla auto-implement source generator's base-class detection is a substring match on `BusinessBase`/`BusinessDocumentBase`, so the local-namespace intermediates work transparently.

## Test plan

- [x] `dotnet build Samples/ProjectTracker/ProjectTracker.sln` — clean (0 errors; only pre-existing NU1603 NuGet version warnings)
- [ ] Smoke-run the Blazor host: create/fetch/save Project and Resource to confirm the byte[] concurrency token round-trips through MobileFormatter when the BO crosses the data portal

🤖 Generated with [Claude Code](https://claude.com/claude-code)