### PR TITLE
#4856 Add regression tests for Required rule on value type properties

### DIFF
--- a/Source/Csla/Rules/CommonRules.cs
+++ b/Source/Csla/Rules/CommonRules.cs
@@ -102,6 +102,18 @@ namespace Csla.Rules.CommonRules
   /// <summary>
   /// Business rule for a required string.
   /// </summary>
+  /// <remarks>
+  /// The rule is broken when the property value is <see langword="null"/>, or when the
+  /// string form of the value is <see langword="null"/>, <see cref="string.Empty"/> or
+  /// consists only of white space.
+  /// <para>
+  /// A non-nullable value type property can therefore never break this rule, because it
+  /// always has a value that produces a non-empty string. For example an
+  /// <see langword="int"/> property with a value of <c>0</c> satisfies the rule. Use a
+  /// nullable property type (such as <see langword="int"/>?) to require that a value was
+  /// supplied, or <see cref="MinValue{T}"/> to require a value within a range.
+  /// </para>
+  /// </remarks>
   public class Required : CommonBusinessRule
   {
     /// <summary>

--- a/Source/tests/Csla.test/ValidationRules/HasRequiredValueTypeRules.cs
+++ b/Source/tests/Csla.test/ValidationRules/HasRequiredValueTypeRules.cs
@@ -1,0 +1,44 @@
+//-----------------------------------------------------------------------
+// <copyright file="HasRequiredValueTypeRules.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>Business object with Required rules on value type properties</summary>
+//-----------------------------------------------------------------------
+
+namespace Csla.Test.ValidationRules
+{
+  [Serializable]
+  public class HasRequiredValueTypeRules : BusinessBase<HasRequiredValueTypeRules>
+  {
+    public static PropertyInfo<int> IdProperty = RegisterProperty<int>(c => c.Id);
+    public int Id
+    {
+      get { return GetProperty(IdProperty); }
+      set { SetProperty(IdProperty, value); }
+    }
+
+    public static PropertyInfo<int?> NullableIdProperty = RegisterProperty<int?>(c => c.NullableId);
+    public int? NullableId
+    {
+      get { return GetProperty(NullableIdProperty); }
+      set { SetProperty(NullableIdProperty, value); }
+    }
+
+    protected override void AddBusinessRules()
+    {
+      BusinessRules.AddRule(new Rules.CommonRules.Required(IdProperty));
+      BusinessRules.AddRule(new Rules.CommonRules.Required(NullableIdProperty));
+    }
+
+    public void CheckRules()
+    {
+      BusinessRules.CheckRules();
+    }
+
+    [Create]
+    private void Create()
+    {
+    }
+  }
+}

--- a/Source/tests/Csla.test/ValidationRules/RequiredRuleTests.cs
+++ b/Source/tests/Csla.test/ValidationRules/RequiredRuleTests.cs
@@ -1,0 +1,99 @@
+//-----------------------------------------------------------------------
+// <copyright file="RequiredRuleTests.cs" company="Marimer LLC">
+//     Copyright (c) Marimer LLC. All rights reserved.
+//     Website: https://cslanet.com
+// </copyright>
+// <summary>Tests for the Required rule on value type properties</summary>
+//-----------------------------------------------------------------------
+
+using Csla.Testing;
+using Csla.TestHelpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Csla.Test.ValidationRules
+{
+  /// <summary>
+  /// Tests the Required rule against value type properties.
+  /// </summary>
+  /// <remarks>
+  /// Regression coverage for issue #4856, where adding a Required rule to an int
+  /// property caused the rule engine to throw while creating the RuleContext.
+  /// </remarks>
+  [TestClass]
+  public class RequiredRuleTests
+  {
+    private static CslaTestHost _testHost;
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext testContext)
+    {
+      _testHost = CslaTestHost.Create();
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup()
+    {
+      _testHost?.Dispose();
+    }
+
+    [TestInitialize]
+    public void Initialize()
+    {
+      TestResults.Reinitialise();
+    }
+
+    [TestMethod]
+    public void SettingIntPropertyWithRequiredRuleRunsRules()
+    {
+      IDataPortal<HasRequiredValueTypeRules> dataPortal = _testHost.GetDataPortal<HasRequiredValueTypeRules>();
+
+      HasRequiredValueTypeRules root = dataPortal.Create();
+      root.Id = 5;
+
+      Assert.AreEqual(5, root.Id);
+      Assert.IsNull(root.BrokenRulesCollection.GetFirstBrokenRule(HasRequiredValueTypeRules.IdProperty.Name), "Id should not be broken");
+    }
+
+    /// <summary>
+    /// The Required rule fails when the value is null or its string form is
+    /// null/empty/whitespace, so zero satisfies the rule on a non-nullable int.
+    /// </summary>
+    [TestMethod]
+    public void RequiredRuleOnIntPropertyIsSatisfiedByZero()
+    {
+      IDataPortal<HasRequiredValueTypeRules> dataPortal = _testHost.GetDataPortal<HasRequiredValueTypeRules>();
+
+      HasRequiredValueTypeRules root = dataPortal.Create();
+      root.CheckRules();
+
+      Assert.AreEqual(0, root.Id);
+      Assert.IsNull(root.BrokenRulesCollection.GetFirstBrokenRule(HasRequiredValueTypeRules.IdProperty.Name), "Id should not be broken");
+    }
+
+    [TestMethod]
+    public void RequiredRuleOnNullableIntPropertyIsBrokenWhenNull()
+    {
+      IDataPortal<HasRequiredValueTypeRules> dataPortal = _testHost.GetDataPortal<HasRequiredValueTypeRules>();
+
+      HasRequiredValueTypeRules root = dataPortal.Create();
+      root.CheckRules();
+
+      Assert.IsNull(root.NullableId);
+      Assert.AreEqual(1, root.BrokenRulesCollection.ErrorCount, "Only NullableId should be broken");
+      Assert.AreEqual("NullableId required", root.BrokenRulesCollection.GetFirstBrokenRule(HasRequiredValueTypeRules.NullableIdProperty.Name).Description);
+    }
+
+    [TestMethod]
+    public void RequiredRuleOnNullableIntPropertyIsSatisfiedByValue()
+    {
+      IDataPortal<HasRequiredValueTypeRules> dataPortal = _testHost.GetDataPortal<HasRequiredValueTypeRules>();
+
+      HasRequiredValueTypeRules root = dataPortal.Create();
+      root.CheckRules();
+      root.NullableId = 1;
+
+      Assert.AreEqual(0, root.BrokenRulesCollection.ErrorCount, "No rule should be broken");
+      Assert.IsTrue(root.IsValid);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Investigating #4856 showed the reported exception cannot occur on `main`.

The user's stack trace came from CSLA 8.2.9, where `RuleContext`'s constructor built its
output/dirty collections through DI:

```csharp
// origin/v9.x Source/Csla/Rules/RuleContext.cs:212
_outputPropertyValues = (LazySingleton<Dictionary<IPropertyInfo, object>>)
  ApplicationContext.CreateInstanceDI(typeof(LazySingleton<Dictionary<IPropertyInfo, object>>));
```

`CreateInstanceDI` with zero parameters reaches `ActivatorUtilities.CreateInstance`, which
treats every public constructor as applicable when no arguments are supplied — so both
`LazySingleton<T>()` and `LazySingleton<T>(Func<T>)` matched, producing the "Multiple
constructors accepting all given argument types" error. This ran on every rule execution;
`int` was incidental. #4528 rewrote `RuleContext` to hold plain `Dictionary`/`List`
collections, removing the call site.

Changes here:

- New test fixture `HasRequiredValueTypeRules` with `PropertyInfo<int>` and
  `PropertyInfo<int?>` properties, both carrying a `Required` rule. Every existing
  `CommonRules.Required` usage in the test tree targeted a `PropertyInfo<string>`, so this
  path had no coverage.
- New `RequiredRuleTests` covering the original repro (setting an `int` property that has a
  `Required` rule), that `0` satisfies the rule on a non-nullable `int`, and that `int?`
  breaks the rule when null and satisfies it when set.
- XML docs on `CommonRules.Required` now state that the rule fails when the value is null or
  its string form is null/empty/whitespace, and that a non-nullable value type property can
  therefore never break it — use a nullable type or `MinValue<T>` instead. The reporter's
  `"Cannot be null"` message on a non-nullable `int` would never have appeared; behavior is
  unchanged, only documented.

Filed #4891 for the still-latent `LazySingleton<T>` defects (its parameterless constructor is
unusable in three separate ways). Fixing that is a breaking change, so it belongs in v11.

## Test plan

- [x] `dotnet build Source\csla.test.sln` — 0 errors
- [x] `dotnet test Source\csla.test.sln --no-build --filter TestCategory!=SkipOnCIServer --settings Source/test.runsettings` — all green (667 passed in `Csla.Tests.dll`, including the 4 new tests)

Closes #4856

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011VEzABB5KneYkRmUx9hFD2