### PR TITLE
#4879 ObjectAdapter handles null property values and skips non-browsable properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,4 @@ Samples/ProjectTracker/ProjectTracker.Blazor/ProjectTracker.Blazor/PTracker.db
 Samples/ProjectTracker/ProjectTracker.Blazor/ProjectTracker.Blazor/PTracker.db-shm
 Samples/ProjectTracker/ProjectTracker.Blazor/ProjectTracker.Blazor/PTracker.db-wal
 .claude/settings.local.json
+.claude/plans/

--- a/Source/Csla/Data/ObjectAdapter.cs
+++ b/Source/Csla/Data/ObjectAdapter.cs
@@ -200,11 +200,11 @@ namespace Csla.Data
 
       if (sourceType != null)
       {
-        // retrieve a list of all public properties
+        // retrieve a list of all public, browsable properties
         PropertyInfo[] props = sourceType.GetProperties();
         if (props.Length >= 0)
           for (int column = 0; column < props.Length; column++)
-            if (props[column].CanRead)
+            if (props[column].CanRead && IsBrowsable(props[column]))
               result.Add(props[column].Name);
 
         // retrieve a list of all public fields
@@ -216,17 +216,20 @@ namespace Csla.Data
       return result;
     }
 
+    private static bool IsBrowsable(PropertyInfo property)
+      => property.GetCustomAttribute<BrowsableAttribute>()?.Browsable != false;
+
     #endregion
 
     #region GetField
 
-    private static string GetField(object obj, string fieldName)
+    private static object GetField(object obj, string fieldName)
     {
-      string result;
+      object result;
       if (obj is DataRowView dataRowView)
       {
         // this is a DataRowView from a DataView
-        result = dataRowView[fieldName].ToString()!;
+        result = ToCellValue(dataRowView[fieldName]);
       }
       else if (obj is ValueType && obj.GetType().IsPrimitive)
       {
@@ -262,13 +265,13 @@ namespace Csla.Data
               else
               {
                 // got a field, return its value
-                result = field.GetValue(obj)!.ToString()!;
+                result = ToCellValue(field.GetValue(obj));
               }
             }
             else
             {
               // found a property, return its value
-              result = prop.GetValue(obj, null)!.ToString()!;
+              result = ToCellValue(prop.GetValue(obj, null));
             }
           }
           catch (Exception ex)
@@ -278,6 +281,17 @@ namespace Csla.Data
         }
       }
       return result;
+    }
+
+    /// <summary>
+    /// Converts a member value into the value stored in the DataTable cell:
+    /// null (or DBNull) becomes DBNull, everything else becomes its string representation.
+    /// </summary>
+    private static object ToCellValue(object? value)
+    {
+      if (value is null || value is DBNull)
+        return DBNull.Value;
+      return value.ToString() ?? (object)DBNull.Value;
     }
 
     #endregion

--- a/Source/Csla/Data/ObjectAdapter.cs
+++ b/Source/Csla/Data/ObjectAdapter.cs
@@ -217,7 +217,7 @@ namespace Csla.Data
     }
 
     private static bool IsBrowsable(PropertyInfo property)
-      => property.GetCustomAttribute<BrowsableAttribute>()?.Browsable != false;
+      => property.GetCustomAttribute<BrowsableAttribute>(inherit: true)?.Browsable != false;
 
     #endregion
 

--- a/Source/tests/Csla.test/DataPortal/ChildEntityList.cs
+++ b/Source/tests/Csla.test/DataPortal/ChildEntityList.cs
@@ -22,7 +22,7 @@ namespace Csla.Test.DataBinding
     #endregion
 
     [Fetch]
