### PR TITLE
Update DI package references for netstandard and net4x targets

### DIFF
--- a/Source/Csla.Web/Csla.Web.csproj
+++ b/Source/Csla.Web/Csla.Web.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
     <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
   </ItemGroup>
 

--- a/Source/Csla/Csla.csproj
+++ b/Source/Csla/Csla.csproj
@@ -55,8 +55,8 @@
   <ItemGroup Condition="$(TargetFramework.StartsWith(&quot;net4&quot;))">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
@@ -107,8 +107,8 @@
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />

--- a/Source/Csla/Reflection/ServiceProviderMethodCaller.cs
+++ b/Source/Csla/Reflection/ServiceProviderMethodCaller.cs
@@ -562,7 +562,6 @@ namespace Csla.Reflection
             var serviceKey = method.ServiceKeys[index];
             if (serviceKey != null)
             {
-#if NET8_0_OR_GREATER
               // Use keyed service injection for .NET 8+
               if (method.AllowNull[index])
               {
@@ -581,9 +580,6 @@ namespace Csla.Reflection
                 // For required keyed services, use extension method
                 plist[index] = service.GetRequiredKeyedService(item.ParameterType, serviceKey);
               }
-#else
-              throw new NotSupportedException("Keyed service injection is only supported on .NET 8.0 or higher.");
-#endif
             }
             else
             {


### PR DESCRIPTION
Updated the references for Microsoft.Extensions.DependencyInjection and Microsoft.Extensions.DependencyInjection.Abstractions from 6.0.0 to 10.0.0 for net4x and netstandard2.0 target frameworks to allow for support of keyed services across all targets supported by CSLA.

Removed the `#if NET_8_0_OR_GREATER` check in ServiceProviderMethodCaller since all targets now support the use of keyed services.