### PR TITLE
#4898 Clarify that IMobileObjectMetastate carries non-public state

### DIFF
--- a/Source/Csla/Core/MobileObject.cs
+++ b/Source/Csla/Core/MobileObject.cs
@@ -108,18 +108,30 @@ namespace Csla.Core
     #region IMobileObjectMetastate Members
 
     /// <summary>
-    /// Override this method to write field values directly
-    /// to a binary stream for metastate serialization.
+    /// Override this method to write the type's non-public state directly to a
+    /// binary stream for metastate serialization.
     /// </summary>
+    /// <remarks>
+    /// Write the bookkeeping the type maintains about itself, not its property
+    /// values; a serializer handles those separately. Always call the base
+    /// implementation first, so that the state written by each type in the
+    /// hierarchy is read back in the same order. The base implementation of this
+    /// method writes nothing, which is correct for a type with no non-public
+    /// state to carry.
+    /// </remarks>
     /// <param name="writer">Binary writer for the output stream.</param>
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     protected virtual void OnGetMetastate(BinaryWriter writer)
     { }
 
     /// <summary>
-    /// Override this method to read field values directly
-    /// from a binary stream for metastate deserialization.
+    /// Override this method to read the type's non-public state directly from a
+    /// binary stream for metastate deserialization.
     /// </summary>
+    /// <remarks>
+    /// Read the values written by <see cref="OnGetMetastate"/> in the same
+    /// order, calling the base implementation first.
+    /// </remarks>
     /// <param name="reader">Binary reader for the input stream.</param>
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     protected virtual void OnSetMetastate(BinaryReader reader)

--- a/Source/Csla/Serialization/Mobile/IMobileObjectMetastate.cs
+++ b/Source/Csla/Serialization/Mobile/IMobileObjectMetastate.cs
@@ -9,27 +9,52 @@
 namespace Csla.Serialization.Mobile
 {
   /// <summary>
-  /// Interface for types that can serialize their metastate
-  /// (field values) to and from a byte array representation.
+  /// Interface for types that can round trip their non-public state - the
+  /// bookkeeping an object maintains about itself, such as whether it is new,
+  /// dirty or deleted - to and from a byte array representation.
   /// </summary>
   /// <remarks>
-  /// This interface provides a lightweight serialization mechanism
-  /// that captures the same field values as OnGetState/OnSetState
-  /// without including child object references. It is intended for
-  /// transitory data serialization scenarios, not long-term storage.
+  /// <para>
+  /// This exists so that a serializer written outside CSLA .NET can preserve
+  /// state it has no other way to reach, without resorting to reflection over
+  /// private fields. The serializer remains responsible for the object's
+  /// property values; this interface covers only the state those values are
+  /// wrapped in.
+  /// </para>
+  /// <para>
+  /// The byte array is opaque. Its layout is decided entirely by the type
+  /// producing it, is not a documented format, and may change between releases,
+  /// so it is suitable for a single serialization round trip and not for
+  /// long-term storage.
+  /// </para>
+  /// <para>
+  /// A type contributes to its metastate by overriding
+  /// <c>OnGetMetastate</c> and <c>OnSetMetastate</c>. A type with no non-public
+  /// state to carry - a <see cref="CommandBase{T}"/> or a
+  /// <see cref="Csla.Rules.BrokenRule"/>, for instance - overrides neither, and
+  /// its metastate is legitimately an empty array.
+  /// </para>
   /// </remarks>
   public interface IMobileObjectMetastate
   {
     /// <summary>
-    /// Serializes the object's field values into a byte array.
+    /// Serializes the object's non-public state into a byte array.
     /// </summary>
-    /// <returns>Byte array containing the serialized field values.</returns>
+    /// <returns>
+    /// Byte array containing the serialized state, which is empty when the type
+    /// has no non-public state to carry.
+    /// </returns>
     byte[] GetMetastate();
 
     /// <summary>
-    /// Deserializes field values from a byte array into the object.
+    /// Restores the object's non-public state from a byte array.
     /// </summary>
-    /// <param name="metastate">Byte array containing the serialized field values.</param>
+    /// <param name="metastate">
+    /// Byte array previously returned by <see cref="GetMetastate"/> on the same
+    /// type. It is empty when that type carries no non-public state, and an
+    /// empty array is accepted rather than treated as an error.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="metastate"/> is <see langword="null"/>.</exception>
     void SetMetastate(byte[] metastate);
   }
 }


### PR DESCRIPTION
## Summary

Comments only; no behaviour change.

`IMobileObjectMetastate` was documented in terms of "field values", and claimed to capture "the same field values as OnGetState/OnSetState". That is *technically* true — `BusinessBase.OnGetState` writes private fields such as `_isNew` and `_isDirty`, while property values live in the `FieldManager` and are serialized separately — but it reads as **property values** to anyone who does not already know that.

It has misled once already. The tests recovered in #4900 included four asserting that property values survive a metastate round trip, which they never have and were never meant to.

## What the docs now say

Taken from #4263 and the design discussion on #4750, where @JasonBock asked for the interface so his source-generator serializer could round trip a BO's non-public bookkeeping — "the values for 'is new', 'is dirty', etc." — instead of reflecting over private fields, while continuing to serialize the property values itself. The byte array was explicitly agreed to be an opaque blob: *"Correct, I don't care what's in the array."*

- The payload is the object's **non-public state**, not its field or property values, and a serializer remains responsible for the property values.
- The array is **opaque** — layout is the producing type's business, undocumented, and may change between releases; good for one round trip, not for storage.
- A type contributes by overriding `OnGetMetastate`/`OnSetMetastate`. A type with no non-public state overrides neither and its metastate is **legitimately empty**, which #4785 settled and is easy to mistake for a bug.
- `SetMetastate` documents that an empty array is accepted and that `null` throws `ArgumentNullException`.
- The same "field values" wording on the two `MobileObject` virtuals is corrected, including that overrides should call the base implementation first so the hierarchy reads back in write order.

Two claims were walked back while writing this, because they were not actually true: an empty array is only valid input for a type that *produces* empty (feeding one to a `BusinessBase` override would hit end-of-stream), and `OnSetMetastate` overrides are not expected to tolerate an empty stream.

`OnGetState`/`OnSetState` keep their "field values" wording — for those it is accurate.

## Test plan

- [x] `dotnet build Source\csla.build.sln` — clean across all seven TFMs, no XML doc warnings, and the new `cref`s resolve
- [x] `dotnet build Source\csla.test.sln` — clean, 0 errors
- [x] CI-filtered suite green: **0 failures across all 12 assemblies**

Closes #4898

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011VEzABB5KneYkRmUx9hFD2