-    private void DataPortal_Fetch(object criteria, IChildDataPortal<ChildEntity> childDataPortal)
+    private void DataPortal_Fetch(object criteria, [Inject] IChildDataPortal<ChildEntity> childDataPortal)
     {
       for (var i = 0; i < 10; i++)
         Add(childDataPortal.CreateChild(i, "first" + i, "last" + i));

--- a/Source/tests/Csla.test/ObjectAdapter/ObjectAdapterTests.cs
+++ b/Source/tests/Csla.test/ObjectAdapter/ObjectAdapterTests.cs
@@ -1,0 +1,125 @@
+//-----------------------------------------------------------------------
+// <copyright file="ObjectAdapterTests.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>Tests for Csla.Data.ObjectAdapter</summary>
+//-----------------------------------------------------------------------
+
+using System.Data;
+using Csla.Data;
+using Csla.Test.DataBinding;
+using Csla.TestHelpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Csla.Test.DataAdapter
+{
+  [TestClass]
+  public class ObjectAdapterTests
+  {
+    private const string ErrorReadingValueText = "Error reading value";
+
+    private static TestDIContext _testDIContext;
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext context)
+    {
+      _testDIContext = TestDIContextFactory.CreateDefaultContext();
+    }
+
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
+    [TestMethod]
+    public void Fill_BusinessObject_DoesNotWriteErrorForNullProperty()
+    {
+      var dataPortal = _testDIContext.CreateDataPortal<ParentEntity>();
+      var entity = ParentEntity.NewParentEntity(dataPortal);
+      entity.Data = "some data";
+      Assert.IsNull(entity.Parent, "test precondition: root object has no parent");
+
+      var dt = new DataTable();
+      new ObjectAdapter().Fill(dt, entity);
+
+      Assert.AreEqual(1, dt.Rows.Count);
+      var row = dt.Rows[0];
+      foreach (DataColumn column in dt.Columns)
+      {
+        var value = row[column] as string;
+        Assert.IsFalse(
+          value != null && value.Contains(ErrorReadingValueText),
+          $"Column '{column.ColumnName}' contains an error message instead of a value: '{value}'");
+      }
+      Assert.AreEqual("some data", row["Data"]);
+      Assert.AreEqual(entity.ID.ToString(), row["ID"]);
+    }
+
+    [TestMethod]
+    public void Fill_BusinessObject_SkipsNonBrowsableProperties()
+    {
+      var dataPortal = _testDIContext.CreateDataPortal<ParentEntity>();
+      var entity = ParentEntity.NewParentEntity(dataPortal);
+
+      var dt = new DataTable();
+      new ObjectAdapter().Fill(dt, entity);
+
+      Assert.IsTrue(dt.Columns.Contains("Data"));
+      Assert.IsTrue(dt.Columns.Contains("ID"));
+      Assert.IsFalse(dt.Columns.Contains("Parent"));
+      Assert.IsFalse(dt.Columns.Contains("IsDirty"));
+      Assert.IsFalse(dt.Columns.Contains("IsNew"));
+      Assert.IsFalse(dt.Columns.Contains("BrokenRulesCollection"));
+    }
+
+    [TestMethod]
+    public void Fill_PlainObject_NullPropertyBecomesDBNull()
+    {
+      var source = new PlainObject { Name = null, Age = 42, NullableNumber = null };
+
+      var dt = new DataTable();
+      new ObjectAdapter().Fill(dt, source);
+
+      Assert.AreEqual(1, dt.Rows.Count);
+      var row = dt.Rows[0];
+      Assert.AreEqual(DBNull.Value, row["Name"]);
+      Assert.AreEqual(DBNull.Value, row["NullableNumber"]);
+      Assert.AreEqual("42", row["Age"]);
+      Assert.AreEqual(DBNull.Value, row["NullField"]);
+    }
+
+    [TestMethod]
+    public void Fill_BusinessList_ProducesOneRowPerItem()
+    {
+      var dataPortal = _testDIContext.CreateDataPortal<ChildEntityList>();
+      var list = dataPortal.Fetch(new object());
+
+      var dt = new DataTable();
+      new ObjectAdapter().Fill(dt, list);
+
+      Assert.AreEqual(list.Count, dt.Rows.Count);
+      Assert.IsFalse(dt.Columns.Contains("Parent"));
+      for (var i = 0; i < list.Count; i++)
+      {
+        Assert.AreEqual(list[i].FirstName, dt.Rows[i]["FirstName"]);
+        foreach (DataColumn column in dt.Columns)
+        {
+          var value = dt.Rows[i][column] as string;
+          Assert.IsFalse(
+            value != null && value.Contains(ErrorReadingValueText),
+            $"Row {i}, column '{column.ColumnName}' contains an error message instead of a value: '{value}'");
+        }
+      }
+    }
+
+    private class PlainObject
+    {
+      public string Name { get; set; }
+      public int Age { get; set; }
+      public int? NullableNumber { get; set; }
+      public string NullField = null;
+    }
+  }
+}

