### PR TITLE
Set version to 10.2.0-beta.1 and fix vulnerable WCF dependency

### DIFF
--- a/Source/Csla.Channels.Wcf/Csla.Channels.Wcf.csproj
+++ b/Source/Csla.Channels.Wcf/Csla.Channels.Wcf.csproj
@@ -41,4 +41,19 @@
     <PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
   </ItemGroup>
 
+  <!-- CoreWCF and System.ServiceModel.Primitives pull in versions of System.Security.Cryptography.Xml
+       that have known high severity advisories (NU1903), so reference a patched version of the package
+       from the servicing band that matches each target framework. -->
+  <ItemGroup Condition="'$(TargetFramework)'=='net8.0'">
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net9.0'">
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.19" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net10.0'">
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.11" />
+  </ItemGroup>
+
 </Project>

--- a/Source/version.json
+++ b/Source/version.json
@@ -1,11 +1,14 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "10.2.0",
+  "version": "10.2.0-beta.1",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"
   ],
+  "nuGetPackageVersion": {
+    "semVer": 2
+  },
   "cloudBuild": {
     "buildNumber": {
       "enabled": false


### PR DESCRIPTION
Prepares the 10.2.0 prerelease.

## Version

`Source/version.json` moves from `10.2.0` to `10.2.0-beta.1`, and adds `nuGetPackageVersion.semVer: 2`. Without the SemVer 2 setting, Nerdbank.GitVersioning defaults to SemVer 1 and flattens the dotted prerelease identifier, producing `10.2.0-beta-1` instead of `10.2.0-beta.1`.

## WCF channel dependency

NuGet audit reports `System.Security.Cryptography.Xml` as carrying eight high severity advisories (CVE-2026-26171, -32203, -33116, -47302, -47304, -50525, -50527, -50648) at the versions `Csla.Channels.Wcf` was resolving transitively through CoreWCF and `System.ServiceModel.Primitives`. `Csla.Channels.Wcf.csproj` now references a patched version from the servicing band matching each target framework:

| Target framework | Was (transitive) | Now |
| --- | --- | --- |
| net8.0 | 8.0.3 | 8.0.4 |
| net9.0 | 8.0.3 | 9.0.19 |
| net10.0 | 10.0.0 | 10.0.11 |

Each version is at or above the first patched version for every advisory in its band. The net4x targets are unaffected: they use framework `System.ServiceModel` references and pull no NuGet dependency beyond `Csla`.

CoreWCF stays at 1.8.1 and the `System.ServiceModel.*` packages are unchanged. 1.9.1 of CoreWCF is a functional upgrade rather than a security one, and the `System.ServiceModel.*` packages are already at their latest versions, so the net10.0 target needed the explicit reference regardless.

## Verification

- `dotnet pack Source/csla.build.sln --configuration Release -p:PublicRelease=true` produces all 16 packages at `10.2.0-beta.1` with no NU19xx audit warnings.
- The packed `Csla.Channels.Wcf` nuspec declares the patched versions for net8.0, net9.0 and net10.0, and still lists only `Csla` for the net4x groups.
- `Csla.Test.Channels.Wcf` integration tests pass (9/9).

Note that `Csla.Maui` is not part of this prerelease, matching 10.1.0, which also shipped without a MAUI package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011VEzABB5KneYkRmUx9hFD2