--- a/docs/Upgrading to CSLA 10.md
+++ b/docs/Upgrading to CSLA 10.md
@@ -108,6 +108,7 @@ Supporting nullable types means that some APIs have changed to support nullable 
 * `Csla.Reflection.LateBoundObject(Type objectType)` constructor removed (hasn't worked so far anyway)
 * `Csla.Core.UndoException` constructors now throw `ArgumentNullException` on necessary parameters and all public fields changed to readonly properties
 * `Csla.Data.ObjectAdapter.Fill(DataTable dt, object source)` throws an `ArgumentNullException` for source instead of `ArgumentException`.
+* `Csla.Data.ObjectAdapter.Fill(...)` now writes `DBNull.Value` into the cell when a property or field value is `null` (previously the cell contained an "Error reading value" message), and properties marked `[Browsable(false)]` (such as `Parent`, `IsNew`, `IsDirty` on business objects) are no longer emitted as columns.
 * `Csla.Reflection.ServiceProviderMethodInfo` 
   * Now has a constructor requiring a `MethodInfo` parameter
   * Property `MethodInfo` property set removed and replaced by the constructor


### PR DESCRIPTION
Closes #4879

## Problem

`Csla.Data.ObjectAdapter.Fill(...)` read every public property via reflection and called `.ToString()` on the result unconditionally. For a root business object, `Parent` is `null`, so the read threw `NullReferenceException`, which was wrapped in a `DataException` and then written into the cell as the exception *message*. Every row ended up with "Error reading value: Parent" instead of a value. The same happened for any other null-valued property or field.

## Changes

- **`Source/Csla/Data/ObjectAdapter.cs`**
  - Property, field, and `DataRowView` reads now go through a null-safe helper. A `null` (or `DBNull`) value becomes `DBNull.Value` in the cell; everything else keeps its string representation.
  - `ScanObject` skips properties marked `[Browsable(false)]`, so CSLA infrastructure properties (`Parent`, `IsNew`, `IsDirty`, `BrokenRulesCollection`, etc.) are no longer emitted as columns. This mirrors standard .NET data-binding behavior.
- **`Source/tests/Csla.test/ObjectAdapter/ObjectAdapterTests.cs`** (new): four tests covering a root business object, non-browsable column omission, POCO nulls becoming `DBNull`, and a business list producing one row per item.
- **`Source/tests/Csla.test/DataPortal/ChildEntityList.cs`**: added the missing `[Inject]` on the child data portal parameter so the fixture can be fetched as a root object.
- **`docs/Upgrading to CSLA 10.md`**: noted both behavior changes under the existing ObjectAdapter entry.

## Behavior change

Anyone relying on `IsDirty`/`IsNew` etc. appearing as report columns will no longer see them. These previously rendered only as `True`/`False` or error text.

## Verification

```
dotnet build Source\csla.test.sln
dotnet test Source\csla.test.sln --no-build --filter TestCategory!=SkipOnCIServer --settings Source/test.runsettings
```

All suites pass (Csla.Tests: 663 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHpUNhVz83k5JMazbsA66F
